### PR TITLE
Docs: changed instructions for running unit tests

### DIFF
--- a/docs/source/running-unit-tests.md
+++ b/docs/source/running-unit-tests.md
@@ -2,29 +2,21 @@
 
 Once you've installed BigchainDB Server, you may want to run all the unit tests. This section explains how.
 
-First of all, if you installed BigchainDB Server using `pip` (i.e. by getting the package from PyPI), then you didn't install the tests. Before you can run all the unit tests, you must [install BigchainDB from source](installing-server.html#how-to-install-bigchaindb-from-source).
+First of all, if you installed BigchainDB Server using `pip` (i.e. by getting the package from PyPI), then you didn't install the tests. **Before you can run all the unit tests, you must [install BigchainDB from source](installing-server.html#how-to-install-bigchaindb-from-source).**
 
 To run all the unit tests, first make sure you have RethinkDB running:
+
 ```text
 $ rethinkdb
 ```
 
 then in another terminal, do:
+
 ```text
-$ py.test -v
+$ python setup.py test
 ```
 
-If the above command doesn't work (e.g. maybe you are running in a conda virtual environment), try:
-```text
-$ python -m pytest -v
-```
-
-(We write our unit tests using the [pytest](http://pytest.org/latest/) framework.)
-
-You can also run all unit tests via `setup.py`, using:
-```text
-$  python setup.py test
-```
+(Aside: How does the above command work? The documentation for [pytest-runner](https://pypi.python.org/pypi/pytest-runner) explains. We use [pytest](http://pytest.org/latest/) to write all unit tests.)
 
 ### Using docker-compose to Run the Tests
 


### PR DESCRIPTION
I simplified the instructions for running all the unit tests, and added some links in an "Aside", so that curious people can easily find out more about pytest and pytest-runner.