### PR TITLE
AWS deployment script doesn't auto-start servers anymore

### DIFF
--- a/deploy-cluster-aws/awsdeploy.sh
+++ b/deploy-cluster-aws/awsdeploy.sh
@@ -131,9 +131,6 @@ if [ "$WHAT_TO_DEPLOY" == "servers" ]; then
     # this will only be sent to one of the nodes, see the
     # definition of init_bigchaindb() in fabfile.py to see why.
     fab init_bigchaindb
-
-    # Start BigchainDB on all the nodes using "screen"
-    fab start_bigchaindb
 else
     # Deploying clients
     # The only thing to configure on clients is the api_endpoint

--- a/docs/source/deploy-on-aws.md
+++ b/docs/source/deploy-on-aws.md
@@ -153,6 +153,7 @@ Here's an example of how one could launch a BigchainDB cluster of three (3) node
 cd bigchaindb
 cd deploy-cluster-aws
 ./awsdeploy.sh 3
+fab start_bigchaindb
 ```
 
 `awsdeploy.sh` is a Bash script which calls some Python and Fabric scripts. The usage is:


### PR DESCRIPTION
Changed how the `awsdeploy.sh` Bash script works: it no longer automatically starts BigchainDB on all BigchainDB servers once they are deployed. You must manually start them using `fab start_bigchaindb`. I updated the docs accordingly.