### PR TITLE
validate_block now checks if a federation node created the block.

### DIFF
--- a/bigchaindb/consensus.py
+++ b/bigchaindb/consensus.py
@@ -167,7 +167,6 @@ class BaseConsensusRules(AbstractConsensusRules):
 
         return transaction
 
-    # TODO: Unsure if a bigchain parameter is really necessary here?
     @staticmethod
     def validate_block(bigchain, block):
         """Validate a block.
@@ -188,6 +187,15 @@ class BaseConsensusRules(AbstractConsensusRules):
         calculated_hash = crypto.hash_data(util.serialize(block['block']))
         if calculated_hash != block['id']:
             raise exceptions.InvalidHash()
+
+        # Check if the block was created by a federation node
+        if block['block']['node_pubkey'] not in (bigchain.federation_nodes + [bigchain.me]):
+            raise exceptions.OperationError('Only federation nodes can create blocks')
+
+        # Check if block signature is valid
+        verifying_key = crypto.VerifyingKey(block['block']['node_pubkey'])
+        if not verifying_key.verify(util.serialize(block['block']), block['signature']):
+            raise exceptions.InvalidSignature('Invalid block signature')
 
         return block
 


### PR DESCRIPTION
resolves #229 
related to #228 

This pull request adds code to check if a block was created by a federation node.
To do so it checks if `block['block']['node_pubkey']` is a federation node and also checks if the signature is correct.

The validation seems to be split between `core` and `consensus`. I decided to add the code to the `consensus` module but during the planned refactor we should address this code split.