### PR TITLE
Docs fix: an asset can't have zero owners

### DIFF
--- a/docs/source/topic-guides/assets.md
+++ b/docs/source/topic-guides/assets.md
@@ -4,7 +4,7 @@ BigchainDB can store data of any kind (within reason), but it's designed to be p
 
 * The fundamental thing that one submits to a BigchainDB federation to be checked and stored (if valid) is a _transaction_, and there are two kinds: creation transactions and transfer transactions.
 * A creation transaction can be use to register any kind of indivisible asset, along with arbitrary metadata.
-* An asset can have zero, one, or several owners.
+* An asset can have one or more owners.
 * The owners of an asset can specify (crypto-)conditions which must be satisified by anyone wishing transfer the asset to new owners. For example, a condition might be that at least 3 of the 5 current owners must cryptographically sign a transfer transaction.
 * BigchainDB verifies that the conditions have been satisified as part of checking the validity of transfer transactions. (Moreover, anyone can check that they were satisfied.)
 * BigchainDB prevents double-spending of an asset.


### PR DESCRIPTION
The **Assets** section under **Topic Guides** used to say "An asset can have zero, one, or several owners." but that is wrong. An asset can't have zero owners. This was pointed out by @MiracleB on Gitter. I fixed it.

What I wrote on Gitter, when @MiracleB asked about the zero owners case:

> When I wrote that, I was thinking about the case of a simple hashlock condition --- anyone who knows (or guesses) the secret preimage can transfer the asset. The current owner(s) don't have to do anything to create the transfer (fulfillment). If the current owner(s) lose the secret preimage, then it becomes effectively impossible to transfer the asset, but someone still owns the asset. I guess there must always be at least one asset owner.