### PR TITLE
Added CLI command to export public key

### DIFF
--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -13,10 +13,7 @@ import json
 import bigchaindb
 import bigchaindb.config_utils
 from bigchaindb import db
-from bigchaindb.exceptions import (
-    DatabaseAlreadyExists,
-    KeypairNotFoundException
-)
+from bigchaindb.exceptions import DatabaseAlreadyExists, KeypairNotFoundException
 from bigchaindb.commands.utils import base_parser, start
 from bigchaindb.processes import Processes
 from bigchaindb import crypto
@@ -43,8 +40,7 @@ def run_configure(args, skip_if_exists=False):
     """Run a script to configure the current node.
 
     Args:
-        skip_if_exists (bool): skip the function if a config file already
-                               exists
+        skip_if_exists (bool): skip the function if a config file already exists
     """
     config_path = args.config or bigchaindb.config_utils.CONFIG_DEFAULT_PATH
     config_file_exists = os.path.exists(config_path)

--- a/bigchaindb/commands/bigchain_benchmark.py
+++ b/bigchaindb/commands/bigchain_benchmark.py
@@ -1,4 +1,5 @@
-'''Command line interface for the `bigchain-benchmark` command.'''
+"""Command line interface for the `bigchaindb-benchmark` command."""
+
 import logging
 import argparse
 

--- a/bigchaindb/commands/utils.py
+++ b/bigchaindb/commands/utils.py
@@ -1,4 +1,6 @@
-"""Utility functions and basic common arguments for ``argparse.ArgumentParser``."""
+"""Utility functions and basic common arguments
+for ``argparse.ArgumentParser``.
+"""
 
 import argparse
 import multiprocessing as mp
@@ -7,7 +9,8 @@ import multiprocessing as mp
 def start(parser, scope):
     """Utility function to execute a subcommand.
 
-    The function will look up in the ``scope`` if there is a function called ``run_<parser.args.command>``
+    The function will look up in the ``scope``
+    if there is a function called ``run_<parser.args.command>``
     and will run it using ``parser.args`` as first positional argument.
 
     Args:
@@ -15,7 +18,8 @@ def start(parser, scope):
         scope (dict): map containing (eventually) the functions to be called.
 
     Raises:
-        NotImplementedError: if ``scope`` doesn't contain a function called ``run_<parser.args.command>``.
+        NotImplementedError: if ``scope`` doesn't contain a function called
+                             ``run_<parser.args.command>``.
     """
     args = parser.parse_args()
 
@@ -29,7 +33,8 @@ def start(parser, scope):
 
     # if no command has been found, raise a `NotImplementedError`
     if not func:
-        raise NotImplementedError('Command `{}` not yet implemented'.format(args.command))
+        raise NotImplementedError('Command `{}` not yet implemented'.
+                                  format(args.command))
 
     args.multiprocess = getattr(args, 'multiprocess', False)
 

--- a/bigchaindb/config_utils.py
+++ b/bigchaindb/config_utils.py
@@ -1,8 +1,8 @@
-"""Utils to configure Bigchain.
+"""Utils to configure BigchainDB.
 
 By calling `file_config`, the global configuration (stored in
-`bigchain.config`) will be updated with the values contained in the
-configuration file.
+`$HOME/.bigchaindb`) will be updated with the values contained
+in the configuration file.
 
 Note that there is a precedence in reading configuration values:
  - local config file;

--- a/bigchaindb/config_utils.py
+++ b/bigchaindb/config_utils.py
@@ -158,7 +158,7 @@ def update_types(config, reference, list_sep=':'):
     return map_leafs(_update_type, config)
 
 
