### PR TITLE
Move monitoring code from the main class to processes

### DIFF
--- a/bigchaindb/client.py
+++ b/bigchaindb/client.py
@@ -1,7 +1,6 @@
 import requests
 
 import bigchaindb
-from bigchaindb import util
 from bigchaindb import config_utils
 from bigchaindb import exceptions
 from bigchaindb import crypto
@@ -112,5 +111,5 @@ def temp_client():
     """
 
     private_key, public_key = crypto.generate_key_pair()
-    return Client(private_key=private_key, public_key=public_key, api_endpoint='http://localhost:5000/api/v1')
+    return Client(private_key=private_key, public_key=public_key, api_endpoint=bigchaindb.config['api_endpoint'])
 

--- a/bigchaindb/commands/bigchain_benchmark.py
+++ b/bigchaindb/commands/bigchain_benchmark.py
@@ -7,23 +7,21 @@ import logstats
 import bigchaindb
 import bigchaindb.config_utils
 from bigchaindb.util import ProcessGroup
+from bigchaindb.client import temp_client
 from bigchaindb.commands.utils import base_parser, start
 
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-USER_PUBLIC_KEY = 'qZAN9Ngs1v4qP1T5UBYw75M5f2ej7mAJx8gBMF4BBWtZ'
-
 
 def _run_load(tx_left, stats):
     logstats.thread.start(stats)
-    b = bigchaindb.Bigchain()
+    client = temp_client()
+    # b = bigchaindb.Bigchain()
 
     while True:
-        tx = b.create_transaction(b.me, USER_PUBLIC_KEY, None, 'CREATE')
-        tx_signed = b.sign_transaction(tx, b.me_private)
-        b.write_transaction(tx_signed)
+        tx = client.create()
 
         stats['transactions'] += 1
 

--- a/bigchaindb/config_utils.py
+++ b/bigchaindb/config_utils.py
@@ -22,6 +22,8 @@ from pkg_resources import iter_entry_points, ResolutionError
 import bigchaindb
 from bigchaindb.consensus import AbstractConsensusRules
 
+# TODO: move this to a proper configuration file for logging
+logging.getLogger('requests').setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 CONFIG_DEFAULT_PATH = os.environ.setdefault(

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -1,17 +1,13 @@
-import rethinkdb as r
 import random
-import rapidjson
 
+import rethinkdb as r
+import rapidjson
 
 import bigchaindb
 from bigchaindb import util
 from bigchaindb import config_utils
 from bigchaindb import exceptions
 from bigchaindb import crypto
-from bigchaindb.monitor import Monitor
-
-
-monitor = Monitor()
 
 
 class GenesisBlockAlreadyExistsError(Exception):
@@ -68,7 +64,6 @@ class Bigchain(object):
     def reconnect(self):
         return r.connect(host=self.host, port=self.port, db=self.dbname)
 
-    @monitor.timer('create_transaction', rate=bigchaindb.config['statsd']['rate'])
     def create_transaction(self, *args, **kwargs):
         """Create a new transaction
 
@@ -104,7 +99,6 @@ class Bigchain(object):
         return self.consensus.verify_signature(
             signed_transaction, *args, **kwargs)
 
-    @monitor.timer('write_transaction', rate=bigchaindb.config['statsd']['rate'])
     def write_transaction(self, signed_transaction, durability='soft'):
         """Write the transaction to bigchain.
 
@@ -239,7 +233,6 @@ class Bigchain(object):
 
         return owned
 
-    @monitor.timer('validate_transaction', rate=bigchaindb.config['statsd']['rate'])
     def validate_transaction(self, transaction):
         """Validate a transaction.
 
@@ -308,7 +301,6 @@ class Bigchain(object):
 
         return block
 
-    @monitor.timer('validate_block')
     # TODO: check that the votings structure is correctly constructed
     def validate_block(self, block):
         """Validate a block.
@@ -351,7 +343,6 @@ class Bigchain(object):
         except Exception:
             return False
 
-    @monitor.timer('write_block')
     def write_block(self, block, durability='soft'):
         """Write a block to bigchain.
 

--- a/bigchaindb/monitor.py
+++ b/bigchaindb/monitor.py
@@ -1,13 +1,14 @@
-import statsd
 from platform import node
+
+import statsd
 
 import bigchaindb
 from bigchaindb import config_utils
 
-class Monitor(statsd.StatsClient):
-    """Set up statsd monitoring
 
-    """
+class Monitor(statsd.StatsClient):
+    """Set up statsd monitoring."""
+
     def __init__(self, *args, **kwargs):
         """Overrides statsd client, fixing prefix to messages and loading configuration
 
@@ -15,6 +16,7 @@ class Monitor(statsd.StatsClient):
             *args: arguments (identical to Statsclient)
             **kwargs: keyword arguments (identical to Statsclient)
         """
+
         config_utils.autoconfigure()
 
         if not kwargs:
@@ -28,3 +30,4 @@ class Monitor(statsd.StatsClient):
         if 'port' not in kwargs:
             kwargs['port'] = bigchaindb.config['statsd']['port']
         super().__init__(*args, **kwargs)
+

--- a/bigchaindb/web/server.py
+++ b/bigchaindb/web/server.py
@@ -7,10 +7,11 @@ import copy
 import multiprocessing
 
 from flask import Flask
+import gunicorn.app.base
 
 from bigchaindb import Bigchain
 from bigchaindb.web import views
-import gunicorn.app.base
+from bigchaindb.monitor import Monitor
 
 
 class StandaloneApplication(gunicorn.app.base.BaseApplication):
@@ -56,6 +57,7 @@ def create_app(debug=False):
     app = Flask(__name__)
     app.debug = debug
     app.config['bigchain'] = Bigchain()
+    app.config['monitor'] = Monitor()
     app.register_blueprint(views.basic_views, url_prefix='/api/v1')
     return app
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -141,5 +141,5 @@ def test_process_group_instantiates_and_start_processes(mock_process):
                                   for i in range(concurrency)], any_order=True)
 
     for process in pg.processes:
-        process.start.assert_called()
+        process.start.assert_called_with()
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch, call
 import pytest
 import queue
 
@@ -120,4 +121,25 @@ def test_pool_raises_empty_exception_when_timeout(mock_queue):
     with pytest.raises(queue.Empty):
         with pool() as instance:
             assert instance == 'hello'
+
+
+@patch('multiprocessing.Process')
+def test_process_group_instantiates_and_start_processes(mock_process):
+    from bigchaindb.util import ProcessGroup
+
+    def noop():
+        pass
+
+    concurrency = 10
+
+    pg = ProcessGroup(concurrency=concurrency, group='test_group', target=noop)
+    pg.start()
+
+    mock_process.assert_has_calls([call(group='test_group', target=noop,
+                                        name=None, args=(), kwargs={},
+                                        daemon=None)
+                                  for i in range(concurrency)], any_order=True)
+
+    for process in pg.processes:
+        process.start.assert_called()
 


### PR DESCRIPTION
This PR is related to #156.

I might need some help from @rhsimplex to check if the new setup is compatible to the one we had before.

Note also we don't monitor `create_transaction` anymore, because this action will be done on the client side, not on the server side.

I moved `write_transaction` to the API server, because this is where the write happens. An idea for the future: we can add `statsd` on every API endpoint to measure how the HTTP Server behaves.