### PR TITLE
Allow non interactive first start

### DIFF
--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -12,7 +12,7 @@ from bigchaindb import db
 from bigchaindb.exceptions import DatabaseAlreadyExists
 from bigchaindb.commands.utils import base_parser, start
 from bigchaindb.processes import Processes
-from bigchaindb.crypto import generate_key_pair
+from bigchaindb import crypto
 
 
 logging.basicConfig(level=logging.INFO)
@@ -52,7 +52,7 @@ def run_configure(args, skip_if_exists=False):
     conf = copy.deepcopy(bigchaindb._config)
 
     print('Generating keypair')
-    conf['keypair']['private'], conf['keypair']['public'] = generate_key_pair()
+    conf['keypair']['private'], conf['keypair']['public'] = crypto.generate_key_pair()
 
     if not args.yes:
         for key in ('host', 'port', 'name'):

--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -4,6 +4,7 @@
 import os
 import logging
 import argparse
+import copy
 
 import bigchaindb
 import bigchaindb.config_utils
@@ -48,13 +49,15 @@ def run_configure(args, skip_if_exists=False):
             return
 
     # Patch the default configuration with the new values
-    conf = bigchaindb._config
+    conf = copy.deepcopy(bigchaindb._config)
+
     print('Generating keypair')
     conf['keypair']['private'], conf['keypair']['public'] = generate_key_pair()
 
-    for key in ('host', 'port', 'name'):
-        val = conf['database'][key]
-        conf['database'][key] = input('Database {}? (default `{}`): '.format(key, val)) or val
+    if not args.yes:
+        for key in ('host', 'port', 'name'):
+            val = conf['database'][key]
+            conf['database'][key] = input('Database {}? (default `{}`): '.format(key, val)) or val
 
     bigchaindb.config_utils.write_config(conf, config_path)
     print('Ready to go!')

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -52,8 +52,7 @@ def mock_rethink_db_drop(monkeypatch):
 
 @pytest.fixture
 def mock_generate_key_pair(monkeypatch):
-    from bigchaindb import crypto
-    monkeypatch.setattr(crypto, 'generate_key_pair', lambda: ('privkey', 'pubkey'))
+    monkeypatch.setattr('bigchaindb.crypto.generate_key_pair', lambda: ('privkey', 'pubkey'))
 
 
 @pytest.fixture


### PR DESCRIPTION
If no configuration is found, `bigchaindb start` will prompt the user for some configuration values (database host, port, and name) and will generate the keypair for the node. This patch allows to run `bigchaindb start` with the `-y` option to run it in a non-interactive way.

Related: #58.