### PR TITLE
Docs on RethinkDB storage setup

### DIFF
--- a/docs/source/appendices/example-rethinkdb-storage-setups.md
+++ b/docs/source/appendices/example-rethinkdb-storage-setups.md
@@ -35,4 +35,4 @@ TODO
 
 TODO
 
-Maybe RAID, ZFS, HDFS, MapR-FS, ... (over EBS volumes, i.e. a DIY Amazon EFS)
+Maybe RAID, ZFS, ... (over EBS volumes, i.e. a DIY Amazon EFS)

--- a/docs/source/appendices/example-rethinkdb-storage-setups.md
+++ b/docs/source/appendices/example-rethinkdb-storage-setups.md
@@ -1,0 +1,27 @@
+# Example RethinkDB Storage Setups
+
+## Example 1: A Partition of an AWS Instance Store
+
+Many [AWS EC2 instance types](https://aws.amazon.com/ec2/instance-types/) comes with an [instance store](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html): temporary storage that disappears when the instance disappears. (Some instance types _don't_ come with an instance store, but you can attach EBS storage.) The size and setup of an instance store depends on the EC2 instance type.
+
+We have some scripts for [deploying a _test_ BigchainDB cluster on AWS](../clusters-feds/deploy-on-aws.html). Those scripts include commands to set up a partition (`/dev/xvdb`) on the [instance store](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html) if that partition exists. Those commands can be found in the file `/deploy-cluster-aws/fabfile.py`, under `def install_rethinkdb()` (i.e. the function to install RethinkDB).
+
+
+TODO: Discuss if/when one would use the instance store to store RethinkDB data.
+
+
+
+## Example 2: An Amazon EBS Volume
+
+Amazon EBS volumes are always replicated.
+
+
+## Example 3: Using Amazon EFS
+
+TODO
+
+
+## Example 4: A RAID Example?
+
+Maybe make two EBS volumes look like one?
+

--- a/docs/source/appendices/example-rethinkdb-storage-setups.md
+++ b/docs/source/appendices/example-rethinkdb-storage-setups.md
@@ -2,18 +2,28 @@
 
 ## Example 1: A Partition of an AWS Instance Store
 
-Many [AWS EC2 instance types](https://aws.amazon.com/ec2/instance-types/) comes with an [instance store](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html): temporary storage that disappears when the instance disappears. (Some instance types _don't_ come with an instance store, but you can attach EBS storage.) The size and setup of an instance store depends on the EC2 instance type.
+Many [AWS EC2 instance types](https://aws.amazon.com/ec2/instance-types/) comes with an [instance store](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html): temporary storage that disappears when the instance disappears. The size and setup of an instance store depends on the EC2 instance type.
 
-We have some scripts for [deploying a _test_ BigchainDB cluster on AWS](../clusters-feds/deploy-on-aws.html). Those scripts include commands to set up a partition (`/dev/xvdb`) on the [instance store](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html) if that partition exists. Those commands can be found in the file `/deploy-cluster-aws/fabfile.py`, under `def install_rethinkdb()` (i.e. the function to install RethinkDB).
+We have some scripts for [deploying a _test_ BigchainDB cluster on AWS](../clusters-feds/deploy-on-aws.html). Those scripts include commands to set up a partition (`/dev/xvdb`) on an [instance store](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html) for RethinkDB data. Those commands can be found in the file `/deploy-cluster-aws/fabfile.py`, under `def install_rethinkdb()` (i.e. the Fabric function to install RethinkDB).
 
+An AWS instance store is convenient, but it's intended for "buffers, caches, scratch data, and other temporary content." Moreover:
 
-TODO: Discuss if/when one would use the instance store to store RethinkDB data.
+* You pay for all the storage, regardless of how much you use.
+* You can't increase the size of the instance store.
+* If the instance stops, terminates, or reboots, you lose the associated instance store.
+* Instance store data isn't replicated, so if the underlying disk drive fails, you lose the data in the instance store.
+* "You can't detach an instance store volume from one instance and attach it to a different instance."
 
+The [AWS documentation says](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html), "...do not rely on instance store for valuable, long-term data. Instead, you can build a degree of redundancy (for example, RAID 1/5/6), or use a file system (for example, HDFS and MapR-FS) that supports redundancy and fault tolerance."
+
+**Even if you don't use an AWS instance store partition to store your node's RethinkDB data, you may find it useful to read the steps in `def install_rethinkdb()`: [see fabfile.py](https://github.com/bigchaindb/bigchaindb/blob/master/deploy-cluster-aws/fabfile.py).**
 
 
 ## Example 2: An Amazon EBS Volume
 
-Amazon EBS volumes are always replicated.
+TODO
+
+Note: Amazon EBS volumes are always replicated.
 
 
 ## Example 3: Using Amazon EFS
@@ -21,7 +31,8 @@ Amazon EBS volumes are always replicated.
 TODO
 
 
-## Example 4: A RAID Example?
+## Other Examples?
 
-Maybe make two EBS volumes look like one?
+TODO
 
+Maybe RAID, ZFS, HDFS, MapR-FS, ... (over EBS volumes, i.e. a DIY Amazon EFS)

--- a/docs/source/appendices/index.rst
+++ b/docs/source/appendices/index.rst
@@ -12,5 +12,6 @@ Appendices
    the-Bigchain-class
    consensus
    ntp-notes
+   example-rethinkdb-storage-setups
    local-rethinkdb-cluster
    licenses

--- a/docs/source/clusters-feds/deploy-on-aws.md
+++ b/docs/source/clusters-feds/deploy-on-aws.md
@@ -2,13 +2,11 @@
 
 This section explains a way to deploy a cluster of BigchainDB nodes on Amazon Web Services (AWS). We use some Bash and Python scripts to launch several instances (virtual servers) on Amazon Elastic Compute Cloud (EC2). Then we use Fabric to install RethinkDB and BigchainDB on all those instances.
 
-**NOTE: At the time of writing, these script _do_ launch a bunch of EC2 instances, and they do install RethinkDB plus BigchainDB on each instance, but don't expect to be able to use the cluster for anything useful. There are several issues related to configuration, networking, and external clients that must be sorted out first. That said, you might find it useful to try out the AWS deployment scripts, because setting up to use them, and using them, will be very similar once those issues get sorted out.**
-
 ## Why?
 
 You might ask why one would want to deploy a centrally-controlled BigchainDB cluster. Isn't BigchainDB supposed to be decentralized, where each node is controlled by a different person or organization?
 
-That's true, but there are some reasons why one might want a centrally-controlled cluster: 1) for testing, and 2) for initial deployment, after which the control of each node can be handed over to a different entity.
+Yes! These scripts are for deploying _test_ clusters, not production clusters.
 
 ## Python Setup
 


### PR DESCRIPTION
* Modified the "Storage Requirements" subsection of **Node Requirements**. Also revised the memory (RAM) requirements.
* Completely rewrote the subsection "Set Up Storage for RethinkDB Data" --- It used to be about setting up the filesystem for RethinkDB, but I realized it's more general than that.
* Created a new section in the appendices, **Example RethinkDB Storage Setups**. That section needs more examples, but I can add those in a future pull request.

I also removed some of the old warnings from the intro to the section on deploying to AWS, and made it clear that one would only use those deployment scripts to deploy a _test_ cluster.