### PR TITLE
Further AWS deployment improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ target/
 # Some files created when deploying a cluster on AWS
 deploy-cluster-aws/conf/rethinkdb.conf
 deploy-cluster-aws/hostlist.py
+deploy-cluster-aws/confiles/

--- a/deploy-cluster-aws/clusterize_confiles.py
+++ b/deploy-cluster-aws/clusterize_confiles.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""Given a directory full of default BigchainDB config files,
+transform them into config files for a cluster with proper
+keyrings, API endpoint values, etc.
+
+Note: This script assumes that there is a file named hostlist.py
+containing public_dns_names = a list of the public DNS names of
+all the hosts in the cluster.
+
+Usage:
+    python clusterize_confiles.py <dir> <number_of_files>
+"""
+
+from __future__ import unicode_literals
+import os
+import json
+import argparse
+
+from hostlist import public_dns_names
+
+
+# Parse the command-line arguments
+parser = argparse.ArgumentParser()
+parser.add_argument('dir',
+                    help='Directory containing the config files')
+parser.add_argument('number_of_files',
+                    help='Number of config files expected in dir',
+                    type=int)
+args = parser.parse_args()
+
+conf_dir = args.dir
+numfiles_expected = int(args.number_of_files)
+
+# Check if the number of files in conf_dir is what was expected
+conf_files = os.listdir(conf_dir)
+numfiles = len(conf_files)
+if numfiles != numfiles_expected:
+    raise ValueError('There are {} files in {} but {} were expected'.
+                     format(numfiles, conf_dir, numfiles_expected))
+
+# Make a list containing all the public keys from
+# all the config files
+pubkeys = []
+for filename in conf_files:
+    file_path = os.path.join(conf_dir, filename)
+    with open(file_path, 'r') as f:
+        conf_dict = json.load(f)
+        pubkey = conf_dict['keypair']['public']
+        pubkeys.append(pubkey)
+
+# Rewrite each config file, one at a time
+for i, filename in enumerate(conf_files):
+    file_path = os.path.join(conf_dir, filename)
+    with open(file_path, 'r') as f:
+        conf_dict = json.load(f)
+        # The keyring is the list of *all* public keys
+        # minus the config file's own public key
+        keyring = list(pubkeys)
+        keyring.remove(conf_dict['keypair']['public'])
+        conf_dict['keyring'] = keyring
+        # Allow incoming server traffic from any IP address
+        # to port 9984
+        conf_dict['server']['bind'] = '0.0.0.0:9984'
+        # Set the api_endpoint
+        conf_dict['api_endpoint'] = 'http://' + public_dns_names[i] + \
+                                    ':9984/api/v1'
+    # Delete the config file
+    os.remove(file_path)
+    # Write new config file with the same filename
+    print('Rewriting {}'.format(file_path))
+    with open(file_path, 'w') as f2:
+        json.dump(conf_dict, f2)

--- a/deploy-cluster-aws/fabfile.py
+++ b/deploy-cluster-aws/fabfile.py
@@ -5,7 +5,7 @@ BigchainDB, including its storage backend (RethinkDB).
 
 from __future__ import with_statement, unicode_literals
 
-from fabric.api import sudo, env
+from fabric.api import sudo, env, hosts
 from fabric.api import task, parallel
 from fabric.contrib.files import sed
 from fabric.operations import run, put
@@ -29,28 +29,6 @@ newrelic_license_key = 'you_need_a_real_license_key'
 
 
 ######################################################################
-
-# DON'T PUT @parallel
-@task
-def set_hosts(hosts):
-    """A helper function to change env.hosts from the
-    command line.
-
-    Args:
-        hosts (str): 'one_node' or 'two_nodes'
-
-    Example:
-        fab set_hosts:one_node init_bigchaindb
-    """
-    if hosts == 'one_node':
-        env.hosts = public_dns_names[:1]
-    elif hosts == 'two_nodes':
-        env.hosts = public_dns_names[:2]
-    else:
-        raise ValueError('Invalid input to set_hosts.'
-                         ' Expected one_node or two_nodes.'
-                         ' Got {}'.format(hosts))
-
 
 # Install base software
 @task
@@ -141,10 +119,10 @@ def configure_bigchaindb():
 # Initialize BigchainDB
 # i.e. create the database, the tables,
 # the indexes, and the genesis block.
-# (This only needs to be run on one node.)
-# Call using:
-#     fab set_hosts:one_node init_bigchaindb
+# (The @hosts decorator is used to make this
+# task run on only one node. See http://tinyurl.com/h9qqf3t )
 @task
+@hosts(public_dns_names[0])
 def init_bigchaindb():
     run('bigchaindb init', pty=False)
 

--- a/deploy-cluster-aws/fabfile.py
+++ b/deploy-cluster-aws/fabfile.py
@@ -143,10 +143,8 @@ def configure_bigchaindb():
 def send_confile(confile):
     put('confiles/' + confile, 'tempfile')
     sudo('mv tempfile ~/.bigchaindb')
-    print('When confile = {} '.format(confile))
-    print('bigchaindb show-config output is:')
+    print('For this node, bigchaindb show-config says:')
     run('bigchaindb show-config')
-    print(' ')
 
 
 # Initialize BigchainDB

--- a/deploy-cluster-aws/fabfile.py
+++ b/deploy-cluster-aws/fabfile.py
@@ -141,7 +141,7 @@ def configure_bigchaindb():
 @task
 def send_confile(confile):
     put('confiles/' + confile, 'tempfile')
-    sudo('mv tempfile ~/.bigchaindb')
+    run('mv tempfile ~/.bigchaindb')
     print('For this node, bigchaindb show-config says:')
     run('bigchaindb show-config')
 

--- a/deploy-cluster-aws/fabfile.py
+++ b/deploy-cluster-aws/fabfile.py
@@ -30,6 +30,24 @@ newrelic_license_key = 'you_need_a_real_license_key'
 
 ######################################################################
 
+# DON'T PUT @parallel
+@task
+def set_host(host_index):
+    """A helper task to change env.hosts from the
+    command line. It will only "stick" for the duration
+    of the fab command that called it.
+
+    Args:
+        host_index (int): 1, 2, 3, etc.
+    Example:
+        fab set_host:4 fab_task_A fab_task_B
+        will set env.hosts = [public_dns_names[3]]
+        but only for doing fab_task_A and fab_task_B
+    """
+    env.hosts = [public_dns_names[int(host_index) - 1]]
+    print('Set env.hosts = {}'.format(env.hosts))
+
+
 # Install base software
 @task
 @parallel
@@ -114,6 +132,21 @@ def install_bigchaindb_from_git_archive():
 @parallel
 def configure_bigchaindb():
     run('bigchaindb -y configure', pty=False)
+
+
+# Send the specified configuration file to
+# the remote host and save it there in
+# ~/.bigchaindb
+# Use in conjunction with set_host()
+# No @parallel
+@task
+def send_confile(confile):
+    put('confiles/' + confile, 'tempfile')
+    sudo('mv tempfile ~/.bigchaindb')
+    print('When confile = {} '.format(confile))
+    print('bigchaindb show-config output is:')
+    run('bigchaindb show-config')
+    print(' ')
 
 
 # Initialize BigchainDB

--- a/deploy-cluster-aws/fabfile.py
+++ b/deploy-cluster-aws/fabfile.py
@@ -38,14 +38,13 @@ def set_host(host_index):
     of the fab command that called it.
 
     Args:
-        host_index (int): 1, 2, 3, etc.
+        host_index (int): 0, 1, 2, 3, etc.
     Example:
         fab set_host:4 fab_task_A fab_task_B
-        will set env.hosts = [public_dns_names[3]]
+        will set env.hosts = [public_dns_names[4]]
         but only for doing fab_task_A and fab_task_B
     """
