### PR TITLE
Use the latest rethinkdb 2.3.x driver for Python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         ]
     },
     install_requires=[
-        'rethinkdb==2.3.0',
+        'rethinkdb~=2.3',
         'pysha3==0.3',
         'pytz==2015.7',
         'cryptoconditions==0.4.1',


### PR DESCRIPTION
The `setup.py` file had `'rethinkdb=2.3.0'` but as it happens, that wasn't quite new enough: the `rethinkdb dump` command would fail in a Python 3 environment. That got fixed by version 2.3.0.post4 but the `setup.py` file was holding it back at version 2.3.0. I changed it to:

'rethinkdb~=2.3'

which means something like, "Use the latest 2.3.x version."

I tested this by doing `pip uninstall rethinkdb` then `pip install --upgrade -e .[dev]` and it worked: it installed rethinkdb-2.3.0.post4
