### PR TITLE
Deploy clients on AWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ target/
 deploy-cluster-aws/conf/rethinkdb.conf
 deploy-cluster-aws/hostlist.py
 deploy-cluster-aws/confiles/
+deploy-cluster-aws/client_confile

--- a/deploy-cluster-aws/awsdeploy.sh
+++ b/deploy-cluster-aws/awsdeploy.sh
@@ -4,27 +4,36 @@
 # if any command has a non-zero exit status
 set -e
 
-USAGE="usage: ./awsdeploy_servers.sh <number_of_nodes_in_cluster> <pypi_or_branch>"
-
-# Auto-generate the tag to apply to all nodes in the cluster
-TAG="bcdb-"`date +%m-%d@%H:%M`
-echo "TAG = "$TAG
+USAGE="usage: ./awsdeploy.sh <number_of_nodes_in_cluster> <pypi_or_branch> <servers_or_clients>"
 
 if [ -z "$1" ]; then
     echo $USAGE
-    echo "No first argument <number_of_nodes_in_cluster> was specified"
+    echo "No first argument was specified"
+    echo "It should be a number like 3 or 15"
     exit 1
 else
     NUM_NODES=$1
 fi
 
-# If they don't include a second argument (<pypi_or_branch>)
-# then assume BRANCH = "pypi" by default
 if [ -z "$2" ]; then
+    echo $USAGE
     echo "No second argument was specified, so BigchainDB will be installed from PyPI"
     BRANCH="pypi"
 else
     BRANCH=$2
+fi
+
+if [ -z "$3" ]; then
+    echo $USAGE
+    echo "No third argument was specified, so servers will be deployed"
+    WHAT_TO_DEPLOY="servers"
+else
+    WHAT_TO_DEPLOY=$3
+fi
+
+if [[ ("$WHAT_TO_DEPLOY" != "servers") && ("$WHAT_TO_DEPLOY" != "clients") ]]; then
+    echo "The third argument, if included, must be servers or clients"
+    exit 1
 fi
 
 # Check for AWS private key file (.pem file)
@@ -39,6 +48,10 @@ if [ ! -d "confiles" ]; then
     echo "See make_confiles.sh to find out how to make it"
     exit 1
 fi
+
+# Auto-generate the tag to apply to all nodes in the cluster
+TAG="BDB-"$WHAT_TO_DEPLOY"-"`date +%m-%d@%H:%M`
+echo "TAG = "$TAG
 
 # Change the file permissions on pem/bigchaindb.pem
 # so that the owner can read it, but that's all

--- a/deploy-cluster-aws/awsdeploy_servers.sh
+++ b/deploy-cluster-aws/awsdeploy_servers.sh
@@ -4,32 +4,27 @@
 # if any command has a non-zero exit status
 set -e
 
-function printErr()
-    {
-        echo "usage: ./awsdeploy_servers.sh <tag> <number_of_nodes_in_cluster> <pypi_or_branch>"
-        echo "No argument $1 supplied"
-    }
+USAGE="usage: ./awsdeploy_servers.sh <number_of_nodes_in_cluster> <pypi_or_branch>"
+
+# Auto-generate the tag to apply to all nodes in the cluster
+TAG="bcdb-"`date +%m-%d@%H:%M`
+echo "TAG = "$TAG
 
 if [ -z "$1" ]; then
-    printErr "<tag>"
+    echo $USAGE
+    echo "No first argument <number_of_nodes_in_cluster> was specified"
     exit 1
+else
+    NUM_NODES=$1
 fi
 
-if [ -z "$2" ]; then
-    printErr "<number_of_nodes_in_cluster>"
-    exit 1
-fi
-
-TAG=$1
-NUM_NODES=$2
-
-# If they don't include a third argument (<pypi_or_branch>)
+# If they don't include a second argument (<pypi_or_branch>)
 # then assume BRANCH = "pypi" by default