-    env.hosts = [public_dns_names[int(host_index) - 1]]
-    print('Set env.hosts = {}'.format(env.hosts))
+    env.hosts = [public_dns_names[int(host_index)]]
 
 
 # Install base software

--- a/deploy-cluster-aws/launch_ec2_nodes.py
+++ b/deploy-cluster-aws/launch_ec2_nodes.py
@@ -195,21 +195,25 @@ with open('hostlist.py', 'w') as f:
 
 
 # For each node in the cluster, check port 22 (ssh) until it's reachable
-for public_dns_name in public_dns_names:
-    # Create an INET, STREAMing socket
+for instance in instances_with_tag:
+    ip_address = instance.public_ip_address
+    # Create a socket
+    # Address Family: AF_INET (means IPv4)
+    # Type: SOCK_STREAM (means connection-oriented TCP protocol)
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     print('Attempting to connect to {} on port 22 (ssh)...'.
-          format(public_dns_name))
+          format(ip_address))
     unreachable = True
     while unreachable:
         try:
-            # Open a TCP connection to the remote node on port 22
-            s.connect((public_dns_name, 22))
-            print('  Port 22 is reachable!')
-            s.shutdown(socket.SHUT_WR)
-            s.close()
-            unreachable = False
+            # Open a connection to the remote node on port 22
+            s.connect((ip_address, 22))
         except socket.error as e:
             print('  Socket error: {}'.format(e))
             print('  Trying again in 3 seconds')
             time.sleep(3.0)
+        else:
+            print('  Port 22 is reachable!')
+            s.shutdown(socket.SHUT_WR)
+            s.close()
+            unreachable = False

