### PR TITLE
Use secondary index on get_transaction

### DIFF
--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -145,8 +145,11 @@ class Bigchain(object):
             If no transaction with that `txid` was found it returns `None`
         """
 
-        response = r.table('bigchain').concat_map(lambda doc: doc['block']['transactions'])\
-            .filter(lambda transaction: transaction['id'] == txid).run(self.conn)
+        response = r.table('bigchain')\
+                    .get_all(txid, index='transaction_id')\
+                    .concat_map(r.row['block']['transactions'])\
+                    .filter(r.row['id'].eq(txid))\
+                    .run(self.conn)
 
         # transaction ids should be unique
         transactions = list(response)

--- a/bigchaindb/db/utils.py
+++ b/bigchaindb/db/utils.py
@@ -47,7 +47,8 @@ def init():
     r.db(dbname).table('backlog').index_create('transaction_timestamp', r.row['transaction']['timestamp']).run(conn)
     # to query the bigchain for a transaction id
     r.db(dbname).table('bigchain').index_create('transaction_id',
-                                                r.row['block']['transactions']['id'], multi=True).run(conn)
+                                                r.row['block']['transactions']['id'],
+                                                multi=True).run(conn)
     # compound index to read transactions from the backlog per assignee
     r.db(dbname).table('backlog')\
         .index_create('assignee__transaction_timestamp', [r.row['assignee'], r.row['transaction']['timestamp']])\

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -47,9 +47,15 @@ def setup_database(request, node_config):
     # to order transactions by timestamp
     r.db(db_name).table('backlog').index_create('transaction_timestamp', r.row['transaction']['timestamp']).run()
     # compound index to read transactions from the backlog per assignee
+    r.db(db_name).table('bigchain').index_create('transaction_id',
+                                                 r.row['block']['transactions']['id'],
+                                                 multi=True).run()
     r.db(db_name).table('backlog')\
         .index_create('assignee__transaction_timestamp', [r.row['assignee'], r.row['transaction']['timestamp']])\
         .run()
+
+    r.db(db_name).table('backlog').index_wait().run()
+    r.db(db_name).table('bigchain').index_wait().run()
 
     def fin():
         print('Deleting `{}` database'.format(db_name))


### PR DESCRIPTION
This PR partially solve #105.

The new query makes use of the secondary index `transaction_id`, and should make the look up from `O(n)` to `O(1)`.