### PR TITLE
Add missing package form installer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         'Operating System :: POSIX :: Linux',
     ],
 
-    packages=['bigchaindb', 'bigchaindb.commands', 'bigchaindb.db'],
+    packages=['bigchaindb', 'bigchaindb.commands', 'bigchaindb.db', 'bigchaindb.web'],
 
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Without this running blockchaindb yields:
Traceback (most recent call last):
  File "/usr/lib/python3.4/runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.4/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/lib/python3.4/trace.py", line 858, in <module>
    main()
  File "/usr/lib/python3.4/trace.py", line 804, in main
    t.runctx(code, globs, globs)
  File "/usr/lib/python3.4/trace.py", line 510, in runctx
    exec(cmd, globals, locals)
  File "/usr/local/bin/bigchaindb", line 9, in <module>
    load_entry_point('BigchainDB==0.1.4', 'console_scripts', 'bigchaindb')()
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 549, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 2542, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 2202, in load
    return self.resolve()
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 2208, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python3.4/dist-packages/BigchainDB-0.1.4-py3.4.egg/bigchaindb/commands/bigchain.py", line 14, in <module>
    from bigchaindb.processes import Processes
  File "/usr/local/lib/python3.4/dist-packages/BigchainDB-0.1.4-py3.4.egg/bigchaindb/processes.py", line 9, in <module>
    from bigchaindb.web import server
ImportError: No module named 'bigchaindb.web'