### PR TITLE
Feat/380/round timestamp add uuid

### DIFF
--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -386,6 +386,10 @@ class Bigchain(object):
             dict: created block.
         """
 
+        # Prevent the creation of empty blocks
+        if len(validated_transactions) == 0:
+            raise exceptions.OperationError('Empty block creation is not allowed')
+
         # Create the new block
         block = {
             'timestamp': util.timestamp(),

--- a/bigchaindb/db/utils.py
+++ b/bigchaindb/db/utils.py
@@ -54,7 +54,7 @@ def init():
         .run(conn)
     # secondary index for payload hash
     r.db(dbname).table('bigchain')\
-        .index_create('payload_hash', r.row['block']['transactions']['transaction']['data']['hash'], multi=True)\
+        .index_create('payload_uuid', r.row['block']['transactions']['transaction']['data']['uuid'], multi=True)\
         .run(conn)
 
     # wait for rethinkdb to finish creating secondary indexes

--- a/bigchaindb/util.py
+++ b/bigchaindb/util.py
@@ -221,14 +221,13 @@ def create_tx(current_owners, new_owners, inputs, operation, payload=None):
 
     # handle payload
     data = None
-    if payload is not None:
-        if isinstance(payload, dict):
-            data = {
-                'uuid': str(uuid.uuid4()),
-                'payload': payload
-            }
-        else:
-            raise TypeError('`payload` must be an dict instance')
+    if isinstance(payload, (dict, type(None))):
+        data = {
+            'uuid': str(uuid.uuid4()),
+            'payload': payload
+        }
+    else:
+        raise TypeError('`payload` must be an dict instance or None')
 
     # handle inputs
     fulfillments = []

--- a/bigchaindb/util.py
+++ b/bigchaindb/util.py
@@ -4,7 +4,7 @@ import contextlib
 import threading
 import queue
 import multiprocessing as mp
-from datetime import datetime
+import uuid
 
 import rapidjson
 
@@ -127,14 +127,13 @@ def deserialize(data):
 
 
 def timestamp():
-    """Calculate a UTC timestamp with microsecond precision.
+    """Calculate a UTC timestamp with second precision.
 
     Returns:
         str: UTC timestamp.
 
     """
-    dt = datetime.utcnow()
-    return "{0:.6f}".format(time.mktime(dt.timetuple()) + dt.microsecond / 1e6)
+    return str(round(time.time()))
 
 
 # TODO: Consider remove the operation (if there are no inputs CREATE else TRANSFER)
@@ -224,9 +223,8 @@ def create_tx(current_owners, new_owners, inputs, operation, payload=None):
     data = None
     if payload is not None:
         if isinstance(payload, dict):
-            hash_payload = crypto.hash_data(serialize(payload))
             data = {
-                'hash': hash_payload,
+                'uuid': str(uuid.uuid4()),
                 'payload': payload
             }
         else:

--- a/docs/source/topic-guides/models.md
+++ b/docs/source/topic-guides/models.md
@@ -57,7 +57,7 @@ Also, note that timestamps come from clients and nodes. Unless you have some rea
         "operation": "<string>",
         "timestamp": "<timestamp from client>",
         "data": {
-            "hash": "<hash of payload>",
+            "uuid": "<uuid4>",
             "payload": "<any JSON document>"
         }
     }
@@ -78,7 +78,7 @@ Here's some explanation of the contents of a transaction:
     - `operation`: String representation of the operation being performed (currently either "CREATE" or "TRANSFER"). It determines how the transaction should be validated.
     - `timestamp`: Time of creation of the transaction in UTC. It's provided by the client.
     - `data`:
-        - `hash`: The hash of the serialized `payload`.
+        - `uuid`: UUID version 4 (random) converted to a string of hex digits in standard form.
         - `payload`: Can be any JSON document. It may be empty in the case of a transfer transaction.
 
 Later, when we get to the models for the block and the vote, we'll see that both include a signature (from the node which created it). You may wonder why transactions don't have signatures... The answer is that they do! They're just hidden inside the `fulfillment` string of each fulfillment. A creation transaction is signed by the node that created it. A transfer transaction is signed by whoever currently controls or owns it.

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -48,24 +48,6 @@ class TestBigchainApi(object):
         assert b.validate_fulfillments(tx) == False
         assert b.validate_fulfillments(tx_signed) == True
 