-if [ -z "$3" ]; then
-    echo "No third argument was specified, so BigchainDB will be installed from PyPI"
+if [ -z "$2" ]; then
+    echo "No second argument was specified, so BigchainDB will be installed from PyPI"
     BRANCH="pypi"
 else
-    BRANCH=$3
+    BRANCH=$2
 fi
 
 # Check for AWS private key file (.pem file)

--- a/deploy-cluster-aws/awsdeploy_servers.sh
+++ b/deploy-cluster-aws/awsdeploy_servers.sh
@@ -6,7 +6,7 @@ set -e
 
 function printErr()
     {
-        echo "usage: ./startup.sh <tag> <number_of_nodes_in_cluster> <pypi_or_branch>"
+        echo "usage: ./awsdeploy_servers.sh <tag> <number_of_nodes_in_cluster> <pypi_or_branch>"
         echo "No argument $1 supplied"
     }
 

--- a/deploy-cluster-aws/fabfile.py
+++ b/deploy-cluster-aws/fabfile.py
@@ -146,6 +146,15 @@ def send_confile(confile):
     run('bigchaindb show-config')
 
 
+@task
+@parallel
+def send_client_confile(confile):
+    put(confile, 'tempfile')
+    run('mv tempfile ~/.bigchaindb')
+    print('For this node, bigchaindb show-config says:')
+    run('bigchaindb show-config')
+
+
 # Initialize BigchainDB
 # i.e. create the database, the tables,
 # the indexes, and the genesis block.
@@ -162,6 +171,12 @@ def init_bigchaindb():
 @parallel
 def start_bigchaindb():
     sudo('screen -d -m bigchaindb -y start &', pty=False)
+
+
+@task
+@parallel
+def start_bigchaindb_load():
+    sudo('screen -d -m bigchaindb load &', pty=False)
 
 
 # Install and run New Relic

--- a/deploy-cluster-aws/startup.sh
+++ b/deploy-cluster-aws/startup.sh
@@ -127,4 +127,3 @@ fab start_bigchaindb
 
 # cleanup
 rm add2known_hosts.sh
-# rm -rf temp_confs

--- a/docs/source/deploy-on-aws.md
+++ b/docs/source/deploy-on-aws.md
@@ -108,19 +108,21 @@ Here's an example of how one could launch a BigchainDB cluster of three (3) node
 # in a Python 2.5-2.7 virtual environment where fabric, boto3, etc. are installed
 cd bigchaindb
 cd deploy-cluster-aws
-./awsdeploy_servers.sh 3 pypi
+./awsdeploy.sh 3
 ```
 
-The `pypi` on the end means that it will install the latest (stable) `bigchaindb` package from the [Python Package Index (PyPI)](https://pypi.python.org/pypi). That is, on each node, BigchainDB is installed using `pip install bigchaindb`. 
-
-`awsdeploy_servers.sh` is a Bash script which calls some Python and Fabric scripts. The usage is:
+`awsdeploy.sh` is a Bash script which calls some Python and Fabric scripts. The usage is:
 ```text
