### PR TITLE
Public validation function

### DIFF
--- a/bigchaindb/client.py
+++ b/bigchaindb/client.py
@@ -90,6 +90,24 @@ class Client:
             tx, private_key=self.private_key)
         return self._push(signed_tx)
 
+    def validate(self, tx):
+        """Validate a transaction object.
+
+        If tx is a `CREATE` transaction, this method will return (True, '') even
+        without the federation signature as long as the transaction is otherwise
+        valid.
+
+        Args:
+            tx (dict): the transaction object to be validated
+
+        Return:
+            (bool, str): (True, '') if the tx is valid, else (False, errormsg)
+        """
+
+        res = requests.post(self.api_endpoint + '/transactions/validate/',
+                            json=tx)
+        return (res.json()['valid'], res.json()['error'])
+
     def _push(self, tx):
         """Submit a transaction to the Federation.
 

--- a/bigchaindb/util.py
+++ b/bigchaindb/util.py
@@ -199,7 +199,9 @@ def verify_signature(signed_transaction):
     if 'assignee' in data:
         data.pop('assignee')
 
-    signature = data.pop('signature')
+    signature = data.pop('signature', None)
+    if not signature: return False
+
     public_key_base58 = signed_transaction['transaction']['current_owner']
     public_key = PublicKey(public_key_base58)
     return public_key.verify(serialize(data), signature)

--- a/bigchaindb/web/views.py
+++ b/bigchaindb/web/views.py
@@ -37,6 +37,7 @@ def get_transaction(tx_id):
     bigchain = current_app.config['bigchain']
 
     tx = bigchain.get_transaction(tx_id)
+    if not tx: flask.abort(404)
     return flask.jsonify(**tx)
 
 
@@ -51,8 +52,8 @@ def create_transaction():
 
     val = {}
 
-    # `force` will try to format the body of the POST request even if the `content-type` header is not
-    # set to `application/json`
+    # `force` will try to format the body of the POST request even if the
+    # `content-type` header is not set to `application/json`
     tx = request.get_json(force=True)
 
     if tx['transaction']['operation'] == 'CREATE':

--- a/bigchaindb/web/views.py
+++ b/bigchaindb/web/views.py
@@ -48,6 +48,7 @@ def create_transaction():
     Return:
         A JSON string containing the data about the transaction.
     """
+
     bigchain = current_app.config['bigchain']
 
     val = {}
@@ -78,6 +79,7 @@ def validate_transaction():
         A JSON object with the `valid` field populated with a boolean value
         and the `error` field populated with an error message or an empty str
     """
+
     bigchain = current_app.config['bigchain']
 
     tx = request.get_json(force=True)
@@ -97,8 +99,8 @@ def validate_transaction():
     except exceptions.InvalidSignature as e:
         # We skipped signing CREATEs with the node's private key, so expect this
         if validate_sig:
-            return flask.jsonify({'valid': False, 'error': repr(e)})
+            return flask.jsonify(valid=False, error=repr(e))
     except Exception as e:
-        return flask.jsonify({'valid': False, 'error': repr(e)})
+        return flask.jsonify(valid=False, error=repr(e))
 
-    return flask.jsonify({'valid': True, 'error': ''})
+    return flask.jsonify(valid=True, error='')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,3 +57,11 @@ def test_client_can_transfer_assets(mock_requests_post, client):
 
     assert util.verify_signature(tx)
 
+
+def test_client_can_validate_transaction(mock_requests_post, client):
+    from bigchaindb import util
+
+    assert client.validate({'valid': True,
+                            'error': ''}) == (True, '')
+    assert client.validate({'valid': False,
+                            'error': 'Some Error'}) == (False, 'Some Error')


### PR DESCRIPTION
This PR adds a `validate` function to the REST API & the python client.
It returns a bool and error message (which is currently just `repr(exception)`).

I'm not sure if you guys want this – but I needed it, so feel free to merge, comment or close. :)

Note: This is branched off of #99, first commit in this branch is: 8e615b9 (which along with 513ed9c may be of value independently of the other changes)