### PR TITLE
Use the default ReadTheDocs theme

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+Sphinx==1.3.5
+sphinxcontrib-napoleon==0.4.4
+recommonmark

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 Sphinx==1.3.5
 sphinxcontrib-napoleon==0.4.4
+sphinx-rtd-theme>=0.1.9
 recommonmark

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,0 @@
-Sphinx==1.3.5
-sphinxcontrib-napoleon==0.4.4
-recommonmark

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,6 +28,9 @@ from recommonmark.parser import CommonMarkParser
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
+import sphinx_rtd_theme
+
+
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
@@ -119,7 +122,8 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
+
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -127,7 +131,7 @@ html_theme = 'alabaster'
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ docs_require = [
     'recommonmark>=0.4.0',
     'Sphinx>=1.3.5',
     'sphinxcontrib-napoleon>=0.4.4',
+    'sphinx-rtd-theme>=0.1.9',
 ]
 
 setup(


### PR DESCRIPTION
I changed the theme of the docs. In the screenshot, the new theme is the one on the left, the old the one on the right.

I think the new theme is much cleaner and readable.

![image](https://cloud.githubusercontent.com/assets/134680/13446477/32b81ede-e014-11e5-8e21-d619536e7f2d.png)
