### PR TITLE
update to cryptoconditions 0.1.6

### DIFF
--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -290,7 +290,7 @@ class Bigchain(object):
         # Calculate the hash of the new block
         block_data = util.serialize(block)
         block_hash = crypto.hash_data(block_data)
-        block_signature = crypto.SigningKey(self.me_private).sign(block_data).decode()
+        block_signature = crypto.SigningKey(self.me_private).sign(block_data)
 
         block = {
             'id': block_hash,
@@ -409,7 +409,7 @@ class Bigchain(object):
         }
 
         vote_data = util.serialize(vote)
-        signature = crypto.SigningKey(self.me_private).sign(vote_data).decode()
+        signature = crypto.SigningKey(self.me_private).sign(vote_data)
 
         vote_signed = {
             'node_pubkey': self.me,

--- a/bigchaindb/crypto.py
+++ b/bigchaindb/crypto.py
@@ -13,5 +13,5 @@ def generate_key_pair():
     sk, pk = ed25519.ed25519_generate_key_pair()
     return sk.decode(), pk.decode()
 
-SigningKey = ed25519.Ed25519SigningKey
-VerifyingKey = ed25519.Ed25519VerifyingKey
+SigningKey = ed25519.SigningKey
+VerifyingKey = ed25519.VerifyingKey

--- a/bigchaindb/util.py
+++ b/bigchaindb/util.py
@@ -219,7 +219,7 @@ def sign_tx(transaction, private_key):
     private_key = crypto.SigningKey(private_key)
     signature = private_key.sign(serialize(transaction))
     signed_transaction = transaction.copy()
-    signed_transaction.update({'signature': signature.decode()})
+    signed_transaction.update({'signature': signature})
     return signed_transaction
 
 

--- a/docs/source/installing-server.md
+++ b/docs/source/installing-server.md
@@ -26,7 +26,7 @@ If you don't already have it, then you should [install Python 3.4+](https://www.
 
 ## Install BigchainDB Server
 
-BigchainDB Server has some OS-level dependencies. In particular, you need to install the OS-level dependencies for the Python **cryptography** package. Instructions for installing those dependencies on your OS can be found in the [cryptography package documentation](https://cryptography.io/en/latest/installation/).
+BigchainDB Server has some OS-level dependencies.
 
 On Ubuntu 14.04, we found that the following was enough:
 ```text

--- a/docs/source/installing-server.md
+++ b/docs/source/installing-server.md
@@ -31,13 +31,13 @@ BigchainDB Server has some OS-level dependencies. In particular, you need to ins
 On Ubuntu 14.04, we found that the following was enough:
 ```text
 $ sudo apt-get update
-$ sudo apt-get install libffi-dev g++ libssl-dev python3-dev
+$ sudo apt-get install g++ python3-dev
 ```
 
 On Fedora 23, we found that the following was enough (tested in February 2015):
 ```text
 $ sudo dnf update
-$ sudo dnf install libffi-devel gcc-c++ redhat-rpm-config python3-devel openssl-devel
+$ sudo dnf install gcc-c++ redhat-rpm-config python3-devel
 ```
 
 (If you're using a version of Fedora before version 22, you may have to use `yum` instead of `dnf`.)

--- a/docs/source/python-server-api-examples.md
+++ b/docs/source/python-server-api-examples.md
@@ -69,7 +69,7 @@ After a couple of seconds, we can check if the transactions was included in the 
 # retrieve a transaction from the bigchain
 tx_retrieved = b.get_transaction(tx_signed['id'])
 
-   'id': '6539dded9479c47b3c83385ae569ecaa90bcf387240d1ee2ea3ae0f7986aeddd',
+{  'id': '6539dded9479c47b3c83385ae569ecaa90bcf387240d1ee2ea3ae0f7986aeddd',
    'transaction': {   'current_owner': 'pvGtcm5dvwWMzCqagki1N6CDKYs2J1cCwTNw8CqJic3Q',
                       'data': {   'hash': '872fa6e6f46246cd44afdb2ee9cfae0e72885fb0910e2bcf9a5a2a4eadb417b8',
                                   'payload': {'msg': 'Hello BigchainDB!'}},

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         'rethinkdb==2.2.0.post4',
         'pysha3==0.3',
         'pytz==2015.7',
-        'cryptoconditions==0.1.1',
+        'cryptoconditions==0.1.6',
         'statsd==3.2.1',
         'python-rapidjson==0.0.6',
         'logstats==0.2.1',


### PR DESCRIPTION
removes the need of the cryptography dependency

can potentialy drop the `libffi-dev` dependency and more?