### PR TITLE
More docs improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,11 +35,18 @@ Familiarize yourself with how we do coding and documentation in the BigchainDB p
     * [Scott Chacon's blog post about GitHub Flow](http://scottchacon.com/2011/08/31/github-flow.html)
 * [semantic versioning](http://semver.org/)
 
-### Step 2 - Fork bigchaindb on GitHub
+### Step 2 - Install some Dependencies
+
+* [Install RethinkDB Server](https://rethinkdb.com/docs/install/)
+* Make sure you have Python 3.4+ (maybe in a virtualenv)
+* [Install BigchaindB Server's OS-level dependencies](http://bigchaindb.readthedocs.io/en/latest/nodes/setup-run-node.html#install-bigchaindb-server)
+* [Make sure you have the latest version of pip](http://bigchaindb.readthedocs.io/en/latest/nodes/setup-run-node.html#how-to-install-bigchaindb-with-pip)
+
+### Step 3 - Fork bigchaindb on GitHub
 
 In your web browser, go to [the BigchainDB repository on GitHub](https://github.com/bigchaindb/bigchaindb) and click the `Fork` button in the top right corner. This creates a new Git repository named `bigchaindb` in _your_ GitHub account.
 
-### Step 3 - Clone Your Fork
+### Step 4 - Clone Your Fork
 
 (This only has to be done once.) In your local terminal, use Git to clone _your_ `bigchaindb` repository to your local computer. Also add the original GitHub bigchaindb/bigchaindb repository as a remote named `upstream` (a convention):
 ```text
@@ -48,7 +55,7 @@ cd bigchaindb
 git add upstream git@github.com:bigchaindb/bigchaindb.git
 ```
 
-### Step 4 - Fetch and Merge the Latest from `upstream/master`
+### Step 5 - Fetch and Merge the Latest from `upstream/master`
 
 Switch to the `master` branch locally, fetch all `upstream` branches, and merge the just-fetched `upstream/master` branch with the local `master` branch:
 ```text
@@ -57,7 +64,7 @@ git fetch upstream
 git merge upstream/master
 ```
 
-### Step 5 - Install the Python module and the CLI
+### Step 6 - Install the Python module and the CLI
 
 In order to use and run the source you just cloned from your fork, you need to install BigchainDB on your computer.
 The core of BigchainDB is a Python module you can install using the standard [Python packaging tools](http://python-packaging-user-guide.readthedocs.org/en/latest/).
@@ -65,8 +72,8 @@ We highly suggest you use `pip` and `virtualenv` to manage your local developmen
 If you need more information on how to do that, refer to the *Python Packaging User Guide* to [install `pip`](http://python-packaging-user-guide.readthedocs.org/en/latest/installing/#requirements-for-installing-packages) and to [create your first `virtualenv`](http://python-packaging-user-guide.readthedocs.org/en/latest/installing/#creating-virtual-environments).
 
 Once you have `pip` installed and (optionally) you are in a virtualenv, go to the root of the repository (i.e. where the `setup.py` file is), and type:
-```bash
-$ pip install -e .[dev]
+```text
+pip install -e .[dev]
 ```
 
 This will install the BigchainDB Python module, the CLI, and all the dependencies useful for contributing to the development of BigchainDB.
@@ -77,8 +84,10 @@ How? Let's split the command down into its components:
  - `.` installs what's in the current directory
  - `[dev]` adds some [extra requirements](https://pythonhosted.org/setuptools/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies) to the installation. (If you are curious, open `setup.py` and look for `dev` in the `extras_require` section.)
 
+Aside: An alternative to `pip install -e .[dev]` is `python setup.py develop`.
 
-### Step 6 - Create a New Branch for Each Bug/Feature
+
+### Step 7 - Create a New Branch for Each Bug/Feature
 
 If your new branch is to **fix a bug** identified in a specific GitHub Issue with number `ISSNO`, then name your new branch `bug/ISSNO/short-description-here`. For example, `bug/67/fix-leap-year-crash`.
 
@@ -89,7 +98,7 @@ Otherwise, please give your new branch a short, descriptive, all-lowercase name.
 git checkout -b new-branch-name
 ```
 
-### Step 7 - Make Edits, git add, git commit
+### Step 8 - Make Edits, git add, git commit
 
 With your new branch checked out locally, make changes or additions to the code or documentation. Remember to:
 
@@ -116,14 +125,14 @@ If your addition or change is substantial, then please add a line or two to the 
 
 (When you submit your pull request [following the instructions below], we run all the tests automatically, so we will see if some are failing. If you don't know why some tests are failing, you can still submit your pull request, but be sure to note the failing tests and to ask for help with resolving them.)
 
-### Step 8 - Push Your New Branch to origin
+### Step 9 - Push Your New Branch to origin
 
 Make sure you've commited all the additions or changes you want to include in your pull request. Then push your new branch to origin (i.e. _your_ remote bigchaindb repository).
 ```text
 git push origin new-branch-name
 ```
 
-### Step 9 - Create a Pull Request 
+### Step 10 - Create a Pull Request 
 
 Go to the GitHub website and to _your_ remote bigchaindb repository (i.e. something like https://github.com/your-user-name/bigchaindb). 
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,11 @@
 A scalable blockchain database. [The whitepaper](https://www.bigchaindb.com/whitepaper/) explains what that means.
 
 
-## Quick Start
+## Get Started
 
+### [Quickstart](http://bigchaindb.readthedocs.io/en/latest/quickstart.html)
 ### [Set Up and Run a BigchainDB Node](http://bigchaindb.readthedocs.io/en/latest/nodes/setup-run-node.html)
 ### [Run BigchainDB with Docker](http://bigchaindb.readthedocs.io/en/latest/nodes/run-with-docker.html)
-### [The Python Server API by Example](http://bigchaindb.readthedocs.io/en/latest/nodes/python-server-api-examples.html)
-### [The Python Driver API by Example](http://bigchaindb.readthedocs.io/en/latest/drivers-clients/python-driver-api-examples.html)
 
 ## Links for Everyone
 * [BigchainDB.com](https://www.bigchaindb.com/) - the main BigchainDB website, including newsletter signup

--- a/docs/source/clusters-feds/federation-set-up.md
+++ b/docs/source/clusters-feds/federation-set-up.md
@@ -13,14 +13,17 @@ This section is about how to set up and run a BigchainDB _federation_, where eac
 
 ## Set Up the Initial Cluster
 
-When you first start a federation cluster, the initial nodes will all start at roughly the same time.
+The federation must decide some things before setting up the initial cluster (initial set of BigchainDB nodes):
 
-The steps to set up a cluster node are outlined in the section titled [Set Up and Run a Node](../nodes/setup-run-node.html). You'll need two pieces of information from all other nodes in the federation:
+1. Who will operate a node in the initial cluster?
+2. What will the replication factor be? (It must be 3 or more for [RethinkDB failover](https://rethinkdb.com/docs/failover/) to work.)
+3. Which node will be responsible for sending the commands to configure the RethinkDB database?
+
+Once those things have been decided, each node operator can begin setting up their BigchainDB node.
+The steps to set up a cluster node are outlined in the section titled [Set Up and Run a Node](../nodes/setup-run-node.html). Each node operator will eventually need two pieces of information from all other nodes in the federation:
 
 1. Their RethinkDB hostname, e.g. `rdb.farm2.organization.org`
 2. Their BigchainDB public key, e.g. `Eky3nkbxDTMgkmiJC8i5hKyVFiAQNmPP4a2G4JdDxJCK`
-
-One node must be chosen as the "designated fist node": they must run some RethinkDB configuration commands after all nodes have started RethinkDB, but before any node has started BigchainDB. 
 
 
 ## Documentation to Come

--- a/docs/source/drivers-clients/example-apps.md
+++ b/docs/source/drivers-clients/example-apps.md
@@ -1,0 +1,5 @@
+# Example Apps
+
+There are some example BigchainDB apps (i.e. apps which use BigchainDB) in [the GitHub repository named bigchaindb-examples](https://github.com/bigchaindb/bigchaindb-examples).
+
+As noted there, the examples are for demonstration purposes only and should not be used as-is for production.

--- a/docs/source/drivers-clients/http-client-server-api.md
+++ b/docs/source/drivers-clients/http-client-server-api.md
@@ -2,14 +2,13 @@
 
 Note: The HTTP client-server API is currently quite rudimentary. For example, there is no ability to do complex queries using the HTTP API. We plan to add querying capabilities in the future. If you want to build a full-featured proof-of-concept, we suggest you use [the Python server API](../nodes/python-server-api-examples.html) for now.
 
-When you start Bigchaindb using `bigchaindb start`, an HTTP API is exposed at:
+When you start Bigchaindb using `bigchaindb start`, an HTTP API is exposed at the address stored in the BigchainDB node configuration settings. The default is for that address to be:
 
 [http://localhost:9984/api/v1/](http://localhost:9984/api/v1/)
 
-For security reasons, the server binds to `localhost:9984`.
-If you want to bind the server to `0.0.0.0` we recommend you to read
-[Deploying Gunicorn](http://docs.gunicorn.org/en/stable/deploy.html) and
-follow the instructions to deploy it in production.
+but that address can be changed by changing the "API endpoint" configuration setting (e.g. in a local config file). There's more information about setting the API endpoint in [the section about Configuring a BigchainDB Node](../nodes/configuration.html).
+
+There are other configuration settings related to the web server (serving the HTTP API). In particular, the default is for the web server socket to bind to `localhost:9984` but that can be changed (e.g. to `0.0.0.0:9984`). For more details, see the "server" settings ("bind", "workers" and "threads") in [the section about Configuring a BigchainDB Node](../nodes/configuration.html).
 
 The HTTP API currently exposes two endpoints, one to get information about a
 specific transaction id, and one to push a transaction to the BigchainDB

--- a/docs/source/drivers-clients/http-client-server-api.md
+++ b/docs/source/drivers-clients/http-client-server-api.md
@@ -1,11 +1,12 @@
 # The HTTP Client-Server API
 
+Note: The HTTP client-server API is currently quite rudimentary. For example, there is no ability to do complex queries using the HTTP API. We plan to add querying capabilities in the future. If you want to build a full-featured proof-of-concept, we suggest you use [the Python server API](../nodes/python-server-api-examples.html) for now.
+
 When you start Bigchaindb using `bigchaindb start`, an HTTP API is exposed at:
 
-- [http://localhost:9984/api/v1/](http://localhost:9984/api/v1/)
+[http://localhost:9984/api/v1/](http://localhost:9984/api/v1/)
 
-
-Please note that for security reasons the server binds to `localhost:9984`.
+For security reasons, the server binds to `localhost:9984`.
 If you want to bind the server to `0.0.0.0` we recommend you to read
 [Deploying Gunicorn](http://docs.gunicorn.org/en/stable/deploy.html) and
 follow the instructions to deploy it in production.
@@ -14,5 +15,4 @@ The HTTP API currently exposes two endpoints, one to get information about a
 specific transaction id, and one to push a transaction to the BigchainDB
 cluster. Those endpoints are documented at:
 
-- [http://docs.bigchaindb.apiary.io/](http://docs.bigchaindb.apiary.io/)
-
+[http://docs.bigchaindb.apiary.io/](http://docs.bigchaindb.apiary.io/)

--- a/docs/source/drivers-clients/index.rst
+++ b/docs/source/drivers-clients/index.rst
@@ -9,4 +9,5 @@ BigchainDB Drivers & Clients
 
    http-client-server-api
    python-driver-api-examples
+   example-apps
    

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Table of Contents
    :maxdepth: 1
 
    introduction
+   quickstart
    nodes/index
    clusters-feds/index
    drivers-clients/index

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,9 +11,9 @@ Table of Contents
    :maxdepth: 1
 
    introduction
-   topic-guides/index
    nodes/index
    clusters-feds/index
    drivers-clients/index
+   topic-guides/index
    release-notes
    appendices/index

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,6 +1,3 @@
-.. You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 BigchainDB Documentation
 ========================
 

--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -5,6 +5,16 @@ BigchainDB is a scalable blockchain database. That is, it's a "big data" databas
 You can read about the motivations, goals and high-level architecture in the [BigchainDB whitepaper](https://www.bigchaindb.com/whitepaper/).
 
 
+## Setup Instructions for Various Cases
+
+* [Set up a stand-alone BigchainDB node for learning and experimenting: Quickstart](quickstart.html)
+* [Set up and run a federation](clusters-feds/federation-set-up.html) (i.a. an organization with a BigchainDB cluster)
+* To set up a stand-alone node so you can help contribute to the development of BigchainDB Server, see [the CONTRIBUTING.md file](https://github.com/bigchaindb/bigchaindb/blob/master/CONTRIBUTING.md)
+* [Deploy a cluster on AWS](clusters-feds/deploy-on-aws.html)
+
+(Instructions for setting up a client will be provided once there's a public testnet.)
+
+
 ## Is BigchainDB Production-Ready?
 
 No, BigchainDB is not production-ready. You can use it to build a prototype or proof-of-concept (POC); many people are already doing that.
@@ -17,3 +27,4 @@ BigchainDB is currently in version 0.X. ([The Releases page on GitHub](https://g
 ## Can I Help?
 
 Yes! BigchainDB is an open-source project; we welcome contributions of all kinds. If you want to request a feature, file a bug report, make a pull request, or help in some other way, please see [the CONTRIBUTING.md file](https://github.com/bigchaindb/bigchaindb/blob/master/CONTRIBUTING.md).
+

--- a/docs/source/nodes/node-requirements.md
+++ b/docs/source/nodes/node-requirements.md
@@ -24,8 +24,12 @@ Every OS has memory requirements; check the memory requirements of your OS.
 
 There is [documentation about RethinkDB's memory requirements](https://rethinkdb.com/docs/memory-usage/). In particular: "RethinkDB requires data structures in RAM on each server proportional to the size of the data on that server’s disk, usually around 1% of the size of the total data set." ([source](https://rethinkdb.com/limitations/))
 
+Also, "The storage engine is used in conjunction with a custom, B-Tree-aware caching engine which allows file sizes many orders of magnitude greater than the amount of available memory. RethinkDB can operate on a terabyte of data with about ten gigabytes of free RAM." ([source](https://www.rethinkdb.com/docs/architecture/))
+
 
 ## Storage Requirements
+
+The RethinkDB storage engine has a number of SSD optimizations, so you can benefit from using SSDs. ([source](https://www.rethinkdb.com/docs/architecture/))
 
 If you want a RethinkDB cluster to store an amount of data D, with a replication factor of R (on every table), and the cluster has N nodes, then each node will need to be able to store R×D/N data plus the storage required for the OS and various other software (RethinkDB, Python, etc.). The secondary indexes also require some storage.
 
@@ -36,9 +40,11 @@ Also, RethinkDB tables can have [at most 64 shards](https://rethinkdb.com/limita
 
 ## Compatible File Systems
 
-RethinkDB has [issues with `btrfs`](https://github.com/rethinkdb/rethinkdb/issues/2781) (B-tree file system).
+RethinkDB "supports most commonly used file systems." ([source](https://www.rethinkdb.com/docs/architecture/))
 
-It's best to have a file system that supports direct I/O, because that will improve RethinkDB performance. Many compressed or encrypted file systems don't support direct I/O.
+It has [issues with BTRFS](https://github.com/rethinkdb/rethinkdb/issues/2781) (B-tree file system).
+
+It's best to have a file system that supports direct I/O, because that will improve RethinkDB performance (if you tell RethinkDB to use direct I/O). Many compressed or encrypted file systems don't support direct I/O.
 
 
 ## CPU Requirements

--- a/docs/source/nodes/setup-run-node.md
+++ b/docs/source/nodes/setup-run-node.md
@@ -1,9 +1,6 @@
-# Set Up and Run a Node
+# Set Up and Run a Cluster Node
 
-This section goes through the steps to set up a BigchainDB node (running RethinkDB Server, BigchainDB Server, etc.). There are instructions for two cases:
-
-1. Stand-Alone Node (useful for local testing and development)
-2. Cluster Node
+If you want to set up a BigchainDB node that's intended to be one of the nodes in a BigchainDB cluster (i.e. where each node is operated by a different member of a federation), then this page is for you, otherwise see [elsewhere](../introduction.html).
 
 
 ## Get a Server
@@ -24,8 +21,6 @@ TODO: Notes about firewall setup. What ports should be open, for what kinds of t
 
 ## Sync Your System Clock
 
-If you're just setting up a stand-alone node, then you can skip this step.
-
 A BigchainDB node uses its system clock to generate timestamps for blocks and votes, so that clock should be kept in sync with some standard clock(s). The standard way to do that is to run an NTP daemon (Network Time Protocol daemon) on the node. (You could also use tlsdate, which uses TLS timestamps rather than NTP, but don't: it's not very accurate and it will break with TLS 1.3, which removes the timestamp.)
 
 NTP is a standard protocol. There are many NTP daemons implementing it. We don't recommend a particular one. On the contrary, we recommend that different nodes in a federation run different NTP daemons, so that a problem with one daemon won't affect all nodes. Some options are:
@@ -44,8 +39,6 @@ The appendix has [some notes on NTP daemon setup](../appendices/ntp-notes.html).
 
 ## Set Up the File System for RethinkDB
 
-If you're just setting up a stand-alone node, then you can probably skip this step.
-
 Ideally, use a file system that supports direct I/O (Input/Output), a feature whereby file reads and writes go directly from RethinkDB to the storage device, bypassing the operating system read and write caches.
 
 TODO: What file systems support direct I/O? How can you check? How do you enable it, if necessary?
@@ -63,12 +56,6 @@ If you don't already have RethinkDB Server installed, you must install it. The R
 
 
 ## Configure RethinkDB Server
-
-### Stand-Alone Node
-
-If you're setting up a stand-alone node (i.e. not intending for it to join a cluster), then the default RethinkDB configuration will work.
-
-### Cluster Node
 
 Create a RethinkDB configuration file (text file) named `instance1.conf` with the following contents (explained below):
 ```text
@@ -146,36 +133,25 @@ Note: You can use `pip` to upgrade the `bigchaindb` package to the latest versio
 
 ### How to Install BigchainDB from Source
 
-If you want to install BitchainDB from source because you want to contribute code (i.e. as a BigchainDB developer), then please see the instructions in [the `CONTRIBUTING.md` file](https://github.com/bigchaindb/bigchaindb/blob/master/CONTRIBUTING.md).
-
-Otherwise, clone the public repository:
+If you want to install BitchainDB from source because you want to use the very latest bleeding-edge code, clone the public repository:
 ```text
 git clone git@github.com:bigchaindb/bigchaindb.git
-```
-
-and then install from source:
-```text
 python setup.py install
 ```
 
 
 ## Configure BigchainDB Server
 
-Start by creating a default BigchainDB configuration file (named `.bigchaindb`) in your `$HOME` directory using:
+Start by creating a default BigchainDB config file:
 ```text
 bigchaindb -y configure
 ```
 
-There's documentation for the `bigchaindb` command is in the section on [the BigchainDB Command Line Interface (CLI)](bigchaindb-cli.html).
+(There's documentation for the `bigchaindb` command is in the section on [the BigchainDB Command Line Interface (CLI)](bigchaindb-cli.html).)
 
-### Stand-Alone Node
+Edit the created config file: 
 
-The default BigchainDB configuration file will work.
-
-### Cluster Node
-
-Open `$HOME/.bigchaindb` in your text editor and:
-
+* Open `$HOME/.bigchaindb` (the created config file) in your text editor.
 * Change `"server": {"bind": "localhost:9984", ... }` to `"server": {"bind": "0.0.0.0:9984", ... }`. This makes it so traffic can come from any IP address to port 9984 (the HTTP Client-Server API port).
 * Change `"api_endpoint": "http://localhost:9984/api/v1"` to `"api_endpoint": "http://your_api_hostname:9984/api/v1"`
 * Change `"keyring": []` to `"keyring": ["public_key_of_other_node_A", "public_key_of_other_node_B", "..."]` i.e. a list of the public keys of all the other nodes in the federation. The keyring should _not_ include your node's public key.
@@ -185,12 +161,7 @@ For more information about the BigchainDB config file, see [Configuring a Bigcha
 
 ## Run RethinkDB Server
 
-If you didn't create a RethinkDB config file (e.g. because you're running a stand-alone node), then you can start RethinkDB using:
-```text
-rethinkdb
-```
-
-If you _did_ create a RethinkDB config file, then you should start RethinkDB using:
+Start RethinkDB using:
 ```text
 rethinkdb --config-file path/to/instance1.conf
 ```
@@ -204,27 +175,20 @@ You can verify that RethinkDB is running by opening the RethinkDB web interface 
 
 ## Run BigchainDB Server
 
-### Stand-Alone Node
-
-It should be enough to do:
-```text
-bigchaindb start
-```
-
-### Cluster Node
-
-After all the cluster nodes have started RethinkDB, but before they start BigchainDB, one designated cluster node must configure the RethinkDB database by running the following commands:
+After all node operators have started RethinkDB, but before they start BigchainDB, one designated node operator must configure the RethinkDB database by running the following commands:
 ```text
 bigchaindb init
 bigchaindb set-shards numshards
 bigchaindb set-replicas numreplicas
 ```
 
+where:
+
 * `bigchaindb init` creates the database within RethinkDB, the tables, the indexes, and the genesis block.
 * `numshards` should be set to the number of nodes in the initial cluster.
 * `numreplicas` should be set to the database replication factor decided by the federation. It must be 3 or more for [RethinkDB failover](https://rethinkdb.com/docs/failover/) to work.
 
-Once the RethinkDB database is configured, every node can start BigchainDB using:
+Once the RethinkDB database is configured, every node operator can start BigchainDB using:
 ```text
 bigchaindb start
 ```

--- a/docs/source/nodes/setup-run-node.md
+++ b/docs/source/nodes/setup-run-node.md
@@ -213,17 +213,18 @@ bigchaindb start
 
 ### Cluster Node
 
-After all the cluster nodes have started RethinkDB, but before they start BigchainDB, a designated cluster node has to do some RethinkDB cluster configuration by running the following two commands:
+After all the cluster nodes have started RethinkDB, but before they start BigchainDB, one designated cluster node must configure the RethinkDB database by running the following commands:
 ```text
 bigchaindb init
 bigchaindb set-shards numshards
+bigchaindb set-replicas numreplicas
 ```
 
-where `numshards` should be set equal to the number of nodes expected to be in the cluster (i.e. once all currently-expected nodes have joined).
+* `bigchaindb init` creates the database within RethinkDB, the tables, the indexes, and the genesis block.
+* `numshards` should be set to the number of nodes in the initial cluster.
+* `numreplicas` should be set to the database replication factor decided by the federation. It must be 3 or more for [RethinkDB failover](https://rethinkdb.com/docs/failover/) to work.
 
-(The `bigchain init` command creates the database within RethinkDB, the tables, the indexes, and the genesis block.)
-
-Once the designated node has run the above two commands, every node can start BigchainDB using:
+Once the RethinkDB database is configured, every node can start BigchainDB using:
 ```text
 bigchaindb start
 ```

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -1,8 +1,6 @@
 # Quickstart
 
-This page has instructions to set up a single stand-alone BigchainDB node for learning or experimenting. If you want to set up a BigchainDB node for production, development, benchmarking, or something else, see the [BigchainDB Nodes](nodes/index.html) section.
-
-We will assume you're using Ubuntu 14.04 or similar. If you're not using Linux, then you might try [running BigchainDB with Docker](nodes/run-with-docker.html).
+This page has instructions to set up a single stand-alone BigchainDB node for learning or experimenting. Instructions for other cases are [elsewhere](introduction.html). We will assume you're using Ubuntu 14.04 or similar. If you're not using Linux, then you might try [running BigchainDB with Docker](nodes/run-with-docker.html).
 
 A. [Install RethinkDB Server](https://rethinkdb.com/docs/install/ubuntu/)
 

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -1,0 +1,40 @@
+# Quickstart
+
+This page has instructions to set up a single stand-alone BigchainDB node for learning or experimenting. If you want to set up a BigchainDB node for production, development, benchmarking, or something else, see the [BigchainDB Nodes](nodes/index.html) section.
+
+We will assume you're using Ubuntu 14.04 or similar. If you're not using Linux, then you might try [running BigchainDB with Docker](nodes/run-with-docker.html).
+
+A. [Install RethinkDB Server](https://rethinkdb.com/docs/install/ubuntu/)
+
+B. Open a Terminal and run RethinkDB Server with the command:
+```text
+rethinkdb
+```
+
+C. Ubuntu 14.04 already has Python 3.4, so you don't need to install it, but you do need to install a couple other things:
+```text
+sudo apt-get update
+sudo apt-get install g++ python3-dev
+```
+
+D. Get the latest version of pip, wheel and setuptools:
+```text
+sudo apt-get install python3-setuptools
+sudo easy_install3 pip
+pip3 install --upgrade pip wheel setuptools
+```
+
+E. Install the `bigchaindb` Python package from PyPI:
+```text
+sudo pip install bigchaindb
+```
+
+F. Configure and run BigchainDB:
+```text
+bigchaindb -y configure
+bigchaindb start
+```
+
+That's it!
+
+For now, you can get a good sense of how to work with BigchainDB by going through [the examples in the section on the Python Server API](nodes/python-server-api-examples.html).

--- a/docs/source/topic-guides/assets.md
+++ b/docs/source/topic-guides/assets.md
@@ -11,3 +11,10 @@ BigchainDB can store data of any kind (within reason), but it's designed to be p
 * Validated transactions are strongly tamper-resistant; see [the section about immutability / tamper-resistance](immutable.html).
 
 You can read more about the details of BigchainDB transactions in [the section on Transaction, Block and Vote Models (data models)](models.html).
+
+
+## BigchainDB Integration with Other Blockchains
+
+BigchainDB works with the [Interledger protocol](https://interledger.org/), enabling the transfer of assets between BigchainDB and other blockchains, ledgers, and payment systems.
+
+We’re actively exploring ways that BigchainDB can be used with other blockchains and platforms.

--- a/docs/source/topic-guides/index.rst
+++ b/docs/source/topic-guides/index.rst
@@ -13,5 +13,6 @@ Topic guides give background and explain concepts at a high level.
    diversity
    immutable
    assets
+   smart-contracts
    models
    node-cluster-fed

--- a/docs/source/topic-guides/models.md
+++ b/docs/source/topic-guides/models.md
@@ -110,7 +110,7 @@ Aside: In BigchainDB, the output of an m-of-n threshold condition can be inverte
 
 When one creates a condition, one can calculate its fulfillment length (e.g. 96). The more complex the condition, the larger its fulfillment length will be. A BigchainDB federation can put an upper limit on the allowed fulfillment length, as a way of capping the complexity of conditions (and the computing time required to validate them).
 
-If someone tries to make a condition where the output of a threshold condition feeds into the input of another “earlier” threshold condition (i.e. in a closed logical circuit), then their computer will take forever to calculate the “condition URI”, at least in theory. In practice, their computer will run out of memory or their client software will timeout after a while.
+If someone tries to make a condition where the output of a threshold condition feeds into the input of another “earlier” threshold condition (i.e. in a closed logical circuit), then their computer will take forever to calculate the (infinite) “condition URI”, at least in theory. In practice, their computer will run out of memory or their client software will timeout after a while.
 
 Aside: In what follows, the list of `new_owners` (in a condition) is always who owned the asset at the time the transaction completed, but before the next transaction started. The list of `current_owners` (in a fulfillment) is always equal to the list of `new_owners` in that asset's previous transaction.
 

--- a/docs/source/topic-guides/smart-contracts.md
+++ b/docs/source/topic-guides/smart-contracts.md
@@ -1,0 +1,3 @@
+# BigchainDB and Smart Contracts
+
+BigchainDB isn’t intended for running smart contracts. That said, it can do many of the things that smart contracts are used to do. For example, the owners of an asset can impose conditions that must be fulfilled by anyone wishing to transfer the asset to new owners; see the [section on conditions](models.html#conditions-and-fulfillments). BigchainDB also [supports a form of escrow](../nodes/python-server-api-examples.html#escrow).


### PR DESCRIPTION
* More notes on node requirements:  memory, storage (RethinkDB can take advantage of SSDs), file systems supported
* New short section on BigchainDB and Smart Contracts
* Added a high-level explanation of conditions (with help from @diminator )
* Added short subsection on BigchainDB Integration with Other Blockchains
* Added note about how one can't currently do queries via the HTTP API. I suggested they use the Python Server API for prototypes, for now
* Moved "Topic Guides" later in the Table of Contents
* Added a Quickstart page with instructions to setup a stand-alone node for learning or experimenting
* Added a new short page about Example Apps (pointing to the `bigchaindb-examples` repo)
* Added the setting of the replication factor to the instructions for cluster node setup
* Refactored the setup instructions into four cases (all linked from the Introduction page):
    1. stand-alone node for learning & experimenting (Quickstart)
    2. set up and run a federation (points to the page about how to set up a cluster node, which got simplified quite a bit)
    3. set up to contribute to the development of BigchainDB Server (points to the CONTRIBUTING.md file, which also got revised)
    4. deploy a cluster on AWS
