### PR TITLE
Fix bug related to config overwrite

### DIFF
--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -45,7 +45,7 @@ def run_configure(args, skip_if_exists=False):
     if config_file_exists and not args.yes:
         want = input('Config file `{}` exists, do you want to override it? '
                      '(cannot be undone) [y/n]: '.format(config_path))
-        if not want:
+        if want != 'y':
             return
 
     # Patch the default configuration with the new values

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -144,3 +144,22 @@ def test_run_configure_when_config_does_not_exist(monkeypatch,
     args = Namespace(config='foo', yes=True)
     return_value = run_configure(args)
     assert return_value is None
+
+
+def test_run_configure_when_config_does_exist(monkeypatch,
+                                              mock_write_config,
+                                              mock_generate_key_pair,
+                                              mock_bigchaindb_backup_config):
+    value = {}
+    def mock_write_config(newconfig, filename=None):
+        value['return'] = newconfig
+
+    from bigchaindb.commands.bigchain import run_configure
+    monkeypatch.setattr('os.path.exists', lambda path: True)
+    monkeypatch.setattr('builtins.input', lambda question: '\n')
+    monkeypatch.setattr('bigchaindb.config_utils.write_config', mock_write_config)
+
+    args = Namespace(config='foo', yes=None)
+    run_configure(args)
+    assert value == {}
+

--- a/tests/utils/test_config_utils.py
+++ b/tests/utils/test_config_utils.py
@@ -5,7 +5,7 @@ import pytest
 import bigchaindb
 
 
-ORIGINAL_CONFIG = copy.deepcopy(bigchaindb.config)
+ORIGINAL_CONFIG = copy.deepcopy(bigchaindb._config)
 
 
 @pytest.fixture(scope='function', autouse=True)


### PR DESCRIPTION
Calling `bigchaindb configure` would overwrite the original config even if the user answered `n`.

This PR is to fix this wrong behavior.