### PR TITLE
Docs: note OS-level dependencies on Fedora

### DIFF
--- a/docs/source/installing.md
+++ b/docs/source/installing.md
@@ -35,9 +35,11 @@ $ sudo apt-get install libffi-dev g++ libssl-dev python3-dev
 
 On Fedora 23, we found that the following was enough (tested in February 2015):
 ```text
-$ yum update
-$ yum install libffi-devel gcc-c++ redhat-rpm-config python3-devel openssl-devel
+$ sudo dnf update
+$ sudo dnf install libffi-devel gcc-c++ redhat-rpm-config python3-devel openssl-devel
 ```
+
+(If you're using a version of Fedora before version 22, you may have to use `yum` instead of `dnf`.)
 
 With OS-level dependencies installed, you can install BigchainDB with `pip` or from source.
 

--- a/docs/source/installing.md
+++ b/docs/source/installing.md
@@ -27,10 +27,16 @@ If you don't already have it, then you should [install Python 3.4+](https://www.
 
 BigchainDB has some OS-level dependencies. In particular, you need to install the OS-level dependencies for the Python **cryptography** package. Instructions for installing those dependencies on your OS can be found in the [cryptography package documentation](https://cryptography.io/en/latest/installation/).
 
-On Ubuntu 14.04, we found that the following was enough (YMMV):
+On Ubuntu 14.04, we found that the following was enough:
 ```text
 $ sudo apt-get update
 $ sudo apt-get install libffi-dev g++ libssl-dev python3-dev
+```
+
+On Fedora 23, we found that the following was enough (tested in February 2015):
+```text
+$ yum update
+$ yum install libffi-devel gcc-c++ redhat-rpm-config python3-devel openssl-devel
 ```
 
 With OS-level dependencies installed, you can install BigchainDB with `pip` or from source.


### PR DESCRIPTION
Based on [this comment](https://github.com/bigchaindb/bigchaindb/issues/23#issuecomment-190260765) on Issue #23 :

Added a short section to the "Installing BigchainDB Server" section of the documentation, listing the OS-level dependencies on Fedora 23, and how to install them. (This may also help users of RHEL and CentOS.)

@r-marques I'm not super-familiar with `yum`; did I get the usage right? Is `sudo` needed?