-    def test_transaction_hash(self, b, user_vk):
-        payload = {'cats': 'are awesome'}
-        tx = b.create_transaction(user_vk, user_vk, None, 'CREATE', payload)
-        tx_calculated = {
-            'conditions': [{'cid': 0,
-                            'condition': tx['transaction']['conditions'][0]['condition'],
-                            'new_owners': [user_vk]}],
-            'data': {'hash': crypto.hash_data(util.serialize(payload)),
-                     'payload': payload},
-            'fulfillments': [{'current_owners': [user_vk],
-                              'fid': 0,
-                              'fulfillment': None,
-                              'input': None}],
-            'operation': 'CREATE',
-            'timestamp': tx['transaction']['timestamp']
-        }
-        assert tx['transaction']['data'] == tx_calculated['data']
-        # assert tx_hash == tx_calculated_hash
 
     def test_transaction_signature(self, b, user_sk, user_vk):
         tx = b.create_transaction(user_vk, user_vk, None, 'CREATE')

--- a/tests/db/test_voter.py
+++ b/tests/db/test_voter.py
@@ -526,6 +526,8 @@ class TestBlockStream(object):
     def test_if_old_blocks_get_should_return_old_block_first(self, b):
         # create two blocks
         block_1 = dummy_block()
+        # sleep so that block_2 as an higher timestamp then block_1
+        time.sleep(1)
         block_2 = dummy_block()
 
         # write the blocks

--- a/tests/db/test_voter.py
+++ b/tests/db/test_voter.py
@@ -9,6 +9,20 @@ from bigchaindb.voter import Voter, Election, BlockStream
 from bigchaindb import crypto, Bigchain
 
 
+# Some util functions
+def dummy_tx():
+    b = Bigchain()
+    tx = b.create_transaction(b.me, b.me, None, 'CREATE')
+    tx_signed = b.sign_transaction(tx, b.me_private)
+    return tx_signed
+
+
+def dummy_block():
+    b = Bigchain()
+    block = b.create_block([dummy_tx()])
+    return block
+
+
 class TestBigchainVoter(object):
 
     def test_valid_block_voting(self, b):
@@ -17,7 +31,9 @@ class TestBigchainVoter(object):
         genesis = b.create_genesis_block()
 
         # create valid block
-        block = b.create_block([])
+        # sleep so that `block` as a higher timestamp then genesis
+        time.sleep(1)
+        block = dummy_block()
         # assert block is valid
         assert b.is_valid_block(block)
         b.write_block(block, durability='hard')
@@ -59,6 +75,8 @@ class TestBigchainVoter(object):
         assert b.is_valid_transaction(tx_signed)
 
         # create valid block
+        # sleep so that block as a higher timestamp then genesis
+        time.sleep(1)
         block = b.create_block([tx_signed])
         # assert block is valid
         assert b.is_valid_block(block)
@@ -172,6 +190,8 @@ class TestBigchainVoter(object):
         genesis = b.create_genesis_block()
 
         # create invalid block
+        # sleep so that `block` as a higher timestamp then `genesis`
+        time.sleep(1)
         block = b.create_block([transaction_signed])
         # change transaction id to make it invalid
         block['block']['transactions'][0]['id'] = 'abc'
@@ -201,7 +221,7 @@ class TestBigchainVoter(object):
 
     def test_vote_creation_valid(self, b):
         # create valid block
-        block = b.create_block([])
+        block = dummy_block()
         # retrieve vote
         vote = b.vote(block, 'abc', True)
 
@@ -215,7 +235,7 @@ class TestBigchainVoter(object):
 
     def test_vote_creation_invalid(self, b):
         # create valid block
-        block = b.create_block([])
+        block = dummy_block()
         # retrieve vote
         vote = b.vote(block, 'abc', False)
 
