### PR TITLE
Return 404 when transaction not found

### DIFF
--- a/bigchaindb/web/views.py
+++ b/bigchaindb/web/views.py
@@ -5,7 +5,7 @@ For more information please refer to the documentation in Apiary:
 """
 
 import flask
-from flask import current_app, request, Blueprint
+from flask import abort, current_app, request, Blueprint
 
 import bigchaindb
 from bigchaindb import util
@@ -50,6 +50,9 @@ def get_transaction(tx_id):
 
     with pool() as bigchain:
         tx = bigchain.get_transaction(tx_id)
+
+    if not tx:
+        abort(404)
 
     return flask.jsonify(**tx)
 

--- a/tests/web/test_basic_views.py
+++ b/tests/web/test_basic_views.py
@@ -16,6 +16,12 @@ def test_get_transaction_endpoint(b, client, user_vk):
     assert tx == res.json
 
 
+@pytest.mark.usefixtures('inputs')
+def test_get_transaction_returns_404_if_not_found(client):
+    res = client.get(TX_ENDPOINT + '123')
+    assert res.status_code == 404
+
+
 def test_post_create_transaction_endpoint(b, client):
     keypair = crypto.generate_key_pair()
 


### PR DESCRIPTION
The Web API now returns `404` instead of a `500` when a transaction is not found.