-./awsdeploy_servers.sh <number_of_nodes_in_cluster> <pypi_or_branch>
+./awsdeploy.sh <number_of_nodes_in_cluster> [pypi_or_branch] [servers_or_clients]
 ```
 
-The first argument is the number of nodes to deploy. The second argument can be `pypi` or the name of a local Git branch (e.g. `master` or `feat/3752/quote-asimov-on-tuesdays`). If you don't include a second argument, then `pypi` will be assumed by default.
+The first argument <number_of_nodes_in_cluster> is required. It's how many nodes you want to deploy.
 
-If you're curious what the `awsdeploy_servers.sh` script does, the source code has lots of explanatory comments, so it's quite easy to read. Here's a link to the latest version on GitHub: [`awsdeploy_servers.sh`](https://github.com/bigchaindb/bigchaindb/blob/master/deploy-cluster-aws/awsdeploy_servers.sh)
+The second argument is optional. It can be the word `pypi` or the name of a local Git branch. `pypi` means that BigchainDB will be installed from the latest `bigchaindb` package in the [Python Package Index (PyPI)](https://pypi.python.org/pypi). That is, on each node, BigchainDB will be installed using `pip install bigchaindb`. If you don't include the second argument, then the default is `pypi`.
+
+The third argument is also optional (but if you want to include it, you must also include the second argument). It must be either `servers` or `clients`, depending on what you want to deploy. If you don't include the third argument, then the default is `servers`.
+
+If you're curious what the `awsdeploy.sh` script does, the source code has lots of explanatory comments, so it's quite easy to read. Here's a link to the latest version on GitHub: [`awsdeploy.sh`](https://github.com/bigchaindb/bigchaindb/blob/master/deploy-cluster-aws/awsdeploy.sh)
 
 It should take a few minutes for the deployment to finish. If you run into problems, see the section on Known Deployment Issues below.
 

--- a/docs/source/deploy-on-aws.md
+++ b/docs/source/deploy-on-aws.md
@@ -103,22 +103,22 @@ You can look inside those files if you're curious. In step 2, they'll be modifie
 
 Step 2 is to launch the nodes ("instances") on AWS, to install all the necessary software on them, configure the software, run the software, and more.
 
-Here's an example of how one could launch a BigchainDB cluster of three (3) nodes tagged `wrigley` on AWS:
+Here's an example of how one could launch a BigchainDB cluster of three (3) nodes on AWS:
 ```text
 # in a Python 2.5-2.7 virtual environment where fabric, boto3, etc. are installed
 cd bigchaindb
 cd deploy-cluster-aws
-./awsdeploy_servers.sh wrigley 3 pypi
+./awsdeploy_servers.sh 3 pypi
 ```
 
 The `pypi` on the end means that it will install the latest (stable) `bigchaindb` package from the [Python Package Index (PyPI)](https://pypi.python.org/pypi). That is, on each node, BigchainDB is installed using `pip install bigchaindb`. 
 
 `awsdeploy_servers.sh` is a Bash script which calls some Python and Fabric scripts. The usage is:
 ```text
