### PR TITLE
Use pip3 instead of pip to upgrade pip, wheel & setuptools

### DIFF
--- a/deploy-cluster-aws/fabfile.py
+++ b/deploy-cluster-aws/fabfile.py
@@ -64,7 +64,7 @@ def install_base_software():
                      software-properties-common python-software-properties \
                      python3-setuptools ipython3 sysstat s3cmd')
     sudo('easy_install3 pip')
-    sudo('pip install --upgrade pip wheel setuptools')
+    sudo('pip3 install --upgrade pip wheel setuptools')
 
 
 # Install RethinkDB

--- a/docs/source/installing-server.md
+++ b/docs/source/installing-server.md
@@ -55,7 +55,7 @@ If it says that `pip` isn't installed, or it says `pip` is associated with a Pyt
 ```text
 $ sudo apt-get install python3-setuptools
 $ sudo easy_install3 pip
-$ pip install --upgrade pip wheel setuptools
+$ pip3 install --upgrade pip wheel setuptools
 ```
 
 (Note: Using `sudo apt-get python3-pip` also installs a Python 3 version of `pip` (named `pip3`) but we found it installed a very old version and there were issues with updating it.)


### PR DESCRIPTION
I tested this by deploying a 3-node cluster on AWS and it worked fine.
