### PR TITLE
Docs: Amazon Linux instances already have NTP set up

### DIFF
--- a/docs/source/appendices/ntp-notes.md
+++ b/docs/source/appendices/ntp-notes.md
@@ -13,12 +13,19 @@ We suggest you run your NTP daemon in a mode which will tell your OS kernel to h
 
 Use the default mode with `ntpd` and `chronyd`. For another NTP daemon, consult its documentation.
 
-It's tricky to make an NTP daemon setup secure. Always install the latest version and read the documentation about how to configure and run it securely.
+It's tricky to make an NTP daemon setup secure. Always install the latest version and read the documentation about how to configure and run it securely. See the [notes on firewall setup](firewall-notes.html).
 
 
-## Ubuntu Packages
+## Amazon Linux Instances
 
-The [Ubuntu 14.04 (Trusty Tahr) package `ntp`](https://launchpad.net/ubuntu/trusty/+source/ntp) is based on the reference implementation of an NTP daemon.
+If your BigchainDB node is running on an Amazon Linux instance (i.e. a Linux instance packaged by Amazon, not Canonical, Red Hat, or someone else), then an NTP daemon should already be installed and configured. See the EC2 documentation on [Setting the Time for Your Linux Instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html).
+
+That said, you should check _which_ NTP daemon is installed. Is it recent? Is it configured securely?
+
+
+## Ubuntu's ntp Package
+
+The [Ubuntu 14.04 (Trusty Tahr) package `ntp`](https://launchpad.net/ubuntu/trusty/+source/ntp) is based on the reference implementation of an NTP daemon (i.e. `ntpd`).
 
 The following commands will uninstall the `ntp` and `ntpdate` packages, install the latest `ntp` package (which _might not be based on the latest ntpd code_), and start the NTP daemon (a local NTP server). (`ntpdate` is not reinstalled because it's [deprecated](https://askubuntu.com/questions/297560/ntpd-vs-ntpdate-pros-and-cons) and you shouldn't use it.)
 ```text
@@ -30,11 +37,11 @@ sudo apt-get install ntp
 sudo service ntp restart
 ```
 
-You can check if NTP is running using `sudo ntpq -p`.
+You can check if `ntpd` is running using `sudo ntpq -p`.
 
 You may want to use different NTP time servers. You can change them by editing the NTP config file `/etc/ntp.conf`.
 
-Note: A server running the NTP daemon can be used by others for DRDoS amplification attacks. The above installation procedure should install a default NTP configuration file `/etc/ntp.conf` with the lines:
+Note: A server running an NTP daemon can be used by others for DRDoS amplification attacks. The above installation procedure should install a default NTP configuration file `/etc/ntp.conf` with the lines:
 ```text
 restrict -4 default kod notrap nomodify nopeer noquery
 restrict -6 default kod notrap nomodify nopeer noquery


### PR DESCRIPTION
This is a small pull request. I just added a small subsection (in "Notes on NTP Daemon Setup") to note that Amazon Linux instances already have an NTP daemon installed, configured, and running.