### PR TITLE
Redid docs for HTTP API to reflect current status

### DIFF
--- a/docs/source/http-client-server-api.md
+++ b/docs/source/http-client-server-api.md
@@ -1,5 +1,11 @@
 # The HTTP Client-Server API
 
-The preferred way to communicate with a node in a BigchainDB cluster is via HTTP requests. Each node exposes a simple HTTP API (the HTTP Client-Server API) that provides, right now, two endpoints, one to get information about a specific transaction id, and one to push a transaction to the BigchainDB cluster.
+When you start Bigchaindb using `bigchaindb start`, an HTTP API is exposed at:
 
-The endpoints are documented using [Apiary](http://docs.bigchaindb.apiary.io/).
+[http://localhost:5000/api/v1/](http://localhost:5000/api/v1/)
+
+Right now, that API can only be accessed from localhost (i.e. not remotely). In the future, we'll enable remote access and explain how that works. See [Issue #149](https://github.com/bigchaindb/bigchaindb/issues/149) on GitHub.
+
+The HTTP API currently exposes two endpoints, one to get information about a specific transaction id, and one to push a transaction to the BigchainDB cluster. Those endpoints are documented at:
+
+[http://docs.bigchaindb.apiary.io/](http://docs.bigchaindb.apiary.io/)


### PR DESCRIPTION
Partially addresses Issue #149 by updating the HTTP API docs to reflect the _current_ status of that API.

