### PR TITLE
Fix some config issues for docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.cache/
+.coverage
+.eggs/
+.git/
+.gitignore
+.ropeproject/
+.travis.yml
+BigchainDB.egg-info/
+dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 RUN pip install --upgrade pip
-RUN pip install --no-cache-dir pytest pytest-cov
 
 COPY . /usr/src/app/
 
-RUN python setup.py develop
+RUN pip install --no-cache-dir -e .[dev]

--- a/bigchaindb/config_utils.py
+++ b/bigchaindb/config_utils.py
@@ -20,7 +20,10 @@ import collections
 import bigchaindb
 
 logger = logging.getLogger(__name__)
-CONFIG_DEFAULT_PATH = os.path.join(os.path.expanduser('~'), '.bigchaindb')
+CONFIG_DEFAULT_PATH = os.environ.setdefault(
+    'BIGCHAINDB_CONFIG_PATH',
+    os.path.join(os.path.expanduser('~'), '.bigchaindb'),
+)
 
 
 # Thanks Alex <3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,16 @@ rethinkdb-data:
 bigchaindb:
   build: .
   volumes:
-    - ./:/usr/src/app/
+    - ./bigchaindb:/usr/src/app/bigchaindb
+    - ./tests:/usr/src/app/tests
+    - ./docs:/usr/src/app/docs
+    - ./setup.py:/usr/src/app/setup.py
+    - ./setup.cfg:/usr/src/app/setup.cfg
+    - ./pytest.ini:/usr/src/app/pytest.ini
+    - ~/.bigchaindb_docker:/root/.bigchaindb_docker
   links:
     - rethinkdb
   environment:
     BIGCHAIN_DATABASE_HOST: rethinkdb
+    BIGCHAINDB_CONFIG_PATH: /root/.bigchaindb_docker/config
   command: bigchaindb start

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,11 @@ tests_require = [
     'pytest-cov',
 ]
 
+dev_require = [
+    'ipdb',
+    'ipython',
+]
+
 setup(
     name='BigchainDB',
     version='0.1.2',
@@ -56,5 +61,8 @@ setup(
     ],
     setup_requires=['pytest-runner'],
     tests_require=tests_require,
-    extras_require={'test': tests_require},
+    extras_require={
+        'test': tests_require,
+        'dev':  dev_require + tests_require,
+    },
 )


### PR DESCRIPTION
Since containers are ephemeral, the config file that gets created under `~/.bigchaindb` will be wiped out along with the container each time a new container is started.

We need a way to mount this file, or to only rely on environment variables, which would be probably easier.

For the time being this PR is a workaround, such that it mounts a docker specific config file from the host.

Addresses issue #36.