### PR TITLE
Correct Rethinkdb buggy version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         ],
     },
     install_requires=[
-        'rethinkdb==2.2.0.post1',
+        'rethinkdb==2.2.0-1',
         'pysha3==0.3',
         'pytz==2015.7',
         'cryptography==1.2.1',


### PR DESCRIPTION
The version of RethinkkDB `post1` in `setup.py` makes impossible to run `bigchaindb-benchmark load` because of error:
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 444, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 725, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 632, in resolve
    raise VersionConflict(dist,req) # XXX put more info here
pkg_resources.VersionConflict: (rethinkdb 2.2.0-1 (/usr/local/lib/python3.4/dist-packages), Requirem
ent.parse('rethinkdb==2.2.0.post1'))
```
I changed to `2.2.0-1` as required by the package.