### PR TITLE
docker images now come from bigchaindb dockerhub account

### DIFF
--- a/docker-compose-monitor.yml
+++ b/docker-compose-monitor.yml
@@ -10,7 +10,7 @@ influxdb:
     PRE_CREATE_DB: "telegraf"
 
 grafana:
-  image: rhsimplex/grafana-bigchaindb-docker
+  image: bigchaindb/grafana-bigchaindb-docker
   tty: true
   ports:
     - "3000:3000"
@@ -18,7 +18,7 @@ grafana:
     - influxdb:localhost
 
 statsd:
-  image: rhsimplex/docker-telegraf-statsd
+  image: bigchaindb/docker-telegraf-statsd
   ports:
     - "8125:8125/udp"
   links:


### PR DESCRIPTION
moved docker containers into the bigchaindb dockerhub account -- just reflects those changes