### PR TITLE
rename verify_signature to validate_fulfillments

### DIFF
--- a/bigchaindb/consensus.py
+++ b/bigchaindb/consensus.py
@@ -15,6 +15,7 @@ class AbstractConsensusRules(metaclass=ABCMeta):
     All methods listed below must be implemented.
     """
 
+    @staticmethod
     @abstractmethod
     def validate_transaction(bigchain, transaction):
         """Validate a transaction.
@@ -31,8 +32,8 @@ class AbstractConsensusRules(metaclass=ABCMeta):
             Descriptive exceptions indicating the reason the transaction failed.
             See the `exceptions` module for bigchain-native error classes.
         """
-        raise NotImplementedError
 
+    @staticmethod
     @abstractmethod
     def validate_block(bigchain, block):
         """Validate a block.
@@ -49,8 +50,8 @@ class AbstractConsensusRules(metaclass=ABCMeta):
             Descriptive exceptions indicating the reason the block failed.
             See the `exceptions` module for bigchain-native error classes.
         """
-        raise NotImplementedError
 
+    @staticmethod
     @abstractmethod
     def create_transaction(*args, **kwargs):
         """Create a new transaction.
@@ -61,8 +62,8 @@ class AbstractConsensusRules(metaclass=ABCMeta):
         Returns:
             dict: newly constructed transaction.
         """
-        raise NotImplementedError
 
+    @staticmethod
     @abstractmethod
     def sign_transaction(transaction, *args, **kwargs):
         """Sign a transaction.
@@ -74,20 +75,19 @@ class AbstractConsensusRules(metaclass=ABCMeta):
         Returns:
             dict: transaction with any signatures applied.
         """
-        raise NotImplementedError
 
+    @staticmethod
     @abstractmethod
     def validate_fulfillments(signed_transaction):
-        """Verify the signature of a transaction.
+        """Validate the fulfillments of a transaction.
 
         Args:
             signed_transaction (dict): signed transaction to verify
 
         Returns:
-            bool: True if the transaction's required signature data is present
+            bool: True if the transaction's required fulfillments are present
                 and correct, False otherwise.
         """
-        raise NotImplementedError
 
 
 class BaseConsensusRules(AbstractConsensusRules):
@@ -217,7 +217,7 @@ class BaseConsensusRules(AbstractConsensusRules):
 
     @staticmethod
     def validate_fulfillments(signed_transaction):
-        """Verify the signature of a transaction.
+        """Validate the fulfillments of a transaction.
 
         Refer to the documentation of ``bigchaindb.util.validate_fulfillments``
         """

--- a/bigchaindb/consensus.py
+++ b/bigchaindb/consensus.py
@@ -157,7 +157,7 @@ class BaseConsensusRules(AbstractConsensusRules):
         if calculated_hash != transaction['id']:
             raise exceptions.InvalidHash()
 
-        # Check signature
+        # Check fulfillments
         if not util.validate_fulfillments(transaction):
             raise exceptions.InvalidSignature()
 

--- a/bigchaindb/consensus.py
+++ b/bigchaindb/consensus.py
@@ -77,7 +77,7 @@ class AbstractConsensusRules(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def verify_signature(signed_transaction):
+    def validate_fulfillments(signed_transaction):
         """Verify the signature of a transaction.
 
         Args:
@@ -158,7 +158,7 @@ class BaseConsensusRules(AbstractConsensusRules):
             raise exceptions.InvalidHash()
 
         # Check signature
-        if not util.verify_signature(transaction):
+        if not util.validate_fulfillments(transaction):
             raise exceptions.InvalidSignature()
 
         return transaction
@@ -216,10 +216,10 @@ class BaseConsensusRules(AbstractConsensusRules):
         return util.sign_tx(transaction, private_key)
 
     @staticmethod
-    def verify_signature(signed_transaction):
+    def validate_fulfillments(signed_transaction):
         """Verify the signature of a transaction.
 
-        Refer to the documentation of ``bigchaindb.util.verify_signature``
+        Refer to the documentation of ``bigchaindb.util.validate_fulfillments``
         """
 
