### PR TITLE
In the docs, clarify that BigchainDB isn't production-ready yet

### DIFF
--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -1,10 +1,27 @@
 # Introduction
 
-BigchainDB is a scalable blockchain database. You can read about its motivations, goals and high-level architecture in the [BigchainDB whitepaper](https://www.bigchaindb.com/whitepaper/). This document, the _BigchainDB Documentation_, is intended primarily for:
+BigchainDB is a scalable blockchain database. You can read about its motivations, goals and high-level architecture in the [BigchainDB whitepaper](https://www.bigchaindb.com/whitepaper/).
+
+
+## Who this Documentation for?
+
+The BigchainDB Documentation is intended primarily for:
 
 1. Developers of BigchainDB server software.
 2. People deploying and managing BigchainDB clusters.
 3. Developers of BigchainDB driver software (SDKs used to develop client software).
 4. App developers who are developing client apps to talk to one or more live, operational BigchainDB clusters. They would use one of the BigchainDB drivers.
 
-If you're curious about what's in our roadmap, see [the ROADMAP.md file](https://github.com/bigchaindb/org/blob/master/ROADMAP.md) and [the list of open issues](https://github.com/bigchaindb/bigchaindb/issues). If you want to request a feature, file a bug report, or make a pull request, see [the CONTRIBUTING.md file](https://github.com/bigchaindb/bigchaindb/blob/master/CONTRIBUTING.md).
+
+## Is BigchainDB Production-Ready?
+
+No, BigchainDB is not production-ready. You can use it to build a prototype or proof-of-concept (POC); many people are already doing that. Please don't use it for something mission-critical.
+
+BigchainDB is currently in version 0.X. ([The Releases page on GitHub](https://github.com/bigchaindb/bigchaindb/releases) has the exact version number.) Once we believe that BigchainDB is production-ready, we'll release version 1.0.
+
+[The BigchainDB Roadmap](https://github.com/bigchaindb/org/blob/master/ROADMAP.md) will give you a sense of the things we intend to do with BigchainDB in the near term and the long term.
+
+
+## Can I Help?
+
+Yes! BigchainDB is an open-source project; we welcome contributions of all kinds. If you want to request a feature, file a bug report, make a pull request, or help in some other way, please see [the CONTRIBUTING.md file](https://github.com/bigchaindb/bigchaindb/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
We've been adding more clarity about BigchainDB not being production-ready across our various materials and communications channels; this PR just adds a note about that in the _Introduction_ section of the BigchainDB documentation.