### PR TITLE
Simplify README.md to four sets of links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,81 +1,36 @@
 # BigchainDB
 
+A scalable blockchain database. [The whitepaper](https://www.bigchaindb.com/whitepaper/) explains what that means.
+
 [![Join the chat at https://gitter.im/bigchaindb/bigchaindb](https://badges.gitter.im/bigchaindb/bigchaindb.svg)](https://gitter.im/bigchaindb/bigchaindb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![PyPI](https://img.shields.io/pypi/v/bigchaindb.svg)](https://pypi.python.org/pypi/BigchainDB)
 [![Travis branch](https://img.shields.io/travis/bigchaindb/bigchaindb/develop.svg)](https://travis-ci.org/bigchaindb/bigchaindb)
 [![Codecov branch](https://img.shields.io/codecov/c/github/bigchaindb/bigchaindb/develop.svg)](https://codecov.io/github/bigchaindb/bigchaindb?branch=develop)
 [![Documentation Status](https://readthedocs.org/projects/bigchaindb/badge/?version=develop)](http://bigchaindb.readthedocs.org/en/develop/?badge=develop)
 
-## Documentation
+## Quick Start
 
-Documentation is available at https://bigchaindb.readthedocs.org/
+### [Install & Run BigchainDB](http://bigchaindb.readthedocs.org/en/develop/installing.html)
+### [Run BigchainDB with Docker](http://bigchaindb.readthedocs.org/en/develop/installing.html#run-bigchaindb-with-docker)
+### [Getting Started (Tutorial)](http://bigchaindb.readthedocs.org/en/develop/getting-started.html)
 
-## Getting started
+## Links for Everyone
+* [BigchainDB.com](https://www.bigchaindb.com/) - the main BigchainDB website, including newsletter signup
+* [Whitepaper](https://www.bigchaindb.com/whitepaper/) - outlines the motivations, goals and core algorithms of BigchainDB
+* [Roadmap](ROADMAP.md)
+* [Blog](https://medium.com/the-bigchaindb-blog)
+* [Twitter](https://twitter.com/BigchainDB)
+* [Google Group](https://groups.google.com/forum/#!forum/bigchaindb)
 
-### Install RethinkDB
+## Links for Developers
+* [Documentation](http://bigchaindb.readthedocs.org/en/develop/#) - for developers
+* [CONTRIBUTING.md](CONTRIBUTING.md) - how to contribute
+* [Community guidelines](CODE_OF_CONDUCT.md)
+* [Open issues](https://github.com/bigchaindb/bigchaindb/issues)
+* [Open pull requests](https://github.com/bigchaindb/bigchaindb/pulls)
+* [Gitter chatroom](https://gitter.im/bigchaindb/bigchaindb)
 
-#### On Ubuntu
-```sh
-# install rethinkdb https://rethinkdb.com/docs/install/ubuntu/
-$ source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
-$ wget -qO- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
-$ sudo apt-get update
-$ sudo apt-get install rethinkdb
-
-# start rethinkdb
-$ rethinkdb
-```
-
-#### On other platforms
-To install RethinkDB on other platform, please refer to [the official documentation](https://rethinkdb.com/docs/install/).
-
-### Install BigchainDB
-```sh
-$ pip install bigchaindb
-```
-
-### Running BigchainDB
-Currently BigchainDB only supports Python 3.4+
-
-
-Start the main process. If it's the first time `bigchaindb` will generate a default
-configuration file for you.
-```sh
-$ bigchaindb start
-```
-
-Generate some tests transactions:
-
-```sh
-$ bigchaindb-benchmark load # add '-m' if you want to use all your cores
-```
-
-To know more about the bigchain command run
-```sh
-$ bigchaindb -h
-```
-
-#### Importing `BigchainDB` from the interpreter (python/ipython)
-Make sure your `rethinkdb` process is running.
-
-```python
->>> from bigchaindb import Bigchain
->>> b = Bigchain()
->>> b.me
-'2B8C8PJxhycFzn4wncRhBNmMWwE5Frr9nLBUa1dGGxj5W'
-```
-
-#### Configuration
-
-BigchainDB creates a default configuration file on `$HOME/.bigchaindb` on the
-first run.
-
-```sh
-$ bigchaindb show-config
-```
-
-#### Testing
-
-```
-$ py.test -v
-```
+## Legal
+* [Licenses](LICENSES.md) - open source & open content
+* [Imprint](https://www.bigchaindb.com/imprint/)
+* [Contact Us](https://www.bigchaindb.com/contact/)


### PR DESCRIPTION
This PR changes the main README.md into, mostly, a bunch of links in four categories:
1. Quick Start
2. Links for Everyone
3. Links for Developers
4. Legal

It's partly in response to issue #73 - now there's only one place we need to keep up-to-date regarding installation instructions: that section of the docs.

Everything that _was_ in the README.md can still be found somewhere in the docs.