### PR TITLE
Renamed Bigchain.federation_nodes as Bigchain.nodes_except_me

### DIFF
--- a/bigchaindb/consensus.py
+++ b/bigchaindb/consensus.py
@@ -138,7 +138,7 @@ class BaseConsensusRules(AbstractConsensusRules):
                 raise ValueError('A CREATE operation has no inputs')
             # TODO: for now lets assume a CREATE transaction only has one current_owner
             if transaction['transaction']['fulfillments'][0]['current_owners'][0] not in (
-                    bigchain.federation_nodes + [bigchain.me]):
+                    bigchain.nodes_except_me + [bigchain.me]):
                 raise exceptions.OperationError(
                     'Only federation nodes can use the operation `CREATE`')
 
@@ -198,7 +198,7 @@ class BaseConsensusRules(AbstractConsensusRules):
             raise exceptions.InvalidHash()
 
         # Check if the block was created by a federation node
-        if block['block']['node_pubkey'] not in (bigchain.federation_nodes + [bigchain.me]):
+        if block['block']['node_pubkey'] not in (bigchain.nodes_except_me + [bigchain.me]):
             raise exceptions.OperationError('Only federation nodes can create blocks')
 
         # Check if block signature is valid

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -59,7 +59,7 @@ class Bigchain(object):
         self.dbname = dbname or bigchaindb.config['database']['name']
         self.me = public_key or bigchaindb.config['keypair']['public']
         self.me_private = private_key or bigchaindb.config['keypair']['private']
-        self.federation_nodes = keyring or bigchaindb.config['keyring']
+        self.nodes_except_me = keyring or bigchaindb.config['keyring']
         self.consensus = config_utils.load_consensus_plugin(consensus_plugin)
 
         if not self.me or not self.me_private:
@@ -127,8 +127,8 @@ class Bigchain(object):
         # we will assign this transaction to `one` node. This way we make sure that there are no duplicate
         # transactions on the bigchain
 
-        if self.federation_nodes:
-            assignee = random.choice(self.federation_nodes)
+        if self.nodes_except_me:
+            assignee = random.choice(self.nodes_except_me)
         else:
             # I am the only node
             assignee = self.me
@@ -395,7 +395,7 @@ class Bigchain(object):
             'timestamp': util.timestamp(),
             'transactions': validated_transactions,
             'node_pubkey': self.me,
-            'voters': self.federation_nodes + [self.me]
+            'voters': self.nodes_except_me + [self.me]
         }
 
         # Calculate the hash of the new block

--- a/bigchaindb/voter.py
+++ b/bigchaindb/voter.py
@@ -30,9 +30,9 @@ class BlockStream(object):
         #       database to get the old blocks.
 
         # TODO how about a one liner, something like:
-        # self.unvoted_blocks = b.get_unvoted_blocks() if not b.federation_nodes else []
+        # self.unvoted_blocks = b.get_unvoted_blocks() if not b.nodes_except_me else []
         self.unvoted_blocks = []
-        if not b.federation_nodes:
+        if not b.nodes_except_me:
             self.unvoted_blocks = b.get_unvoted_blocks()
 
     def get(self):

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -149,7 +149,7 @@ class TestBigchainApi(object):
     def test_assign_transaction_multiple_nodes(self, b, user_vk, user_sk):
         # create 5 federation nodes
         for _ in range(5):
-            b.federation_nodes.append(crypto.generate_key_pair()[1])
+            b.nodes_except_me.append(crypto.generate_key_pair()[1])
 
         # test assignee for several transactions
         for _ in range(20):
@@ -161,8 +161,8 @@ class TestBigchainApi(object):
             # retrieve the transaction
             response = r.table('backlog').get(tx_signed['id']).run(b.conn)
 
-            # check if the assignee is the federation_nodes
-            assert response['assignee'] in b.federation_nodes
+            # check if the assignee is one of the _other_ federation nodes
+            assert response['assignee'] in b.nodes_except_me
 
     @pytest.mark.usefixtures('inputs')
     def test_genesis_block(self, b):
@@ -440,7 +440,7 @@ class TestBlockValidation(object):
             'timestamp': util.timestamp(),
             'transactions': [tx_invalid],
             'node_pubkey': b.me,
-            'voters': b.federation_nodes
+            'voters': b.nodes_except_me
         }
 
         block_data = util.serialize(block)

--- a/tests/db/test_voter.py
+++ b/tests/db/test_voter.py
@@ -496,7 +496,7 @@ class TestBlockStream(object):
 
     def test_if_federation_size_is_greater_than_one_ignore_past_blocks(self, b):
         for _ in range(5):
-            b.federation_nodes.append(crypto.generate_key_pair()[1])
+            b.nodes_except_me.append(crypto.generate_key_pair()[1])
         new_blocks = mp.Queue()
         bs = BlockStream(new_blocks)
         block_1 = dummy_block()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -32,7 +32,7 @@ def test_bigchain_class_default_initialization(config):
     assert bigchain.dbname == config['database']['name']
     assert bigchain.me == config['keypair']['public']
     assert bigchain.me_private == config['keypair']['private']
-    assert bigchain.federation_nodes == config['keyring']
+    assert bigchain.nodes_except_me == config['keyring']
     assert bigchain.consensus == BaseConsensusRules
     assert bigchain._conn is None
 
@@ -55,6 +55,6 @@ def test_bigchain_class_initialization_with_parameters(config):
     assert bigchain.dbname == init_kwargs['dbname']
     assert bigchain.me == init_kwargs['public_key']
     assert bigchain.me_private == init_kwargs['private_key']
-    assert bigchain.federation_nodes == init_kwargs['keyring']
+    assert bigchain.nodes_except_me == init_kwargs['keyring']
     assert bigchain.consensus == BaseConsensusRules
     assert bigchain._conn is None


### PR DESCRIPTION
Someone new to the BigchainDB code might look at the list named `Bigchain.federation_nodes` and think that it includes all the federation nodes, but it doesn't. (It doesn't include the public key of the current node; that's stored in `Bigchain.me`.)

I figured it would be a good idea to rename it so there's less ambiguity. I changed it to `Bigchain.nodes_except_me`. That name makes a good pair with `Bigchain.me`.

An alternative would be `Bigchain.keyring` but that name is also somewhat ambiguous. I suppose BigchainDB developers should know what "keyring" means (i.e. that it excludes the public key of the current node). I prefer to assume as little as possible.