### PR TITLE
Pass a custom bigchain instance to util.sign_tx

### DIFF
--- a/bigchaindb/consensus.py
+++ b/bigchaindb/consensus.py
@@ -217,13 +217,13 @@ class BaseConsensusRules(AbstractConsensusRules):
                               payload)
 
     @staticmethod
-    def sign_transaction(transaction, private_key):
+    def sign_transaction(transaction, private_key, bigchain=None):
         """Sign a transaction
 
         Refer to the documentation of ``bigchaindb.util.sign_tx``
         """
 
-        return util.sign_tx(transaction, private_key)
+        return util.sign_tx(transaction, private_key, bigchain=bigchain)
 
     @staticmethod
     def validate_fulfillments(signed_transaction):

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -85,7 +85,7 @@ class Bigchain(object):
             dict: transaction with any signatures applied.
         """
 
-        return self.consensus.sign_transaction(transaction, *args, **kwargs)
+        return self.consensus.sign_transaction(transaction, *args, bigchain=self, **kwargs)
 
     def validate_fulfillments(self, signed_transaction, *args, **kwargs):
         """Validate the fulfillment(s) of a transaction.

--- a/bigchaindb/util.py
+++ b/bigchaindb/util.py
@@ -298,7 +298,7 @@ def create_tx(current_owners, new_owners, inputs, operation, payload=None):
     return transaction
 
 
-def sign_tx(transaction, signing_keys):
+def sign_tx(transaction, signing_keys, bigchain=None):
     """Sign a transaction
 
     A transaction signed with the `current_owner` corresponding private key.
@@ -306,6 +306,8 @@ def sign_tx(transaction, signing_keys):
     Args:
         transaction (dict): transaction to sign.
         signing_keys (list): list of base58 encoded private keys to create the fulfillments of the transaction.
+        bigchain (obj): bigchain instance used to get the details of the previous transaction outputs. Useful
+                        if the `Bigchain` instance was instantiated with parameters that override the config file.
 
     Returns:
         dict: transaction with the `fulfillment` fields populated.
@@ -324,10 +326,11 @@ def sign_tx(transaction, signing_keys):
 
     tx = copy.deepcopy(transaction)
 
+    bigchain = bigchain if bigchain is not None else bigchaindb.Bigchain()
+
     for fulfillment in tx['transaction']['fulfillments']:
         fulfillment_message = get_fulfillment_message(transaction, fulfillment)
         # TODO: avoid instantiation, pass as argument!
-        bigchain = bigchaindb.Bigchain()
         input_condition = get_input_condition(bigchain, fulfillment)
         parsed_fulfillment = cc.Fulfillment.from_dict(input_condition['condition']['details'])
         # for the case in which the type of fulfillment is not covered by this method

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,7 +23,7 @@ def mock_requests_post(monkeypatch):
 
 @pytest.fixture
 def mock_bigchaindb_sign(monkeypatch):
-    def mockreturn(transaction, private_key):
+    def mockreturn(transaction, private_key, bigchain):
         return transaction
 
     monkeypatch.setattr('bigchaindb.util.sign_tx', mockreturn)


### PR DESCRIPTION
`util.sign_tx` requires a `bigchaindb.Bigchain` instance to be able to retrieve the details of the outputs of the previous transaction in order to create the fulfillment.

In the previous implementation `util.sign_tx` was instantiating a `Bigchain` instance with `bigchaindb.Bigchain()`. This does not work if you are signing a transaction created with a custom Bigchain instance.

Example:
```python
b = bigchaindb.Bigchain(dbname='custom_bigchain')
tx = b.create_transaction(.....)
tx_signed = b.sign_transaction(tx, sk)
```

This would not work because sign_transaction would use `b = bigchaindb.Bigchain()` and so would look in the `bigchain` database for the previous transaction by default instead of the `custom_bigchain`

To solve this `Bigchain.sign_transaction` passes `self` by default to `util.sign_tx`