--- a/deploy-cluster-aws/make_confiles.sh
+++ b/deploy-cluster-aws/make_confiles.sh
@@ -33,7 +33,7 @@ mkdir $CONFDIR
 
 # Use the bigchaindb configure command to create
 # $NUMFILES BigchainDB config files in $CONFDIR
-for (( i=1; i<=$NUMFILES; i++ )); do
+for (( i=0; i<$NUMFILES; i++ )); do
     CONPATH=$CONFDIR"/bcdb_conf"$i
     echo "Writing "$CONPATH
     bigchaindb -y -c $CONPATH configure

--- a/deploy-cluster-aws/make_confiles.sh
+++ b/deploy-cluster-aws/make_confiles.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+
+# The set -e option instructs bash to immediately exit
+# if any command has a non-zero exit status
+set -e
+
+function printErr()
+    {
+        echo "usage: ./make_confiles.sh <dir> <number_of_files>"
+        echo "No argument $1 supplied"
+    }
+
+if [ -z "$1" ]; then
+    printErr "<dir>"
+    exit 1
+fi
+
+if [ -z "$2" ]; then
+    printErr "<number_of_files>"
+    exit 1
+fi
+
+CONFDIR=$1
+NUMFILES=$2
+
+# If $CONFDIR exists, remove it
+if [ -d "$CONFDIR" ]; then
+    rm -rf $CONFDIR
+fi
+
+# Create $CONFDIR
+mkdir $CONFDIR
+
+# Use the bigchaindb configure command to create
+# $NUMFILES BigchainDB config files in $CONFDIR
+for (( i=1; i<=$NUMFILES; i++ )); do
+    CONPATH=$CONFDIR"/bcdb_conf"$i
+    echo "Writing "$CONPATH
+    bigchaindb -y -c $CONPATH configure
+done

--- a/deploy-cluster-aws/startup.sh
+++ b/deploy-cluster-aws/startup.sh
@@ -21,7 +21,7 @@ if [ -z "$2" ]; then
 fi
 
 TAG=$1
-NODES=$2
+NUM_NODES=$2
 
 # If they don't include a third argument (<pypi_or_branch>)
 # then assume BRANCH = "pypi" by default
@@ -35,6 +35,13 @@ fi
 # Check for AWS private key file (.pem file)
 if [ ! -f "pem/bigchaindb.pem" ]; then
     echo "File pem/bigchaindb.pem (AWS private key) is missing"
+    exit 1
+fi
+
+# Check for the confiles directory
+if [ ! -d "confiles" ]; then
+    echo "Directory confiles is needed but does not exist"
+    echo "See make_confiles.sh to find out how to make it"
     exit 1
 fi
 
@@ -52,7 +59,7 @@ chmod 0400 pem/bigchaindb.pem
 # 5. writes the shellscript add2known_hosts.sh
 # 6. (over)writes a file named hostlist.py
 #    containing a list of all public DNS names.
-python launch_ec2_nodes.py --tag $TAG --nodes $NODES 
+python launch_ec2_nodes.py --tag $TAG --nodes $NUM_NODES
 
 # Make add2known_hosts.sh executable then execute it.
 # This adds remote keys to ~/.ssh/known_hosts
@@ -86,13 +93,28 @@ else
 fi
 
 # Configure BigchainDB on all nodes
-fab configure_bigchaindb
 
-# TODO: Get public keys from all nodes
+# The idea is to send a bunch of locally-created configuration
+# files out to each of the instances / nodes.
 
+# Assume a set of $NUM_NODES BigchaindB config files
+# already exists in the confiles directory.
+# One can create a set using a command like
+# ./make_confiles.sh confiles $NUM_NODES
+# (We can't do that here now because this virtual environment
+# is a Python 2 environment that may not even have
+# bigchaindb installed, so bigchaindb configure can't be called)
 
-# TODO: Add list of public keys to keyring of all nodes
+# Transform the config files in the confiles directory
+# to have proper keyrings, api_endpoint values, etc.
+python clusterize_confiles.py confiles $NUM_NODES
 
+# Send one of the config files to each instance
+for (( HOST=1 ; HOST<=$NUM_NODES ; HOST++ )); do
+    CONFILE="bcdb_conf"$HOST
+    echo "Sending "$CONFILE
+    fab set_host:$HOST send_confile:$CONFILE
+done
 
 # Initialize BigchainDB (i.e. Create the RethinkDB database,
 # the tables, the indexes, and genesis glock). Note that
@@ -105,3 +127,4 @@ fab start_bigchaindb
 
 # cleanup
 rm add2known_hosts.sh
+# rm -rf temp_confs

--- a/deploy-cluster-aws/startup.sh
+++ b/deploy-cluster-aws/startup.sh
@@ -94,11 +94,11 @@ fab configure_bigchaindb
 # TODO: Add list of public keys to keyring of all nodes
 
 
