### PR TITLE
Changed the HTML sidebar in the Documentation

### DIFF
--- a/docs/source/_templates/sidebar-links-template.html
+++ b/docs/source/_templates/sidebar-links-template.html
@@ -1,0 +1,6 @@
+<h3>Quick links</h3>
+<p>
+<a href="https://github.com/bigchaindb/bigchaindb">GitHub repository</a>
+<br>
+<a href="https://www.bigchaindb.com/">BigchainDB website</a>
+</p>

--- a/docs/source/_templates/sidebar-title-template.html
+++ b/docs/source/_templates/sidebar-title-template.html
@@ -1,0 +1,1 @@
+<h1>BigchainDB</h1>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -166,7 +166,12 @@ html_static_path = ['_static']
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+html_sidebars = {
+    '**': ['sidebar-title-template.html',
+           'globaltoc.html',
+           'sidebar-links-template.html',
+           'searchbox.html'],
+}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.


### PR DESCRIPTION
The new layout of the sidebar is, from top to bottom:
* **BigchainDB** (i.e. a title)
* (global)Table of Contents
* (All top-level headings are always listed, and the second-level headings of the current section are also shown)
* Quick links
    * GitHub repository (linked)
    * BigchainDB website (linked)
* Quick search
    * (search box)


