### PR TITLE
Re-add link to licenses in the docs

### DIFF
--- a/LICENSES.md
+++ b/LICENSES.md
@@ -2,7 +2,7 @@
 
 All officially-supported BigchainDB _driver code_ is licensed under the Apache License, Version 2.0, the full text of which can be found at [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0).
 
-All short code snippets embedded in the official BigchainDB _documentation_ is licensed under the Apache License, Version 2.0, the full text of which can be found at [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0).
+All short code snippets embedded in the official BigchainDB _documentation_ are licensed under the Apache License, Version 2.0, the full text of which can be found at [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0).
 
 All _other_ officially-supported BigchainDB code is licensed under the GNU Affero General Public License version 3 (AGPLv3), the full text of which can be found at [http://www.gnu.org/licenses/agpl.html](http://www.gnu.org/licenses/agpl.html).
 

--- a/docs/source/_templates/license-template.html
+++ b/docs/source/_templates/license-template.html
@@ -1,4 +1,0 @@
-<h3>License</h3>
-<p>
-This documentation is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
-</p>

--- a/docs/source/_templates/sidebar-links-template.html
+++ b/docs/source/_templates/sidebar-links-template.html
@@ -1,6 +1,0 @@
-<h3>Quick links</h3>
-<p>
-<a href="https://github.com/bigchaindb/bigchaindb">GitHub repository</a>
-<br>
-<a href="https://www.bigchaindb.com/">BigchainDB website</a>
-</p>

--- a/docs/source/_templates/sidebar-title-template.html
+++ b/docs/source/_templates/sidebar-title-template.html
@@ -1,1 +1,0 @@
-<h1>BigchainDB Documentation</h1>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -168,13 +168,10 @@ html_static_path = ['_static']
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {
-    '**': ['sidebar-title-template.html',
-           'globaltoc.html',
-           'sidebar-links-template.html',
-           'searchbox.html',
-           'license-template.html'],
-}
+#html_sidebars = {
+#    '**': ['globaltoc.html',
+#           'searchbox.html'],
+#}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,7 @@ Table of Contents
    json-serialization
    developer-interface
    monitoring
+   licenses
    contributing
    faq
    release-notes

--- a/docs/source/licenses.md
+++ b/docs/source/licenses.md
@@ -1,0 +1,3 @@
+# Licenses
+
+Information about how the BigchainDB code and documentation are licensed can be found in [the LICENSES.md file](https://github.com/bigchaindb/bigchaindb/blob/develop/LICENSES.md) (in the root directory of the repository).


### PR DESCRIPTION
Resolves Issue #104 (in part).

* Edited and commented-out the custom sidebar settings from the docs (in `/docs/source/conf.py`) because the new ReadTheDocs theme ignores that anyway. Removed the associated sidebar template files from the `/docs/source/_templates/` directory.
* Added a new "Licenses" section to the documentation. It just links to to the `LICENSES.md` file on GitHub, so there's always one central source of licensing information.
* Fixed minor typo in `LICENSES.md`.