### PR TITLE
New and revised timestamp docs

### DIFF
--- a/bigchaindb/util.py
+++ b/bigchaindb/util.py
@@ -127,11 +127,11 @@ def deserialize(data):
 
 
 def timestamp():
-    """Calculate a UTC timestamp with second precision.
+    """The Unix time, rounded to the nearest second.
+       See https://en.wikipedia.org/wiki/Unix_time
 
     Returns:
-        str: UTC timestamp.
-
+        str: the Unix time
     """
     return str(round(time.time()))
 

--- a/docs/source/appendices/ntp-notes.md
+++ b/docs/source/appendices/ntp-notes.md
@@ -1,13 +1,15 @@
 # Notes on NTP Daemon Setup
 
-As mentioned [elsewhere in these docs](../nodes/setup-run-node.html), there are several NTP daemons available, including:
+There are several NTP daemons available, including:
 
-* The reference NTP daemon from ntp.org; see [their support website](http://support.ntp.org/bin/view/Support/WebHome)
-* [OpenNTPD](http://www.openntpd.org/)
+* The reference NTP daemon (`ntpd`) from ntp.org; see [their support website](http://support.ntp.org/bin/view/Support/WebHome)
 * [chrony](https://chrony.tuxfamily.org/index.html)
+* [OpenNTPD](http://www.openntpd.org/)
 * Maybe [NTPsec](https://www.ntpsec.org/), once it's production-ready
 * Maybe [Ntimed](http://nwtime.org/projects/ntimed/), once it's production-ready
 * [More](https://en.wikipedia.org/wiki/Ntpd#Implementations)
+
+We suggest you run your NTP daemon in a mode which steps the system clock back by one second when a leap second occurs, rather than using one of the fancy "slewing" or "smearing" options. That's the default with `ntpd` and `chronyd`. (Aside: There's [an interesting blog post by Red Hat](http://developers.redhat.com/blog/2015/06/01/five-different-ways-handle-leap-seconds-ntp/) about the various ways to handle leap seconds.)
 
 It's tricky to make an NTP daemon setup secure. Always install the latest version and read the documentation about how to configure and run it securely.
 

--- a/docs/source/appendices/ntp-notes.md
+++ b/docs/source/appendices/ntp-notes.md
@@ -9,7 +9,7 @@ There are several NTP daemons available, including:
 * Maybe [Ntimed](http://nwtime.org/projects/ntimed/), once it's production-ready
 * [More](https://en.wikipedia.org/wiki/Ntpd#Implementations)
 
-We suggest you run your NTP daemon in a mode which steps the system clock back by one second when a leap second occurs, rather than using one of the fancy "slewing" or "smearing" options. That's the default with `ntpd` and `chronyd`. (Aside: There's [an interesting blog post by Red Hat](http://developers.redhat.com/blog/2015/06/01/five-different-ways-handle-leap-seconds-ntp/) about the various ways to handle leap seconds.)
+We suggest you run your NTP daemon in a mode which tells the kernel to step the system clock back by one second when a leap second occurs, rather than using one of the fancy "slewing" or "smearing" options. That's the default with `ntpd` and `chronyd`. (Aside: There's [an interesting blog post by Red Hat](http://developers.redhat.com/blog/2015/06/01/five-different-ways-handle-leap-seconds-ntp/) about the various ways to handle leap seconds.)
 
 It's tricky to make an NTP daemon setup secure. Always install the latest version and read the documentation about how to configure and run it securely.
 

--- a/docs/source/appendices/ntp-notes.md
+++ b/docs/source/appendices/ntp-notes.md
@@ -9,7 +9,9 @@ There are several NTP daemons available, including:
 * Maybe [Ntimed](http://nwtime.org/projects/ntimed/), once it's production-ready
 * [More](https://en.wikipedia.org/wiki/Ntpd#Implementations)
 
-We suggest you run your NTP daemon in a mode which tells the kernel to step the system clock back by one second when a leap second occurs, rather than using one of the fancy "slewing" or "smearing" options. That's the default with `ntpd` and `chronyd`. (Aside: There's [an interesting blog post by Red Hat](http://developers.redhat.com/blog/2015/06/01/five-different-ways-handle-leap-seconds-ntp/) about the various ways to handle leap seconds.)
+We suggest you run your NTP daemon in a mode which will tell your OS kernel to handle leap seconds in a particular way: the default NTP way, so that system clock adjustments are localized and not spread out across the minutes, hours, or days surrounding leap seconds (e.g. "slewing" or "smearing"). There's [a nice Red Hat Developer Blog post about the various options](http://developers.redhat.com/blog/2015/06/01/five-different-ways-handle-leap-seconds-ntp/).
+
+Use the default mode with `ntpd` and `chronyd`. For another NTP daemon, consult its documentation.
 
 It's tricky to make an NTP daemon setup secure. Always install the latest version and read the documentation about how to configure and run it securely.
 

--- a/docs/source/nodes/setup-run-node.md
+++ b/docs/source/nodes/setup-run-node.md
@@ -23,18 +23,9 @@ TODO: Notes about firewall setup. What ports should be open, for what kinds of t
 
 A BigchainDB node uses its system clock to generate timestamps for blocks and votes, so that clock should be kept in sync with some standard clock(s). The standard way to do that is to run an NTP daemon (Network Time Protocol daemon) on the node. (You could also use tlsdate, which uses TLS timestamps rather than NTP, but don't: it's not very accurate and it will break with TLS 1.3, which removes the timestamp.)
 
-NTP is a standard protocol. There are many NTP daemons implementing it. We don't recommend a particular one. On the contrary, we recommend that different nodes in a federation run different NTP daemons, so that a problem with one daemon won't affect all nodes. Some options are:
+NTP is a standard protocol. There are many NTP daemons implementing it. We don't recommend a particular one. On the contrary, we recommend that different nodes in a federation run different NTP daemons, so that a problem with one daemon won't affect all nodes.
 
-* The reference NTP daemon from ntp.org; see [their support website](http://support.ntp.org/bin/view/Support/WebHome)
-* [OpenNTPD](http://www.openntpd.org/)
-* [chrony](https://chrony.tuxfamily.org/index.html)
-* Maybe [NTPsec](https://www.ntpsec.org/), once it's production-ready
-* Maybe [Ntimed](http://nwtime.org/projects/ntimed/), once it's production-ready
-* [More](https://en.wikipedia.org/wiki/Ntpd#Implementations)
-
-It's tricky to make an NTP daemon setup secure. Always install the latest version and read the documentation about how to configure and run it securely.
-
-The appendix has [some notes on NTP daemon setup](../appendices/ntp-notes.html).
+Please see the [notes on NTP daemon setup in the Appendices](../appendices/ntp-notes.html).
 
 
 ## Set Up the File System for RethinkDB

--- a/docs/source/topic-guides/index.rst
+++ b/docs/source/topic-guides/index.rst
@@ -15,4 +15,5 @@ Topic guides give background and explain concepts at a high level.
    assets
    smart-contracts
    models
+   timestamps
    node-cluster-fed

--- a/docs/source/topic-guides/models.md
+++ b/docs/source/topic-guides/models.md
@@ -8,6 +8,11 @@ _Transactions_ are used to register, issue, create or transfer things (e.g. asse
 Below we often refer to cryptographic hashes, keys and signatures. The details of those are covered in [the section on cryptography](../appendices/cryptography.html).
 
 
+## Some Words of Caution
+
+BigchainDB is still in the early stages of development. The data models described below may change substantially before BigchainDB reaches a production-ready state (i.e. version 1.0 and higher).
+
+
 ## Transaction Concepts
 
 Transactions are the most basic kind of record stored by BigchainDB. There are two kinds: creation transactions and transfer transactions.
@@ -36,13 +41,6 @@ When a node is asked to check the validity of a transaction, it must do several 
 * validation of all fulfillments, including validation of cryptographic signatures if they’re among the conditions.
 
 The full details of transaction validation can be found in the code for `validate_transaction()` in the `BaseConsensusRules` class of [`consensus.py`](https://github.com/bigchaindb/bigchaindb/blob/master/bigchaindb/consensus.py) (unless other validation rules are being used by a federation, in which case those should be consulted instead).
-
-
-## Some Words of Caution
-
-BigchainDB is still in the early stages of development. The data models described below may change substantially before BigchainDB reaches a production-ready state (i.e. version 1.0 and higher).
-
-Also, note that timestamps come from clients and nodes. Unless you have some reason to believe that some timestamps are correct or meaningful, we advise you to ignore them (i.e. don't make any decisions based on them). (You might trust a timestamp, for example, if it came from a trusted timestamping service and it is embedded in the transaction data `payload` along with the signature from the timestamping service. You might trust node timestamps if you know all the nodes are running NTP servers.)
 
 
 ## The Transaction Model
@@ -76,7 +74,7 @@ Here's some explanation of the contents of a transaction:
     - `conditions`: List of conditions. Each _condition_ is a _crypto-condition_ that needs to be fulfilled by a transfer transaction in order to transfer ownership to new owners.
     See [Conditions and Fulfillments](#conditions-and-fulfillments) below.
     - `operation`: String representation of the operation being performed (currently either "CREATE" or "TRANSFER"). It determines how the transaction should be validated.
-    - `timestamp`: Time of creation of the transaction in UTC. It's provided by the client.
+    - `timestamp`: The Unix time when the transaction was created. It's provided by the client. See [the section on timestamps](timestamps.html).
     - `data`:
         - `uuid`: UUID version 4 (random) converted to a string of hex digits in standard form.
         - `payload`: Can be any JSON document. It may be empty in the case of a transfer transaction.
@@ -238,7 +236,7 @@ If there is only one _current owner_, the fulfillment will be a simple signature
 
 - `id`: The hash of the serialized `block` (i.e. the `timestamp`, `transactions`, `node_pubkey`, and `voters`). This is also a database primary key; that's how we ensure that all blocks are unique.
 - `block`:
-    - `timestamp`: Timestamp when the block was created. It's provided by the node that created the block.
+    - `timestamp`: The Unix time when the block was created. It's provided by the node that created the block. See [the section on timestamps](timestamps.html).
     - `transactions`: A list of the transactions included in the block.
     - `node_pubkey`: The public key of the node that create the block.
     - `voters`: A list of public keys of federation nodes. Since the size of the 
@@ -260,7 +258,7 @@ Each node must generate a vote for each block, to be appended to that block's `v
         "previous_block": "<id of the block previous to this one>",
         "is_block_valid": "<true|false>",
         "invalid_reason": "<None|DOUBLE_SPEND|TRANSACTIONS_HASH_MISMATCH|NODES_PUBKEYS_MISMATCH",
-        "timestamp": "<timestamp of the voting action>"
+        "timestamp": "<Unix time when the vote was generated, provided by the voting node>"
     },
     "signature": "<signature of vote>"
 }

--- a/docs/source/topic-guides/timestamps.md
+++ b/docs/source/topic-guides/timestamps.md
@@ -26,6 +26,13 @@ If a client or node's system clock is wrong, then its timestamps will be wrong. 
 Those timestamps come from many sources, so you can look at all of them to get some statistical sense of when the transaction "actually happened." The timestamp of the block should always be after the timestamp of the transaction, and the timestamp of the votes should always be after the timestamp of the block.
 
 
+## How BigchainDB Uses Timestamps
+
+BigchainDB _doesn't_ use timestamps to determine the order of transactions or blocks. In particular, the order of blocks is determined by RethinkDB's changefeed on the bigchain table.
+
+BigchainDB _does_ use timestamps for some things. It uses them to determine if a transaction has been waiting in the backlog for too long (i.e. because the node assigned to it hasn't handled it yet). It also uses timestamps to determine the status of timeout conditions (used by escrow).
+
+
 ## Syncing with Standard Clocks
 
 A client or node can run an NTP daemon to keep its system clock in sync with standard clocks. There's more information about that in the section titled [Sync Your System Clock](../nodes/setup-run-node.html#sync-your-system-clock).

--- a/docs/source/topic-guides/timestamps.md
+++ b/docs/source/topic-guides/timestamps.md
@@ -40,7 +40,7 @@ A client or node can run an NTP daemon to keep its system clock in sync with sta
 
 ## Converting Timestamps to UTC
 
-It's not always possible to convert a Unix time to a UTC time, because Unix time doesn't have leap seconds, but UTC does. That means that there are some Unix times which correspond to two different UTC times, and there are other Unix times which don't correspond to any UTC time. Be suspicious of any function which claims to convert Unix time to UTC time. It's possible, but to be correct, it would have to give two answers for some Unix times, and errors for other Unix times.
+It's not always possible to convert a Unix time to a UTC time, because Unix time doesn't have leap seconds, but UTC does. That means that there are some Unix times which correspond to two different UTC times. Be suspicious of any function which claims to convert Unix time to UTC time. It's possible, but to be correct, it would have to give two answers for some Unix times. (In theory, leap seconds can be negative, but that has never happened.)
 
 Leap seconds are rare, so it's usually not a problem to convert a Unix time to a UTC time; just check the converter that you're using to make sure that it's got some sophistication.
 

--- a/docs/source/topic-guides/timestamps.md
+++ b/docs/source/topic-guides/timestamps.md
@@ -28,7 +28,7 @@ We suggest that BigchainDB nodes run their NTP daemon in a mode which tells the 
 
 The result is that some timestamps can't be converted unambigously to a single UTC timestamp, but that only happens for leap seconds, and leap seconds are rare. (Only 26 had been inserted between 1972 and the end of 2015.)
 
-**So long as you avoid the leap seconds, you can convert BigchainDB timestamps (Unix time timestamps) to UTC unambiguosly using any standard conversion tool or library function.**
+**So long as you avoid the leap seconds, you can convert BigchainDB timestamps (Unix time timestamps) to UTC unambiguously using any standard conversion tool or library function.**
 
 There's [a list of all the leap seconds on Wikipedia](https://en.wikipedia.org/wiki/Leap_second).
 
@@ -68,7 +68,7 @@ BigchainDB has a utility function named `timestamp()` which amounts to:
 timestamp() = str(round(time.time()))
 ```
 
-In other words, it calls the `time()` function in Python's `time` module, rounds that to the nearest integer, and converts the result to a string.
+In other words, it calls the `time()` function in Python's `time` module, [rounds](https://docs.python.org/3/library/functions.html#round) that to the nearest integer, and converts the result to a string.
 
 It rounds the output of `time.time()` to the nearest second because, according to [the Python documentation for `time.time()`](https://docs.python.org/3.4/library/time.html#time.time), "...not all systems provide time with a better precision than 1 second."
 
@@ -80,6 +80,10 @@ ret = clock_gettime(CLOCK_REALTIME, &tp);
 With `CLOCK_REALTIME` as the first argument, it returns the Unix time as described above.
 
 
-## Why Not Use UTC, TAI or Something Unambiguous for Timestamps?
+## Why Not Use UTC, TAI or Some Other Time that Has Unambiguous Timestamps for Leap Seconds?
 
-*nix system clocks, and the library functions to access them, use Unix time (also called POSIX time), not UTC, TAI, or something unambiguous. There are many nonstandard and uncommon ways to get an unambiguous time, but we opted to use something standard. Unix time is only problematic for leap seconds, and those are rare. All other times are represented uniquely.
+It would be nice to use UTC or TAI timestamps, but unfortunately, *nix system clocks use Unix time (POSIX time) so that's what we can _easily get_ from them, e.g. using clock_gettime().
+
+In principle, it's possible to get UTC or TAI timestamps, but it's also tricky and nonstandard. One must be careful, and in our opinion, the added complexity isn't justified.
+
+The Unix time timestamps we use are only ambiguous for leap seconds, and those are very rare. Even for those timestamps, the extra uncertainty is only one second, and that's not bad considering that we only report timestamps to a precision of one second in the first place. All other timestamps can be converted to UTC with no ambiguity.

--- a/docs/source/topic-guides/timestamps.md
+++ b/docs/source/topic-guides/timestamps.md
@@ -1,27 +1,22 @@
 # Timestamps in BigchainDB
 
-Each transaction, block and vote has an associated timestamp.
-
-Interpreting those timestamps is tricky, hence the need for this section.
+Each transaction, block and vote has an associated timestamp. Interpreting those timestamps is tricky, hence the need for this section.
 
 
-## Timestamp Sources
+## Timestamp Sources & Accuracy
 
 A transaction's timestamp is provided by the client which created and submitted the transaction to a BigchainDB node. A block's timestamp is provided by the BigchainDB node which created the block. A vote's timestamp is provided by the BigchainDB node which created the vote.
 
-When a BigchainDB client or node needs a timestamp, it calls a BigchainDB utility function named `timestamp()`. There's a detailed explanation of how that function works below, but the short version is that it gets the [Unix time](https://en.wikipedia.org/wiki/Unix_time) from the system clock, rounded to the nearest second.
+When a BigchainDB client or node needs a timestamp, it calls a BigchainDB utility function named `timestamp()`. There's a detailed explanation of how that function works below, but the short version is that it gets the [Unix time](https://en.wikipedia.org/wiki/Unix_time) from its system clock, rounded to the nearest second.
 
-[Unix time](https://en.wikipedia.org/wiki/Unix_time) is defined as defined as the number of seconds that have elapsed since 00:00:00 Coordinated Universal Time (UTC), Thursday, 1 January 1970 (i.e. since the Unix Epoch), _not counting leap seconds_.
+We can't say anything about the accuracy of the system clock on clients. Timestamps from clients are still potentially useful, however, in a statistical sense. We say more about that below.
+
+We advise BigchainDB nodes to run special software (an "NTP daemon") to keep their system clock in sync with standard time servers.
 
 
-## System Clock Accuracy
+## Converting Timestamps to UTC
 
-We can't say anything about the accuracy client system clocks (i.e. used to generate the timestamps for transactions). They're still potentially useful, however, in a statistical sense. We say more about that below.
-
-We advise BigchainDB nodes to run special software (an "NTP daemon") to keep their system clock in sync with standard time servers. That sounds great, but there's a gotcha. NTP uses [UTC (Coordinated Universal Time)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time) and UTC has [leap seconds](https://en.wikipedia.org/wiki/Leap_second), but Unix time ignores leap seconds.
-
-A leap second is an extra second added to the end of some days. On a leap second, the UTC time goes from 23:59:59 UTC to 23:59:60 UTC (instead of 00:00:00 UTC like usual).
-There's [a nice blog post by Red Hat](http://developers.redhat.com/blog/2015/06/01/five-different-ways-handle-leap-seconds-ntp/) about what happens when a leap second arrives via NTP:
+To convert a BigchainDB timestamp (a Unix time) to UTC, you need to know how the node providing the timestamp was maintaining its system clock (which is the source of its timestamps). In particular, you need to know how it was handling leap seconds. It turns out there are many ways to handle leap seconds. There's [a nice Red Hat Developer Blog post about the various options](http://developers.redhat.com/blog/2015/06/01/five-different-ways-handle-leap-seconds-ntp/):
 
 > "When a leap second is inserted to UTC, the system clock skips that second [23:59:60] as it can’t be represented and is suddenly ahead of UTC by one second. There are several ways how the clock can be corrected."
 
@@ -29,7 +24,15 @@ There's [a nice blog post by Red Hat](http://developers.redhat.com/blog/2015/06/
 
 > "... There will be a backward step, but the clock will be off only for one second."
 
-We suggest that BigchainDB nodes run their NTP daemon in a mode which steps the system clock back by one second when a leap second occurs, rather than using one of the fancy "slewing" or "smearing" options. That way, there's only a small set of ambiguous timestamps (i.e. the ones associated with leap seconds).
+We suggest that BigchainDB nodes run their NTP daemon in a mode which tells the kernel to step the system clock back by one second when a leap second occurs, rather than using one of the fancy "slewing" or "smearing" options. That way, there's only a small set of ambiguous timestamps (i.e. the ones associated with leap seconds).
+
+The result is that some timestamps can't be converted unambigously to a single UTC timestamp, but that only happens for leap seconds, and leap seconds are rare. (Only 26 had been inserted between 1972 and the end of 2015.)
+
+**So long as you avoid the leap seconds, you can convert BigchainDB timestamps (Unix time timestamps) to UTC unambiguosly using any standard conversion tool or library function.**
+
+There's [a list of all the leap seconds on Wikipedia](https://en.wikipedia.org/wiki/Leap_second).
+
+There's another gotcha with (Unix time) timestamps: you can't calculate the real-world elapsed time between two timestamps (correctly) by subtracting the smaller timestamp from the larger one. The result won't include any of the leap seconds that occured between the two timestamps. You could look up how many leap seconds happened between the two timestamps and add that to the result. There are many library functions for working with timestamps; those are beyond the scope of this documentation.
 
 
 ## Using Timestamps
@@ -49,13 +52,6 @@ Those timestamps come from many sources, so you can look at all of them to get s
 BigchainDB _doesn't_ use timestamps to determine the order of transactions or blocks. In particular, the order of blocks is determined by RethinkDB's changefeed on the bigchain table.
 
 BigchainDB does use timestamps for some things. It uses them to determine if a transaction has been waiting in the backlog for too long (i.e. because the node assigned to it hasn't handled it yet). It also uses timestamps to determine the status of timeout conditions (used by escrow).
-
-
-## Converting Timestamps to UTC
-
-It's not always possible to convert a Unix time to a UTC time, because Unix time doesn't have leap seconds, but UTC does. That means that there are some Unix times which correspond to two different UTC times. Be suspicious of any function which claims to convert Unix time to UTC time. It's possible, but to be correct, it would have to give two answers for some Unix times.
-
-Leap seconds are rare, so it's usually not a problem to convert a Unix time to a UTC time; just check the converter that you're using to make sure that it's got some sophistication.
 
 
 ## Including Trusted Timestamps
@@ -82,3 +78,8 @@ ret = clock_gettime(CLOCK_REALTIME, &tp);
 ```
 
 With `CLOCK_REALTIME` as the first argument, it returns the Unix time as described above.
+
+
+## Why Not Use UTC, TAI or Something Unambiguous for Timestamps?
+
+*nix system clocks, and the library functions to access them, use Unix time (also called POSIX time), not UTC, TAI, or something unambiguous. There are many nonstandard and uncommon ways to get an unambiguous time, but we opted to use something standard. Unix time is only problematic for leap seconds, and those are rare. All other times are represented uniquely.

--- a/docs/source/topic-guides/timestamps.md
+++ b/docs/source/topic-guides/timestamps.md
@@ -1,0 +1,64 @@
+# Timestamps in BigchainDB
+
+Each transaction, block and vote has an associated timestamp.
+
+Interpreting those timestamps is tricky. If there's one message to take away from this section, it is this: you need to look at multiple timestamps from multiple sources to get some idea of when something happened.
+
+
+## Timestamp Sources
+
+A transaction's timestamp is provided by the client which created and submitted the transaction to a BigchainDB node. A block's timestamp is provided by the BigchainDB node which created the block. A vote's timestamp is provided by the BigchainDB node which created the vote.
+
+When a BigchainDB client or node needs a timestamp, it calls a BigchainDB utility function named `timestamp()`. There's a detailed explanation of how that function works below, but the bottom line is that it gets the Unix time from the system clock, rounded to the nearest second.
+
+Unix time is defined as defined as the number of seconds that have elapsed since 00:00:00 Coordinated Universal Time (UTC), Thursday, 1 January 1970 (i.e. since the Unix Epoch), _not counting leap seconds_. There are more details in [the Wikipedia article about Unix time](https://en.wikipedia.org/wiki/Unix_time).
+
+
+## How to Interpret Timestamps
+
+If a client or node's system clock is wrong, then its timestamps will be wrong. That's not the end of the world, though, because you can look at many timestamps to get an idea of when something happened. For example, a transaction in a decided-valid block has many associated timestamps:
+
+* its own timestamp
+* the timestamps of the other transactions in the block; there could be as many as 999 of those
+* the timestamp of the block
+* the timestamps of all the votes on the block
+
+Those timestamps come from many sources, so you can look at all of them to get some statistical sense of when the transaction "actually happened." The timestamp of the block should always be after the timestamp of the transaction, and the timestamp of the votes should always be after the timestamp of the block.
+
+
+## Syncing with Standard Clocks
+
+A client or node can run an NTP daemon to keep its system clock in sync with standard clocks. There's more information about that in the section titled [Sync Your System Clock](../nodes/setup-run-node.html#sync-your-system-clock).
+
+
+## Converting Timestamps to UTC
+
+It's not always possible to convert a Unix time to a UTC time, because Unix time doesn't have leap seconds, but UTC does. That means that there are some Unix times which correspond to two different UTC times, and there are other Unix times which don't correspond to any UTC time. Be suspicious of any function which claims to convert Unix time to UTC time. It's possible, but to be correct, it would have to give two answers for some Unix times, and errors for other Unix times.
+
+Leap seconds are rare, so it's usually not a problem to convert a Unix time to a UTC time; just check the converter that you're using to make sure that it's got some sophistication.
+
+
+## Including Trusted Timestamps
+
+If you want to create a transaction payload with a trusted timestamp, you can.
+
+One way to do that would be to send a payload to a trusted timestamping service. They will send back a timestamp, a signature, and their public key. They should also explain how you can verify the signature. You can then include the original payload, the timestamp, the signature, and the service's public key in your transaction. That way, anyone can verify that the original payload was signed by the trusted timestamping service.
+
+
+## How the timestamp() Function Works
+
+BigchainDB has a utility function named `timestamp()` which amounts to:
+```python
+timestamp() = str(round(time.time()))
+```
+
+In other words, it calls the `time()` function in Python's `time` module, rounds that to the nearest integer, and converts the result to a string.
+
+It rounds the output of `time.time()` to the nearest second because, according to [the Python documentation for `time.time()`](https://docs.python.org/3.4/library/time.html#time.time), "...not all systems provide time with a better precision than 1 second."
+
+How does `time.time()` work? If you look in the C source code, it calls `floattime()` and `floattime()` calls [clock_gettime()](https://www.cs.rutgers.edu/~pxk/416/notes/c-tutorials/gettime.html), if it's available.
+```text
+ret = clock_gettime(CLOCK_REALTIME, &tp);
+```
+
+(If `clock_gettime()` is not available or returns with a nonzero exit code, it falls back to `_PyTime_gettimeofday_info()`, which is a wrapper around [gettimeofday()](http://man7.org/linux/man-pages/man2/gettimeofday.2.html), an older function that was marked obsolete in POSIX.1-2008.)


### PR DESCRIPTION
I revised the BigchainDB documentation on timestamps:

* Added a new "Timestamps in BigchainDB" page in the Topic Guides.
* Fixed the docstring for the `timestamp()` function. It gets the Unix time, not UTC. The two are related, but different. In particular, UTC has leap seconds but Unix time doesn't.
* Made a suggestion on NTP daemon settings (if doing cluster node setup).
* Revised the `timestamp` explanations in the page about data models (transactions, blocks, votes)