-def dict_config(config):
+def set_config(config):
     """Set bigchaindb.config equal to the default config dict,
     then update that with whatever is in the provided config dict,
     and then set bigchaindb.config['CONFIGURED'] = True
@@ -210,8 +210,7 @@ def autoconfigure(filename=None, config=None, force=False):
     if config:
         newconfig = update(newconfig, config)
 
-    dict_config(newconfig)
-    return newconfig
+    return set_config(newconfig)
 
 
 def load_consensus_plugin(name=None):

--- a/bigchaindb/config_utils.py
+++ b/bigchaindb/config_utils.py
@@ -22,6 +22,7 @@ from pkg_resources import iter_entry_points, ResolutionError
 import bigchaindb
 from bigchaindb.consensus import AbstractConsensusRules
 
+# logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 CONFIG_DEFAULT_PATH = os.environ.setdefault(
@@ -78,19 +79,21 @@ def update(d, u):
 
 
 def file_config(filename=None):
-    """Returns the values found in a configuration file.
+    """Returns the config values found in a configuration file.
 
     Args:
-        filename (str): the JSON file with the configuration. Defaults to ``None``.
-            If ``None``, the HOME of the current user and the string ``.bigchaindb`` will be used.
+        filename (str): the JSON file with the configuration values.
+            If ``None``, CONFIG_DEFAULT_PATH will be used.
 
-    Note:
-        The function merges the values in ``filename`` with the **default configuration**,
-        so any update made to ``bigchaindb.config`` will be lost.
+    Returns:
+        dict: The config values in the specified config file (or the
+              file at CONFIG_DEFAULT_PATH, if filename == None)
     """
+    logger.debug('On entry into file_config(), filename = {}'.format(filename))
     if not filename:
         filename = CONFIG_DEFAULT_PATH
 
+    logger.debug('file_config() will try to open `{}`'.format(filename))
     with open(filename) as f:
         config = json.load(f)
 
@@ -210,7 +213,7 @@ def autoconfigure(filename=None, config=None, force=False):
     if config:
         newconfig = update(newconfig, config)
 
-    return set_config(newconfig)
+    set_config(newconfig)  # sets bigchaindb.config
 
 
 def load_consensus_plugin(name=None):

--- a/bigchaindb/config_utils.py
+++ b/bigchaindb/config_utils.py
@@ -159,16 +159,20 @@ def update_types(config, reference, list_sep=':'):
 
 
 def dict_config(config):
-    """Merge the provided configuration with the default one.
+    """Set bigchaindb.config equal to the default config dict,
+    then update that with whatever is in the provided config dict,
+    and then set bigchaindb.config['CONFIGURED'] = True
 
     Args:
-        newconfig (dict): a dictionary with the configuration to load.
+        config (dict): the config dict to read for changes
+                       to the default config
 
     Note:
