### PR TITLE
Small fix to the documentation

### DIFF
--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -171,7 +171,7 @@ class Bigchain(object):
 
         Returns:
             A list of transactions containing that payload. If no transaction exists with that payload it
-            returns `None`
+            returns an empty list `[]`
         """
 
         cursor = r.table('bigchain')\


### PR DESCRIPTION
`get_tx_by_payload_hash` returns an empty list if there are no transactions instead of None