### PR TITLE
Display useful message when setuptools is outdated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,27 @@ For full docs visit https://bigchaindb.readthedocs.org
 """
 from setuptools import setup, find_packages
 
+
 # get the version
 version = {}
 with open('bigchaindb/version.py') as fp:
     exec(fp.read(), version)
+
+
+# check if setuptools is up to date
+def check_setuptools_features():
+    import pkg_resources
+    try:
+        list(pkg_resources.parse_requirements('foo~=1.0'))
+    except pkg_resources.RequirementParseError:
+        exit('Your Python distribution comes with an incompatible version '
+             'of `setuptools`. Please run:\n'
+             ' $ pip install --update setuptools\n'
+             'and then run this command again')
+
+
+check_setuptools_features()
+
 
 tests_require = [
     'pytest',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def check_setuptools_features():
     import pkg_resources
     try:
         list(pkg_resources.parse_requirements('foo~=1.0'))
-    except pkg_resources.RequirementParseError:
+    except ValueError:
         exit('Your Python distribution comes with an incompatible version '
              'of `setuptools`. Please run:\n'
              ' $ pip install --update setuptools\n'

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def check_setuptools_features():
     except ValueError:
         exit('Your Python distribution comes with an incompatible version '
              'of `setuptools`. Please run:\n'
-             ' $ pip install --update setuptools\n'
+             ' $ pip3 install --upgrade setuptools\n'
              'and then run this command again')
 
 


### PR DESCRIPTION
This should help users trying to install BigchainDB using Pip and an old version of `setuptools`.

Related: #236 #274

On Ubuntu 14:04, the old error was:
```
root@139a61af2e8d:/bigchaindb# python3 setup.py install

Installed /tmp/easy_install-_nf2audp/pytest-runner-2.7.1/setuptools_scm-1.11.0-py3.4.egg
your setuptools is too old (<12)
setuptools_scm functionality is degraded
zip_safe flag not set; analyzing archive contents...

Installed /bigchaindb/pytest_runner-2.7.1-py3.4.egg
error in BigchainDB setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers
```

while the new error is:
```
root@139a61af2e8d:/bigchaindb# python3 setup.py install
Your Python distribution comes with an incompatible version of `setuptools`. Please run:
 $ pip3 install --upgrade setuptools
and then run this command again
```