-        The function merges ``newconfig`` with the **default configuration**, so any
-        update made to ``bigchaindb.config`` will be lost.
+        Any previous changes made to ``bigchaindb.config`` will be lost.
     """
+    # Deep copy the default config into bigchaindb.config
     bigchaindb.config = copy.deepcopy(bigchaindb._config)
+    # Update the default config with whatever is in the passed config
     update(bigchaindb.config, update_types(config, bigchaindb.config))
     bigchaindb.config['CONFIGURED'] = True
 

--- a/bigchaindb/config_utils.py
+++ b/bigchaindb/config_utils.py
@@ -54,7 +54,20 @@ def map_leafs(func, mapping):
 # Thanks Alex <3
 # http://stackoverflow.com/a/3233356/597097
 def update(d, u):
-    """Recursively update a mapping."""
+    """Recursively update a mapping (i.e. a dict, list, set, or tuple).
+
+    Conceptually, d and u are two sets trees (with nodes and edges).
+    This function goes through all the nodes of u. For each node in u,
+    if d doesn't have that node yet, then this function adds the node from u,
+    otherwise this function overwrites the node already in d with u's node.
+
+    Args:
+        d (mapping): The mapping to overwrite and add to.
+        u (mapping): The mapping to read for changes.
+
+    Returns:
+        mapping: An updated version of d (updated by u).
+    """
     for k, v in u.items():
         if isinstance(v, collections.Mapping):
             r = update(d.get(k, {}), v)

--- a/bigchaindb/config_utils.py
+++ b/bigchaindb/config_utils.py
@@ -22,7 +22,6 @@ from pkg_resources import iter_entry_points, ResolutionError
 import bigchaindb
 from bigchaindb.consensus import AbstractConsensusRules
 
-# logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 CONFIG_DEFAULT_PATH = os.environ.setdefault(

--- a/docs/source/bigchaindb-cli.md
+++ b/docs/source/bigchaindb-cli.md
@@ -1,27 +1,55 @@
-# The BigchainDB Command Line Interfaces (CLIs)
+# The BigchainDB Command Line Interface (CLI)
 
-BigchainDB has some Command Line Interfaces (CLIs). One of them is the `bigchaindb` command which we already saw when we first started BigchainDB using:
+There are some command-line commands for working with BigchainDB: `bigchaindb` and `bigchaindb-benchmark`. This section provides an overview of those commands.
+
+## bigchaindb
+
+### bigchaindb --help
+
+One can get basic help with the `bigchaindb` command using `bigchaindb --help` or `bigchaindb -h`.
+
+### bigchaindb configure
+
+This command generates a public/private keypair for the node, and writes a BigchainDB configuration file to the node's file system. It's documented in the section [Configuring a BigchainDB Node](configuration.html).
+
+If you want to force-generate a new configuration file regardless of whether one already exists (i.e. skipping the yes/no prompt), then use `bigchaindb -y configure`.
+
+### bigchaindb add-to-keyring KEY
+
+This command is used to add a single public key (KEY) to the node's keyring (a list of public keys of _other_ nodes in the federation). For example, this command:
 ```text
-$ bigchaindb configure
-$ bigchaindb start
+bigchaindb add-to-keyring F9C2vsnEkiaeUTrDRnJrmtV1AJxWjud9eTvMU5LLqa1C
 ```
 
-When you run `bigchaindb configure`, it creates a default configuration file in `$HOME/.bigchaindb`. You can check that configuration using:
-```text
-$ bigchaindb show-config
-```
+adds the public key `F9C2vsnEkiaeUTrDRnJrmtV1AJxWjud9eTvMU5LLqa1C` to the node's keyring. If you attempt to add the node's own public key, or you attempt to add a key that's already in the keyring, then no key will be added to the keyring.
 
-To find out what else you can do with the `bigchain` command, use:
-```text
-$ bigchaindb -h
-```
+### bigchaindb show-config
 
-There's another command named `bigchaindb-benchmark`. It's used to run benchmarking tests. You can learn more about it using:
+This command shows the values of the configuration settings, which can come from a variety of sources. See [the section on configuring BigchainDB](configuration.html) for more details and examples.
+
+### bigchaindb export-my-pubkey
+
+This command writes the node's public key (i.e. one of its configuration values) to standard output (stdout).
+
+### bigchaindb init
+
+This command creates a RethinkDB database, two RethinkDB database tables (backlog and bigchain), various RethinkDB database indexes, and the genesis block.
+
+Note: The `bigchaindb start` command (see below) always starts by trying a `bigchaindb init` first. If it sees that the RethinkDB database already exists, then it doesn't re-initialize the database. One doesn't have to do `bigchaindb init` before `bigchaindb start`. `bigchaindb init` is useful if you only want to initialize (but not start).
+
+### bigchaindb drop
+
+This command drops (erases) the RethinkDB database. You will be prompted to make sure. If you want to force-drop the database (i.e. skipping the yes/no prompt), then use `bigchaindb -y drop`
+
+### bigchaindb start
+
+This command starts BigchainDB. It always begins by trying a `bigchaindb init` first. See the note in the documentation for `bigchaindb init`.
+
+
+## bigchaindb-benchmark
+
+The `bigchaindb-benchmark` command is used to run benchmarking tests. You can learn more about it using:
 ```text
 $ bigchaindb-benchmark -h
 $ bigchaindb-benchmark load -h
 ```
-
-Note that you can always start `bigchaindb` using a different config file using the `-c` option.
-For more information check the help with `bigchaindb -h`.
-

--- a/docs/source/bigchaindb-cli.md
+++ b/docs/source/bigchaindb-cli.md
@@ -14,15 +14,6 @@ This command generates a public/private keypair for the node, and writes a Bigch
 
 If you want to force-generate a new configuration file regardless of whether one already exists (i.e. skipping the yes/no prompt), then use `bigchaindb -y configure`.
 
-### bigchaindb add-to-keyring KEY
-
-This command is used to add a single public key (KEY) to the node's keyring (a list of public keys of _other_ nodes in the federation). For example, this command:
-```text
-bigchaindb add-to-keyring F9C2vsnEkiaeUTrDRnJrmtV1AJxWjud9eTvMU5LLqa1C
-```
-
-adds the public key `F9C2vsnEkiaeUTrDRnJrmtV1AJxWjud9eTvMU5LLqa1C` to the node's keyring. If you attempt to add the node's own public key, or you attempt to add a key that's already in the keyring, then no key will be added to the keyring.
-
 ### bigchaindb show-config
 
 This command shows the values of the configuration settings, which can come from a variety of sources. See [the section on configuring BigchainDB](configuration.html) for more details and examples.

--- a/docs/source/installing-server.md
+++ b/docs/source/installing-server.md
@@ -95,15 +95,16 @@ $ rethinkdb
 Then open a different terminal and run:
 ```text
 $ bigchaindb -y configure
-$ bigchaindb init
 ```
 
-That creates a configuration file in `$HOME/.bigchaindb` (documented in [the section on configuration](configuration.html)), initializes the database, creates the tables, creates the indexes, and generates the genesis block.
+That creates a configuration file in `$HOME/.bigchaindb` (documented in [the section on configuration](configuration.html)). More documentation about the `bigchaindb` command is in the section on [the BigchainDB Command Line Interface (CLI)](bigchaindb-cli.html).
 
 You can start BigchainDB Server using:
 ```text
 $ bigchaindb start
 ```
+
+If it's the first time you've run `bigchaindb start`, then it creates the database (a RethinkDB database), the tables, the indexes, and the genesis block. It then starts BigchainDB. If you're run `bigchaindb start` or `bigchaindb init` before (and you haven't dropped the database), then `bigchaindb start` just starts BigchainDB.
 
 
 ## Run BigchainDB with Docker

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def ignore_local_config_file(monkeypatch):
 @pytest.fixture(scope='function', autouse=True)
 def restore_config(request, node_config):
     from bigchaindb import config_utils
-    config_utils.dict_config(node_config)
+    config_utils.set_config(node_config)
 
 
 @pytest.fixture(scope='module')

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -17,7 +17,7 @@ from bigchaindb.db import get_conn
 @pytest.fixture(autouse=True)
 def restore_config(request, node_config):
     from bigchaindb import config_utils
-    config_utils.dict_config(node_config)
+    config_utils.set_config(node_config)
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -82,7 +82,7 @@ def test_bigchain_run_start_assume_yes_create_default_config(monkeypatch, mock_p
         value['return'] = newconfig
 
     monkeypatch.setattr(config_utils, 'write_config', mock_write_config)
-    monkeypatch.setattr(config_utils, 'file_config', lambda x: config_utils.dict_config(expected_config))
+    monkeypatch.setattr(config_utils, 'file_config', lambda x: config_utils.set_config(expected_config))
     monkeypatch.setattr('os.path.exists', lambda path: False)
 
     args = Namespace(config=None, yes=True)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -124,7 +124,6 @@ def test_bigchain_export_my_pubkey_when_pubkey_set(capsys, monkeypatch):
     out, err = capsys.readouterr()
     assert out == config['keypair']['public'] + '\n'
     assert out == 'Charlie_Bucket\n'
-    assert err == ''
 
 
 def test_bigchain_export_my_pubkey_when_pubkey_not_set(monkeypatch):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -108,6 +108,43 @@ def test_bigchain_show_config(capsys):
     assert output_config == config
 
 
+def test_bigchain_export_my_pubkey_when_pubkey_set(capsys, monkeypatch):
+    from bigchaindb import config
+    from bigchaindb.commands.bigchain import run_export_my_pubkey
+
+    args = Namespace(config='dummy')
+    # so in run_export_my_pubkey(args) below,
+    # filename=args.config='dummy' is passed to autoconfigure().
+    # We just assume autoconfigure() works and sets
+    # config['keypair']['public'] correctly (tested elsewhere).
+    # We force-set config['keypair']['public'] using monkeypatch.
+    monkeypatch.setitem(config['keypair'], 'public', 'Charlie_Bucket')
+    _, _ = capsys.readouterr()  # has the effect of clearing capsys
+    run_export_my_pubkey(args)
+    out, err = capsys.readouterr()
+    assert out == config['keypair']['public'] + '\n'
+    assert out == 'Charlie_Bucket\n'
+    assert err == ''
+
+
+def test_bigchain_export_my_pubkey_when_pubkey_not_set(monkeypatch):
+    from bigchaindb import config
+    from bigchaindb.commands.bigchain import run_export_my_pubkey
+
+    args = Namespace(config='dummy')
+    monkeypatch.setitem(config['keypair'], 'public', None)
+    # assert that run_export_my_pubkey(args) raises SystemExit:
+    with pytest.raises(SystemExit) as exc_info:
+        run_export_my_pubkey(args)
+    # exc_info is an object of class ExceptionInfo
+    # https://pytest.org/latest/builtin.html#_pytest._code.ExceptionInfo
+    assert exc_info.type == SystemExit
+    # exc_info.value is an object of class SystemExit
+    # https://docs.python.org/3/library/exceptions.html#SystemExit
+    assert exc_info.value.code == \
+        "This node's public key wasn't set anywhere so it can't be exported"
+
+
 def test_bigchain_run_init_when_db_exists(mock_db_init_with_existing_db):
     from bigchaindb.commands.bigchain import run_init
     args = Namespace(config=None)
@@ -159,4 +196,3 @@ def test_run_configure_when_config_does_exist(monkeypatch,
     args = Namespace(config='foo', yes=None)
     run_configure(args)
     assert value == {}
-

--- a/tests/utils/test_config_utils.py
+++ b/tests/utils/test_config_utils.py
@@ -18,7 +18,7 @@ def test_bigchain_instance_is_initialized_when_conf_provided():
     from bigchaindb import config_utils
     assert 'CONFIGURED' not in bigchaindb.config
 
-    config_utils.dict_config({'keypair': {'public': 'a', 'private': 'b'}})
+    config_utils.set_config({'keypair': {'public': 'a', 'private': 'b'}})
 
     assert bigchaindb.config['CONFIGURED'] is True
     b = bigchaindb.Bigchain()

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -5,7 +5,7 @@ from ..db import conftest
 @pytest.fixture(autouse=True)
 def restore_config(request, node_config):
     from bigchaindb import config_utils
-    config_utils.dict_config(node_config)
+    config_utils.set_config(node_config)
 
 
 @pytest.fixture(scope='module', autouse=True)


### PR DESCRIPTION
The main thing that this pull request does is add a new command to the BigchainDB command-line interface (CLI):
```text
bigchaindb export-my-pubkey
```

That command prints the node's public key to standard output (or exits and gives an error message on stderr if nothing set the node's public key).

This PR originally included another new command to import a public key to a node's keychain, but then I realized that our approach to managing the keyring(s) needs to be rethought. I'll write more about that in a new issue. UPDATE: See issue #187 

Also in this PR:
* More thorough documentation for the `bigchaindb` command.
* Lots of minor changes to code docstrings and syntax (i.e. not changing functionality, just helping the next person reading that code for the first time)

Resolves #179 