### PR TITLE
Python Style Guide: How to Format Long import Statements

### DIFF
--- a/PYTHON_STYLE_GUIDE.md
+++ b/PYTHON_STYLE_GUIDE.md
@@ -43,6 +43,16 @@ my_string = 'This is a very long string, so long that it will not fit into just 
 
 It seems the preference is for slashes, but using parentheses is okay too. (There are good arguments either way. Arguing about it seems like a waste of time.)
 
+### How to Format Long import Statements
+
+If you need to `import` lots of names from a module or package, and they won't all fit in one line (without making the line too long), then use parentheses to spread the names across multiple lines, like so:
+```python
+from Tkinter import (Tk, Frame, Button, Entry, Canvas, Text,
+    LEFT, DISABLED, NORMAL, RIDGE, END)
+```
+
+For the rationale, see [PEP 328](https://www.python.org/dev/peps/pep-0328/#rationale-for-parentheses).
+
 ### Using the % operator or `format()` to Format Strings
 
 Given the choice:


### PR DESCRIPTION
I added a short section to the Python Style Guide about how to format long `import` statements. It's based on [PEP 328](https://www.python.org/dev/peps/pep-0328/#rationale-for-parentheses).
