### PR TITLE
Docs: Added two concepts to backup strategies

### DIFF
--- a/docs/source/clusters-feds/backup.md
+++ b/docs/source/clusters-feds/backup.md
@@ -86,7 +86,7 @@ See the last subsection of this page for a better way to use this idea.
 
 **Continuous backup** might mean incremental backup on a very regular basis (e.g. every ten minutes), or it might mean backup of every database operation as it happens. The latter is also called transaction logging or continuous archiving.
 
-RethinkDB doesn't have a built-in incremental or continuous backup capability. Incremental backup was mentioned briefly in RethinkDB Issue [#89](https://github.com/rethinkdb/rethinkdb/issues/89).
+At the time of writing, RethinkDB didn't have a built-in incremental or continuous backup capability, but the idea was raised in RethinkDB issues [#89](https://github.com/rethinkdb/rethinkdb/issues/89) and [#5890](https://github.com/rethinkdb/rethinkdb/issues/5890). On July 5, 2016, Daniel Mewes (of RethinkDB) wrote the following comment on issue #5890: "We would like to add this feature [continuous backup], but haven't started working on it yet."
 
 To get a sense of what continuous backup might look like for RethinkDB, one can look at the continuous backup options available for MongoDB. MongoDB, the company, offers continuous backup with [Ops Manager](https://www.mongodb.com/products/ops-manager) (self-hosted) or [Cloud Manager](https://www.mongodb.com/cloud) (fully managed). Features include:
 

--- a/docs/source/clusters-feds/backup.md
+++ b/docs/source/clusters-feds/backup.md
@@ -121,6 +121,6 @@ You might want to disconnect the `backup` set from the `original` set first, and
 
 You will want to re-connect the `backup` set to the `original` set as soon as possible, so it's able to catch up.
 
-If something bad happens to the entire original BigchainDB cluster (including the `backup` set) and you need to restore it from a snapshot, you can, but before you make the cluster live, you should 1) delete all entries in the backlog table, 2) delete all blocks after the last voted-valid block, and 3) delete all votes on the blocks deleted in part 2.
+If something bad happens to the entire original BigchainDB cluster (including the `backup` set) and you need to restore it from a snapshot, you can, but before you make BigchainDB live, you should 1) delete all entries in the backlog table, 2) delete all blocks after the last voted-valid block, 3) delete all votes on the blocks deleted in part 2, and 4) rebuild the RethinkDB indexes.
 
 **NOTE:** Sometimes snapshots are _incremental_. For example, [Amazon EBS snapshots](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSSnapshots.html) are incremental, meaning "only the blocks on the device that have changed after your most recent snapshot are saved. **This minimizes the time required to create the snapshot and saves on storage costs.**" [Emphasis added]


### PR DESCRIPTION
I added two concepts to the section on backup strategies:

1. Replication isn't backup; you still need to consider having a normal, "cold" backup.
2. Added the idea of disconnecting the `backup` set, waiting for it to settle, and snapshotting all its file systems.

Helps with issue #283 