### PR TITLE
Update index in documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,7 +18,6 @@ Table of Contents
    contributing
    faq
    release-notes
-   software-architecture
    cryptography
    models
    json-serialization


### PR DESCRIPTION
Removed a reference to the now-deleted software-architecture file in docs/index.rst