-        return util.verify_signature(signed_transaction)
+        return util.validate_fulfillments(signed_transaction)

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -87,12 +87,12 @@ class Bigchain(object):
         return self.consensus.sign_transaction(transaction, *args, **kwargs)
 
     def validate_fulfillments(self, signed_transaction, *args, **kwargs):
-        """Verify the fulfillment(s) of a transaction.
+        """Validate the fulfillment(s) of a transaction.
 
         Refer to the documentation of your consensus plugin.
 
         Returns:
-            bool: True if the transaction's required fulfillments is present
+            bool: True if the transaction's required fulfillments are present
                 and correct, False otherwise.
         """
 

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -86,17 +86,17 @@ class Bigchain(object):
 
         return self.consensus.sign_transaction(transaction, *args, **kwargs)
 
-    def verify_signature(self, signed_transaction, *args, **kwargs):
-        """Verify the signature(s) of a transaction.
+    def validate_fulfillments(self, signed_transaction, *args, **kwargs):
+        """Verify the fulfillment(s) of a transaction.
 
         Refer to the documentation of your consensus plugin.
 
         Returns:
-            bool: True if the transaction's required signature data is present
+            bool: True if the transaction's required fulfillments is present
                 and correct, False otherwise.
         """
 
-        return self.consensus.verify_signature(
+        return self.consensus.validate_fulfillments(
             signed_transaction, *args, **kwargs)
 
     def write_transaction(self, signed_transaction, durability='soft'):

--- a/bigchaindb/util.py
+++ b/bigchaindb/util.py
@@ -358,7 +358,7 @@ def fulfill_simple_signature_fulfillment(fulfillment, parsed_fulfillment, fulfil
 
         Args:
             fulfillment (dict): BigchainDB fulfillment to fulfill.
-            parsed_fulfillment (object): cryptoconditions.Ed25519Fulfillment instance.
+            parsed_fulfillment (cryptoconditions.Ed25519Fulfillment): cryptoconditions.Ed25519Fulfillment instance.
             fulfillment_message (dict): message to sign.
             key_pairs (dict): dictionary of (public_key, private_key) pairs.
 
@@ -380,16 +380,16 @@ def fulfill_simple_signature_fulfillment(fulfillment, parsed_fulfillment, fulfil
 def fulfill_threshold_signature_fulfillment(fulfillment, parsed_fulfillment, fulfillment_message, key_pairs):
     """Fulfill a cryptoconditions.ThresholdSha256Fulfillment
 
-            Args:
-                fulfillment (dict): BigchainDB fulfillment to fulfill.
-                parsed_fulfillment (object): cryptoconditions.ThresholdSha256Fulfillment instance.
-                fulfillment_message (dict): message to sign.
-                key_pairs (dict): dictionary of (public_key, private_key) pairs.
+        Args:
+            fulfillment (dict): BigchainDB fulfillment to fulfill.
+            parsed_fulfillment (cryptoconditions.ThresholdSha256Fulfillment): cryptoconditions.ThresholdSha256Fulfillment instance.
+            fulfillment_message (dict): message to sign.
+            key_pairs (dict): dictionary of (public_key, private_key) pairs.
 
-            Returns:
-                object: fulfilled cryptoconditions.ThresholdSha256Fulfillment
+        Returns:
+            object: fulfilled cryptoconditions.ThresholdSha256Fulfillment
 
-            """
+        """
     parsed_fulfillment_copy = copy.deepcopy(parsed_fulfillment)
     parsed_fulfillment.subconditions = []
 
@@ -421,11 +421,11 @@ def check_hash_and_signature(transaction):
         raise exceptions.InvalidHash()
 
     # Check signature
-    if not verify_signature(transaction):
+    if not validate_fulfillments(transaction):
         raise exceptions.InvalidSignature()
 
 
-def verify_signature(signed_transaction):
+def validate_fulfillments(signed_transaction):
     """Verify the signature of a transaction
 
     A valid transaction should have been signed `current_owner` corresponding private key.

--- a/bigchaindb/web/views.py
+++ b/bigchaindb/web/views.py
@@ -75,8 +75,8 @@ def create_transaction():
             tx = util.transform_create(tx)
             tx = bigchain.consensus.sign_transaction(tx, private_key=bigchain.me_private)
 
-        if not bigchain.consensus.verify_signature(tx):
-            val['error'] = 'Invalid transaction signature'
+        if not bigchain.consensus.validate_fulfillments(tx):
+            val['error'] = 'Invalid transaction fulfillments'
 
         with monitor.timer('write_transaction', rate=bigchaindb.config['statsd']['rate']):
             val = bigchain.write_transaction(tx)

--- a/docs/source/consensus.md
+++ b/docs/source/consensus.md
@@ -30,7 +30,7 @@ validate_transaction(bigchain, transaction)
 validate_block(bigchain, block)
 create_transaction(*args, **kwargs)
 sign_transaction(transaction, *args, **kwargs)
-verify_signature(transaction)
+validate_fulfillments(transaction)
 ```
 
 Together, these functions are sufficient for most customizations. For example:

--- a/docs/source/python-server-api-examples.md
+++ b/docs/source/python-server-api-examples.md
@@ -694,7 +694,7 @@ threshold_tx_transfer['transaction']['fulfillments'][0]['fulfillment'] = thresho
 
 # Optional validation checks
 assert threshold_fulfillment.validate(threshold_tx_fulfillment_message) == True
-assert b.verify_signature(threshold_tx_transfer) == True
+assert b.validate_fulfillments(threshold_tx_transfer) == True
 assert b.validate_transaction(threshold_tx_transfer)
 
 b.write_transaction(threshold_tx_transfer)

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -37,7 +37,7 @@ class TestBigchainApi(object):
     @pytest.mark.usefixtures('inputs')
     def test_create_transaction_transfer(self, b, user_vk, user_sk):
         input_tx = b.get_owned_ids(user_vk).pop()
-        assert b.verify_signature(b.get_transaction(input_tx['txid'])) == True
+        assert b.validate_fulfillments(b.get_transaction(input_tx['txid'])) == True
 
         tx = b.create_transaction(user_vk, b.me, input_tx, 'TRANSFER')
 
@@ -46,8 +46,8 @@ class TestBigchainApi(object):
 
         tx_signed = b.sign_transaction(tx, user_sk)
 
-        assert b.verify_signature(tx) == False
-        assert b.verify_signature(tx_signed) == True
+        assert b.validate_fulfillments(tx) == False
+        assert b.validate_fulfillments(tx_signed) == True
 
     def test_transaction_hash(self, b, user_vk):
         payload = {'cats': 'are awesome'}
@@ -73,7 +73,7 @@ class TestBigchainApi(object):
         tx_signed = b.sign_transaction(tx, user_sk)
 
         assert tx_signed['transaction']['fulfillments'][0]['fulfillment'] is not None
-        assert b.verify_signature(tx_signed)
+        assert b.validate_fulfillments(tx_signed)
 
     def test_serializer(self, b, user_vk):
         tx = b.create_transaction(user_vk, user_vk, None, 'CREATE')
@@ -1218,7 +1218,7 @@ class TestCryptoconditions(object):
 
         assert fulfillment['current_owners'][0] == b.me
         assert fulfillment_from_uri.public_key.to_ascii().decode() == b.me
-        assert b.verify_signature(tx_signed) == True
+        assert b.validate_fulfillments(tx_signed) == True
         assert b.is_valid_transaction(tx_signed) == tx_signed
 
     @pytest.mark.usefixtures('inputs')
@@ -1250,7 +1250,7 @@ class TestCryptoconditions(object):
         assert fulfillment['current_owners'][0] == user_vk
         assert fulfillment_from_uri.public_key.to_ascii().decode() == user_vk
         assert fulfillment_from_uri.condition.serialize_uri() == prev_condition['uri']
-        assert b.verify_signature(tx_signed) == True
+        assert b.validate_fulfillments(tx_signed) == True
         assert b.is_valid_transaction(tx_signed) == tx_signed
 
     def test_override_condition_create(self, b, user_vk):
@@ -1268,7 +1268,7 @@ class TestCryptoconditions(object):
 
         assert fulfillment['current_owners'][0] == b.me
         assert fulfillment_from_uri.public_key.to_ascii().decode() == b.me
-        assert b.verify_signature(tx_signed) == True
+        assert b.validate_fulfillments(tx_signed) == True
         assert b.is_valid_transaction(tx_signed) == tx_signed
 
     @pytest.mark.usefixtures('inputs')
@@ -1290,7 +1290,7 @@ class TestCryptoconditions(object):
 
         assert fulfillment['current_owners'][0] == user_vk
         assert fulfillment_from_uri.public_key.to_ascii().decode() == user_vk
-        assert b.verify_signature(tx_signed) == True
+        assert b.validate_fulfillments(tx_signed) == True
         assert b.is_valid_transaction(tx_signed) == tx_signed
 
     def test_override_fulfillment_create(self, b, user_vk):
@@ -1302,7 +1302,7 @@ class TestCryptoconditions(object):
 
         tx['transaction']['fulfillments'][0]['fulfillment'] = fulfillment.serialize_uri()
 
-        assert b.verify_signature(tx) == True
+        assert b.validate_fulfillments(tx) == True
         assert b.is_valid_transaction(tx) == tx
 
     @pytest.mark.usefixtures('inputs')
@@ -1319,7 +1319,7 @@ class TestCryptoconditions(object):
 
         tx['transaction']['fulfillments'][0]['fulfillment'] = fulfillment.serialize_uri()
 
-        assert b.verify_signature(tx) == True
+        assert b.validate_fulfillments(tx) == True
         assert b.is_valid_transaction(tx) == tx
 
     @pytest.mark.usefixtures('inputs')
@@ -1573,7 +1573,7 @@ class TestCryptoconditions(object):
         assert tx_transfer_signed['transaction']['fulfillments'][0]['fulfillment'] \
             == expected_fulfillment.serialize_uri()
 
-        assert b.verify_signature(tx_transfer_signed) is True
+        assert b.validate_fulfillments(tx_transfer_signed) is True
 
     def test_create_asset_with_hashlock_condition(self, b):
         hashlock_tx = b.create_transaction(b.me, None, None, 'CREATE')

--- a/tests/doc/run_doc_python_server_api_examples.py
+++ b/tests/doc/run_doc_python_server_api_examples.py
@@ -233,7 +233,7 @@ assert threshold_fulfillment.validate(threshold_tx_fulfillment_message) == True
 
 threshold_tx_transfer['transaction']['fulfillments'][0]['fulfillment'] = threshold_fulfillment.serialize_uri()
 
-assert b.verify_signature(threshold_tx_transfer) == True
+assert b.validate_fulfillments(threshold_tx_transfer) == True
 
 assert b.validate_transaction(threshold_tx_transfer) == threshold_tx_transfer
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -51,7 +51,7 @@ def test_client_can_create_assets(mock_requests_post, client):
     assert tx['transaction']['conditions'][0]['new_owners'][0] == client.public_key
     assert tx['transaction']['fulfillments'][0]['input'] is None
 
-    assert util.verify_signature(tx)
+    assert util.validate_fulfillments(tx)
 
 
 def test_client_can_transfer_assets(mock_requests_post, mock_bigchaindb_sign, client):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -34,7 +34,7 @@ def test_transform_create(b, user_sk, user_vk):
 
     assert tx['transaction']['fulfillments'][0]['current_owners'][0] == b.me
     assert tx['transaction']['conditions'][0]['new_owners'][0] == user_vk
-    assert util.verify_signature(tx)
+    assert util.validate_fulfillments(tx)
 
 
 def test_empty_pool_is_populated_with_instances(mock_queue):


### PR DESCRIPTION
title says it all

reasoning:
- `verify_signature` was limited to signature conditions
- `cryptoconditions.Fulfillment` has a method `validate()`
- bigchain has a method `validate_transaction` which does additional checks

Also

- cleaned up abstract class of consensus
- updated some docstring types