-./awsdeploy_servers.sh <tag> <number_of_nodes_in_cluster> <pypi_or_branch>
+./awsdeploy_servers.sh <number_of_nodes_in_cluster> <pypi_or_branch>
 ```
 
-The first two arguments are self-explanatory. The third argument can be `pypi` or the name of a local Git branch (e.g. `master` or `feat/3752/quote-asimov-on-tuesdays`). If you don't include a third argument, then `pypi` will be assumed by default.
+The first argument is the number of nodes to deploy. The second argument can be `pypi` or the name of a local Git branch (e.g. `master` or `feat/3752/quote-asimov-on-tuesdays`). If you don't include a second argument, then `pypi` will be assumed by default.
 
 If you're curious what the `awsdeploy_servers.sh` script does, the source code has lots of explanatory comments, so it's quite easy to read. Here's a link to the latest version on GitHub: [`awsdeploy_servers.sh`](https://github.com/bigchaindb/bigchaindb/blob/master/deploy-cluster-aws/awsdeploy_servers.sh)
 

--- a/docs/source/deploy-on-aws.md
+++ b/docs/source/deploy-on-aws.md
@@ -108,19 +108,19 @@ Here's an example of how one could launch a BigchainDB cluster of three (3) node
 # in a Python 2.5-2.7 virtual environment where fabric, boto3, etc. are installed
 cd bigchaindb
 cd deploy-cluster-aws
-./startup.sh wrigley 3 pypi
+./awsdeploy_servers.sh wrigley 3 pypi
 ```
 
 The `pypi` on the end means that it will install the latest (stable) `bigchaindb` package from the [Python Package Index (PyPI)](https://pypi.python.org/pypi). That is, on each node, BigchainDB is installed using `pip install bigchaindb`. 
 
-`startup.sh` is a Bash script which calls some Python and Fabric scripts. The usage is:
+`awsdeploy_servers.sh` is a Bash script which calls some Python and Fabric scripts. The usage is:
 ```text
-./startup.sh <tag> <number_of_nodes_in_cluster> <pypi_or_branch>
+./awsdeploy_servers.sh <tag> <number_of_nodes_in_cluster> <pypi_or_branch>
 ```
 
 The first two arguments are self-explanatory. The third argument can be `pypi` or the name of a local Git branch (e.g. `master` or `feat/3752/quote-asimov-on-tuesdays`). If you don't include a third argument, then `pypi` will be assumed by default.
 
-If you're curious what the `startup.sh` script does, the source code has lots of explanatory comments, so it's quite easy to read. Here's a link to the latest version on GitHub: [`startup.sh`](https://github.com/bigchaindb/bigchaindb/blob/master/deploy-cluster-aws/startup.sh)
+If you're curious what the `awsdeploy_servers.sh` script does, the source code has lots of explanatory comments, so it's quite easy to read. Here's a link to the latest version on GitHub: [`awsdeploy_servers.sh`](https://github.com/bigchaindb/bigchaindb/blob/master/deploy-cluster-aws/awsdeploy_servers.sh)
 
 It should take a few minutes for the deployment to finish. If you run into problems, see the section on Known Deployment Issues below.
 

--- a/docs/source/deploy-on-aws.md
+++ b/docs/source/deploy-on-aws.md
@@ -160,13 +160,23 @@ cd deploy-cluster-aws
 ./awsdeploy.sh <number_of_nodes_in_cluster> [pypi_or_branch] [servers_or_clients]
 ```
 
-The first argument <number_of_nodes_in_cluster> is required. It's how many nodes you want to deploy.
+**<number_of_nodes_in_cluster>** (Required)
 
-The second argument is optional. It can be the word `pypi` or the name of a local Git branch. `pypi` means that BigchainDB will be installed from the latest `bigchaindb` package in the [Python Package Index (PyPI)](https://pypi.python.org/pypi). That is, on each node, BigchainDB will be installed using `pip install bigchaindb`. If you don't include the second argument, then the default is `pypi`.
+The number of nodes you want to deploy. Example value: 5
 
-The third argument is also optional (but if you want to include it, you must also include the second argument). It must be either `servers` or `clients`, depending on what you want to deploy. If you don't include the third argument, then the default is `servers`.
+**[pypi_or_branch]** (Optional)
 
-If you're curious what the `awsdeploy.sh` script does, the source code has lots of explanatory comments, so it's quite easy to read. Here's a link to the latest version on GitHub: [`awsdeploy.sh`](https://github.com/bigchaindb/bigchaindb/blob/master/deploy-cluster-aws/awsdeploy.sh)
+Where the nodes should get their BigchainDB source code. If it's `pypi`, then BigchainDB will be installed from the latest `bigchaindb` package in the [Python Package Index (PyPI)](https://pypi.python.org/pypi). That is, on each node, BigchainDB will be installed using `pip install bigchaindb`. You can also put the name of a local Git branch; it will be compressed and sent out to all the nodes for installation. If you don't include the second argument, then the default is `pypi`.
+
+**[servers_or_clients]** (Optional)
+
+If you want to deploy BigchainDB servers, then the third argument should be `servers`.
+If you want to deploy BigchainDB clients, then the third argument should be `clients`.
+The third argument is optional, but if you want to include it, you must also include the second argument. If you don't include the third argument, then the default is `servers`.
+
+---
+
+If you're curious what the `awsdeploy.sh` script does, [the source code](https://github.com/bigchaindb/bigchaindb/blob/master/deploy-cluster-aws/awsdeploy.sh) has lots of explanatory comments, so it's quite easy to read.
 
 It should take a few minutes for the deployment to finish. If you run into problems, see the section on Known Deployment Issues below.
 


### PR DESCRIPTION
* Renamed `startup.sh` to `awsdeploy.sh`
* Modified that script and the fabfile to enable deployment of servers _or_ clients
* The "tag" is now auto-generated, rather than being something that's specified on the command line
* Updated the docs to explain how to use `awsdeploy.sh`

This is part of Project Minky: PR #246 