### PR TITLE
Install docs: Suggest upgrading pip wheel & setuptools

### DIFF
--- a/deploy-cluster-aws/fabfile.py
+++ b/deploy-cluster-aws/fabfile.py
@@ -64,7 +64,7 @@ def install_base_software():
                      software-properties-common python-software-properties \
                      python3-setuptools ipython3 sysstat s3cmd')
     sudo('easy_install3 pip')
-    sudo('pip install -U pip wheel setuptools')
+    sudo('pip install --upgrade pip wheel setuptools')
 
 
 # Install RethinkDB

--- a/docs/source/installing-server.md
+++ b/docs/source/installing-server.md
@@ -55,7 +55,9 @@ If it says that `pip` isn't installed, or it says `pip` is associated with a Pyt
 ```text
 $ sudo apt-get install python3-setuptools
 $ sudo easy_install3 pip
+$ pip install --upgrade pip wheel setuptools
 ```
+
 (Note: Using `sudo apt-get python3-pip` also installs a Python 3 version of `pip` (named `pip3`) but we found it installed a very old version and there were issues with updating it.)
 
 Once you have a version of `pip` associated with Python 3.4+, then you can install BigchainDB Server (and officially-supported BigchainDB drivers) using:


### PR DESCRIPTION
The AWS deployment fabfile was already upgrading pip, wheel, and setuptools to their latest versions. I added a line to do the same in the BigchainDB Installation documentation.

I also edited the AWS deployment fabfile, changing `-U` to `--upgrade`; it [means the same thing](https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-U) but it's easier to guess what it's doing if you're new to pip.