### PR TITLE
Add informative JSON message to the API root

### DIFF
--- a/bigchaindb/web/server.py
+++ b/bigchaindb/web/server.py
@@ -62,6 +62,7 @@ def create_app(settings):
     app.config['bigchain_pool'] = util.pool(Bigchain, size=settings.get('threads', 4))
     app.config['monitor'] = Monitor()
 
+    app.register_blueprint(views.info_views, url_prefix='/')
     app.register_blueprint(views.basic_views, url_prefix='/api/v1')
     return app
 

--- a/bigchaindb/web/views.py
+++ b/bigchaindb/web/views.py
@@ -8,9 +8,10 @@ import flask
 from flask import current_app, request, Blueprint
 
 import bigchaindb
-from bigchaindb import util
+from bigchaindb import util, version
 
 
+info_views = Blueprint('info_views', __name__)
 basic_views = Blueprint('basic_views', __name__)
 
 
@@ -33,6 +34,16 @@ def record(state):
         raise ValueError('This blueprint expects you to provide '
                          'a monitor instance to record system '
                          'performance.')
+
+@info_views.route('/')
+def home():
+    return flask.jsonify({
+        'software': 'BigchainDB',
+        'version': version.__version__,
+        'public_key': bigchaindb.config['keypair']['public'],
+        'keyring': bigchaindb.config['keyring'],
+        'api_endpoint': bigchaindb.config['api_endpoint']
+    })
 
 
 @basic_views.route('/transactions/<tx_id>')

--- a/tests/web/test_basic_views.py
+++ b/tests/web/test_basic_views.py
@@ -16,6 +16,13 @@ def test_get_transaction_endpoint(b, client, user_vk):
     assert tx == res.json
 
 
+def test_api_endpoint_shows_basic_info(client):
+    from bigchaindb import version
+    res = client.get('/')
+    assert res.json['software'] == 'BigchainDB'
+    assert res.json['version'] == version.__version__
+
+
 def test_post_create_transaction_endpoint(b, client):
     keypair = crypto.generate_key_pair()
 


### PR DESCRIPTION
Expose some basic data about the node when visiting the API root.

Example:

```
{
  "api_endpoint": "http://localhost:9984/api/v1",
  "keyring": [],
  "public_key": "9kqcpibHQza5RxMsvpPpviB2B1gaohn44oPa48UND1zE",
  "software": "BigchainDB",
  "version": "0.4.0"
}
```