@@ -233,9 +253,9 @@ class TestBigchainVoter(object):
 
         # insert blocks in the database while the voter process is not listening
         # (these blocks won't appear in the changefeed)
-        block_1 = b.create_block([])
+        block_1 = dummy_block()
         b.write_block(block_1, durability='hard')
-        block_2 = b.create_block([])
+        block_2 = dummy_block()
         b.write_block(block_2, durability='hard')
 
         # voter is back online, we simulate that by creating a queue and a Voter instance
@@ -243,7 +263,7 @@ class TestBigchainVoter(object):
         voter = Voter(q_new_block)
 
         # create a new block that will appear in the changefeed
-        block_3 = b.create_block([])
+        block_3 = dummy_block()
         b.write_block(block_3, durability='hard')
 
         # put the last block in the queue
@@ -266,9 +286,12 @@ class TestBigchainVoter(object):
 
     def test_voter_chains_blocks_with_the_previous_ones(self, b):
         b.create_genesis_block()
-        block_1 = b.create_block([])
+        # sleep so that `block_*` as a higher timestamp then `genesis`
+        time.sleep(1)
+        block_1 = dummy_block()
         b.write_block(block_1, durability='hard')
-        block_2 = b.create_block([])
+        time.sleep(1)
+        block_2 = dummy_block()
         b.write_block(block_2, durability='hard')
 
         q_new_block = mp.Queue()
@@ -294,7 +317,7 @@ class TestBigchainVoter(object):
 
     def test_voter_checks_for_previous_vote(self, b):
         b.create_genesis_block()
-        block_1 = b.create_block([])
+        block_1 = dummy_block()
         b.write_block(block_1, durability='hard')
 
         q_new_block = mp.Queue()
@@ -326,7 +349,7 @@ class TestBlockElection(object):
 
     def test_quorum(self, b):
         # create a new block
-        test_block = b.create_block([])
+        test_block = dummy_block()
 
         # simulate a federation with four voters
         key_pairs = [crypto.generate_key_pair() for _ in range(4)]
@@ -393,7 +416,7 @@ class TestBlockElection(object):
     def test_quorum_odd(self, b):
         # test partial quorum situations for odd numbers of voters
         # create a new block
-        test_block = b.create_block([])
+        test_block = dummy_block()
 
         # simulate a federation with four voters
         key_pairs = [crypto.generate_key_pair() for _ in range(5)]
@@ -476,7 +499,7 @@ class TestBlockStream(object):
             b.federation_nodes.append(crypto.generate_key_pair()[1])
         new_blocks = mp.Queue()
         bs = BlockStream(new_blocks)
-        block_1 = b.create_block([])
+        block_1 = dummy_block()
         new_blocks.put(block_1)
         assert block_1 == bs.get()
 
@@ -485,8 +508,8 @@ class TestBlockStream(object):
         bs = BlockStream(new_blocks)
 
         # create two blocks
-        block_1 = b.create_block([])
-        block_2 = b.create_block([])
+        block_1 = dummy_block()
+        block_2 = dummy_block()
 
         # write the blocks
         b.write_block(block_1, durability='hard')
@@ -502,8 +525,8 @@ class TestBlockStream(object):
 
     def test_if_old_blocks_get_should_return_old_block_first(self, b):
         # create two blocks
-        block_1 = b.create_block([])
-        block_2 = b.create_block([])
+        block_1 = dummy_block()
+        block_2 = dummy_block()
 
         # write the blocks
         b.write_block(block_1, durability='hard')
@@ -520,8 +543,8 @@ class TestBlockStream(object):
         # pp(block_2)
 
         # create two new blocks that will appear in the changefeed
-        block_3 = b.create_block([])
-        block_4 = b.create_block([])
+        block_3 = dummy_block()
+        block_4 = dummy_block()
 
         # simulate a changefeed
         new_blocks.put(block_3)


### PR DESCRIPTION
resolves #380

Changes done in this pull request:
- Round the timestamp to have second precision.
- Replaced the payload hash with an uuid4. This allows us to index the payload even if it is a duplicate
- Updated secondary index `payload_hash -> payload_uuid`
- Added and updated tests