-# Send a "bigchaindb init" command to one node
-# to initialize the BigchainDB database 
-# i.e. create the database, the tables,
-# the indexes, and the genesis block.
-fab set_hosts:one_node init_bigchaindb
+# Initialize BigchainDB (i.e. Create the RethinkDB database,
+# the tables, the indexes, and genesis glock). Note that
+# this will only be sent to one of the nodes, see the
+# definition of init_bigchaindb() in fabfile.py to see why.
+fab init_bigchaindb
 
 # Start BigchainDB on all the nodes using "screen"
 fab start_bigchaindb

--- a/deploy-cluster-aws/startup.sh
+++ b/deploy-cluster-aws/startup.sh
@@ -110,7 +110,7 @@ fi
 python clusterize_confiles.py confiles $NUM_NODES
 
 # Send one of the config files to each instance
-for (( HOST=1 ; HOST<=$NUM_NODES ; HOST++ )); do
+for (( HOST=0 ; HOST<$NUM_NODES ; HOST++ )); do
     CONFILE="bcdb_conf"$HOST
     echo "Sending "$CONFILE
     fab set_host:$HOST send_confile:$CONFILE

--- a/docs/source/deploy-on-aws.md
+++ b/docs/source/deploy-on-aws.md
@@ -87,28 +87,26 @@ Add some rules for Inbound traffic:
 
 ### AWS Deployment Step 1
 
-Step 1 is to create a set of BigchainDB configuration files in a directory named `confiles`. They can be the default configuration files (i.e. what gets created when you use the `bigchaindb -y configure` command). An easy way to create a set of config files is to use the `make_confiles.sh` script. For example, if you **go into a virtual environment where `bigchaindb` is installed (i.e. probably a Python 3 virtual environment)** and enter:
+Suppose _N_ is the number of nodes you want in your BigchainDB cluster. If you already have a set of _N_ BigchainDB configuration files in the `deploy-cluster-aws/confiles` directory, then you can jump to step 2. To create such a set, you can do something like:
 ```text
 # in a Python 3 virtual environment where bigchaindb is installed
 cd bigchaindb
-cd deploy_cluster_aws
+cd deploy-cluster-aws
 ./make_confiles.sh confiles 3
 ```
 
-then three (3) default BigchainDB configuration files will be created in a directory named `confiles`, namely:
+That will create three (3) _default_ BigchainDB configuration files in the `deploy-cluster-aws/confiles` directory (which will be created if it doesn't already exist). The three files will be named `bcdb_conf0`, `bcdb_conf1`, and `bcdb_conf2`.
 
-* `confiles/bcdb_conf0`
-* `confiles/bcdb_conf1`
-* `confiles/bcdb_conf2`
-
-You can look inside those files if you're curious. In step 2, they'll be modified. For example, the default keyring is an empty list. In step 2, the deployment script automatically change the keyring of each node to be a list of the public keys of all other nodes.
+You can look inside those files if you're curious. In step 2, they'll be modified. For example, the default keyring is an empty list. In step 2, the deployment script automatically changes the keyring of each node to be a list of the public keys of all other nodes. Other changes are also made.
 
 ### AWS Deployment Step 2
 
-Step 2 is to launch the nodes ("instances") on AWS, to install all the necessary software on them, to configure the software, and to run the software.
+Step 2 is to launch the nodes ("instances") on AWS, to install all the necessary software on them, configure the software, run the software, and more.
 
 Here's an example of how one could launch a BigchainDB cluster of three (3) nodes tagged `wrigley` on AWS:
 ```text
+# in a Python 2.5-2.7 virtual environment where fabric, boto3, etc. are installed
+cd bigchaindb
 cd deploy-cluster-aws
 ./startup.sh wrigley 3 pypi
 ```


### PR DESCRIPTION
This pull request adds a bunch of new stuff to the AWS deployment scripts:
* An easier way to make Fabric send the `bigchaindb init` command to only one node: use the `@hosts(hostname)` decorator.
* The `make_confiles.sh` script to generate a set of default BigchainDB config files. You have to do this before calling `./startup.sh` as explained in the updated documentation for AWS deployment.
* The `clusterize_confiles.py` script to make all the config files for a cluster consistent with each other and with the hostnames of the nodes in the cluster
* Updated `startup.sh` and `fabfile.py` to clusterize the set of config files and send a different config file to each node in the cluster

I also figured out a way to make sure the nodes are all ready to start getting commands from Fabric (via ssh), rather than waiting 45 seconds. I just create a local socket and then try to connect it to port 22 on all the nodes, and keep trying those connections until they all work.

Note: These scripts are just to help us get a test cluster up and running now, before we implement a better way of handling the list of public keys in the federation, like what's outlined in Issue #187.