### PR TITLE
Remove block_number

### DIFF
--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -584,9 +584,6 @@ class Bigchain(object):
 
         res = r.table('bigchain').get(last_voted[0]['vote']['voting_for_block']).run(self.conn)
 
-        if 'block_number' in last_voted[0]:
-            res['block_number'] = last_voted[0]['block_number']
-
         return res
 
     def get_unvoted_blocks(self):

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -598,9 +598,11 @@ class Bigchain(object):
             .order_by(r.desc(r.row['block']['timestamp'])) \
             .run(self.conn)
 
+        # FIXME: I (@vrde) don't like this solution. Filtering should be done at a
+        #        database level. Solving issue #444 can help untangling the situation
         unvoted = filter(lambda block: not util.is_genesis_block(block), unvoted)
 
-        return unvoted
+        return list(unvoted)
 
     def block_election_status(self, block):
         """Tally the votes on a block, and return the status: valid, invalid, or undecided."""

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -577,11 +577,11 @@ class Bigchain(object):
             # get the latest value for the vote timestamp (over all votes)
             max_timestamp = r.table('votes') \
                 .filter(r.row['node_pubkey'] == self.me) \
-                .max(lambda x: x['vote']['timestamp']) \
+                .max(r.row['vote']['timestamp']) \
                 .run(self.conn)['vote']['timestamp']
 
             last_voted = list(r.table('votes') \
-                .filter(lambda x: x['vote']['timestamp'] == max_timestamp) \
+                .filter(r.row['vote']['timestamp'] == max_timestamp) \
                 .filter(r.row['node_pubkey'] == self.me) \
                 .run(self.conn))
 

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -598,8 +598,7 @@ class Bigchain(object):
             .order_by(r.desc(r.row['block']['timestamp'])) \
             .run(self.conn)
 
-        if unvoted and util.is_genesis_block(unvoted[0]):
-            unvoted.pop(0)
+        unvoted = filter(lambda block: not util.is_genesis_block(block), unvoted)
 
         return unvoted
 

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -581,8 +581,8 @@ class Bigchain(object):
                 .run(self.conn)['vote']['timestamp']
 
             last_voted = list(r.table('votes') \
-                .filter(r.row['node_pubkey'] == self.me) \
                 .filter(lambda x: x['vote']['timestamp'] == max_timestamp) \
+                .filter(r.row['node_pubkey'] == self.me) \
                 .run(self.conn))
 
         except r.ReqlNonExistenceError:

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -573,6 +573,7 @@ class Bigchain(object):
         try:
             # get the latest value for the vote timestamp (over all votes)
             max_timestamp = r.table('votes') \
+                .filter(r.row['node_pubkey'] == self.me) \
                 .concat_map(lambda x: [x['vote']['timestamp']]) \
                 .max() \
                 .run(self.conn)

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -577,9 +577,8 @@ class Bigchain(object):
             # get the latest value for the vote timestamp (over all votes)
             max_timestamp = r.table('votes') \
                 .filter(r.row['node_pubkey'] == self.me) \
-                .concat_map(lambda x: [x['vote']['timestamp']]) \
-                .max() \
-                .run(self.conn)
+                .max(lambda x: x['vote']['timestamp']) \
+                .run(self.conn)['vote']['timestamp']
 
             last_voted = list(r.table('votes') \
                 .filter(r.row['node_pubkey'] == self.me) \

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -613,7 +613,7 @@ class Bigchain(object):
         unvoted = r.table('bigchain') \
             .filter(lambda block: r.table('votes').get_all([block['id'], self.me], index='block_and_voter')
                     .is_empty()) \
-            .order_by(r.desc(r.row['block']['timestamp'])) \
+            .order_by(r.asc(r.row['block']['timestamp'])) \
             .run(self.conn)
 
         # FIXME: I (@vrde) don't like this solution. Filtering should be done at a

--- a/bigchaindb/db/utils.py
+++ b/bigchaindb/db/utils.py
@@ -42,8 +42,6 @@ def init():
     # create the secondary indexes
     # to order blocks by timestamp
     r.db(dbname).table('bigchain').index_create('block_timestamp', r.row['block']['timestamp']).run(conn)
-    # to order blocks by block number
-    r.db(dbname).table('bigchain').index_create('block_number', r.row['block']['block_number']).run(conn)
     # to order transactions by timestamp
     r.db(dbname).table('backlog').index_create('transaction_timestamp', r.row['transaction']['timestamp']).run(conn)
     # to query the bigchain for a transaction id

--- a/bigchaindb/exceptions.py
+++ b/bigchaindb/exceptions.py
@@ -56,3 +56,7 @@ class MultipleVotesError(Exception):
 
 class GenesisBlockAlreadyExistsError(Exception):
     """Raised when trying to create the already existing genesis block"""
+
+
+class CyclicBlockchainError(Exception):
+    """Raised when there is a cycle in the blockchain"""

--- a/bigchaindb/util.py
+++ b/bigchaindb/util.py
@@ -615,3 +615,18 @@ def transform_create(tx):
     new_tx = create_tx(b.me, transaction['fulfillments'][0]['current_owners'], None, 'CREATE', payload=payload)
     return new_tx
 
+
+def is_genesis_block(block):
+    """Check if the block is the genesis block.
+
+    Args:
+        block (dict): the block to check
+
+    Returns:
+        bool: True if the block is the genesis block, False otherwise.
+    """
+
+    # we cannot have empty blocks, there will always be at least one
+    # element in the list so we can safely refer to it
+    return block['block']['transactions'][0]['transaction']['operation'] == 'GENESIS'
+

--- a/bigchaindb/voter.py
+++ b/bigchaindb/voter.py
@@ -65,7 +65,6 @@ class Voter(object):
         self.q_validated_block = mp.Queue()
         self.q_voted_block = mp.Queue()
         self.v_previous_block_id = mp.Value(ctypes.c_char_p)
-        self.v_previous_block_number = mp.Value(ctypes.c_uint64)
         self.initialized = mp.Event()
 
     def feed_blocks(self):
@@ -105,18 +104,15 @@ class Voter(object):
                 return
 
             logger.info('new_block arrived to voter')
-            block_number = self.v_previous_block_number.value + 1
 
             with self.monitor.timer('validate_block'):
                 validity = b.is_valid_block(new_block)
 
             self.q_validated_block.put((new_block,
                                         self.v_previous_block_id.value.decode(),
-                                        block_number,
                                         validity))
 
             self.v_previous_block_id.value = new_block['id'].encode()
-            self.v_previous_block_number.value = block_number
 
     def vote(self):
         """
@@ -134,9 +130,9 @@ class Voter(object):
                 self.q_voted_block.put('stop')
                 return
 
-            validated_block, previous_block_id, block_number, decision = elem
+            validated_block, previous_block_id, decision = elem
             vote = b.vote(validated_block, previous_block_id, decision)
-            self.q_voted_block.put((validated_block, vote, block_number))
+            self.q_voted_block.put((validated_block, vote))
 
     def update_block(self):
         """
@@ -154,22 +150,21 @@ class Voter(object):
                 logger.info('clean exit')
                 return
 
-            block, vote, block_number = elem
-            logger.info('updating block %s with number %s and with vote %s', block['id'], block_number, vote)
-            b.write_vote(block, vote, block_number)
+            block, vote = elem
+            logger.info('updating block %s and with vote %s', block['id'], vote)
+            b.write_vote(block, vote)
 
     def bootstrap(self):
         """
         Before starting handling the new blocks received by the changefeed we need to handle unvoted blocks
         added to the bigchain while the process was down
 
-        We also need to set the previous_block_id and the previous block_number
+        We also need to set the previous_block_id.
         """
 
         b = Bigchain()
         last_voted = b.get_last_voted_block()
 
-        self.v_previous_block_number.value = last_voted['block_number']
         self.v_previous_block_id.value = last_voted['id'].encode()
 
     def kill(self):

--- a/docs/source/topic-guides/models.md
+++ b/docs/source/topic-guides/models.md
@@ -260,7 +260,6 @@ Each node must generate a vote for each block, to be appended the `votes` table.
         "timestamp": "<Unix time when the vote was generated, provided by the voting node>"
     },
     "signature": "<signature of vote>",
-    "block_number": "<roughly sequential integer index for block ordering>"
 }
 ```
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ Tasks:
 
 import os
 import copy
-from functools import partial
 
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ Tasks:
 
 import os
 import copy
+from functools import partial
 
 import pytest
 

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -98,23 +98,22 @@ def cleanup_tables(request, node_config):
 
 
 @pytest.fixture
-def inputs(user_vk, amount=4, b=None, blocks=4):
+def inputs(user_vk):
     from bigchaindb.exceptions import GenesisBlockAlreadyExistsError
     # 1. create the genesis block
-    b = b or Bigchain()
+    b = Bigchain()
     try:
         b.create_genesis_block()
     except GenesisBlockAlreadyExistsError:
         pass
 
     # 2. create block with transactions for `USER` to spend
-    for block in range(blocks):
+    for block in range(4):
         transactions = []
-        for i in range(amount):
+        for i in range(10):
             tx = b.create_transaction(b.me, user_vk, None, 'CREATE')
             tx_signed = b.sign_transaction(tx, b.me_private)
             transactions.append(tx_signed)
-            b.write_transaction(tx_signed)
 
         block = b.create_block(transactions)
         b.write_block(block, durability='hard')

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -98,7 +98,7 @@ def cleanup_tables(request, node_config):
 
 
 @pytest.fixture
-def inputs(user_vk, amount=1, b=None):
+def inputs(user_vk, amount=4, b=None, blocks=4):
     from bigchaindb.exceptions import GenesisBlockAlreadyExistsError
     # 1. create the genesis block
     b = b or Bigchain()
@@ -108,13 +108,13 @@ def inputs(user_vk, amount=1, b=None):
         pass
 
     # 2. create block with transactions for `USER` to spend
-    transactions = []
-    for i in range(amount):
-        tx = b.create_transaction(b.me, user_vk, None, 'CREATE')
-        tx_signed = b.sign_transaction(tx, b.me_private)
-        transactions.append(tx_signed)
-        b.write_transaction(tx_signed)
+    for block in range(blocks):
+        transactions = []
+        for i in range(amount):
+            tx = b.create_transaction(b.me, user_vk, None, 'CREATE')
+            tx_signed = b.sign_transaction(tx, b.me_private)
+            transactions.append(tx_signed)
+            b.write_transaction(tx_signed)
 
-    block = b.create_block(transactions)
-    b.write_block(block, durability='hard')
-    return block
+        block = b.create_block(transactions)
+        b.write_block(block, durability='hard')

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -262,7 +262,7 @@ class TestBigchainApi(object):
                        .run(b.conn))[0]
         assert b.get_last_voted_block() == genesis
 
-    def test_get_last_voted_block_returns_the_correct_block(self, b, monkeypatch):
+    def test_get_last_voted_block_returns_the_correct_block_same_timestamp(self, b, monkeypatch):
         genesis = b.create_genesis_block()
 
         assert b.get_last_voted_block() == genesis
@@ -275,6 +275,33 @@ class TestBigchainApi(object):
         b.write_block(block_2, durability='hard')
         b.write_block(block_3, durability='hard')
 
+        # make sure all the blocks are written at the same time
+        monkeypatch.setattr(util, 'timestamp', lambda: 1)
+
+        b.write_vote(block_1, b.vote(block_1, b.get_last_voted_block()['id'], True))
+        assert b.get_last_voted_block()['id'] == block_1['id']
+
+        b.write_vote(block_2, b.vote(block_2, b.get_last_voted_block()['id'], True))
+        assert b.get_last_voted_block()['id'] == block_2['id']
+
+        b.write_vote(block_3, b.vote(block_3, b.get_last_voted_block()['id'], True))
+        assert b.get_last_voted_block()['id'] == block_3['id']
+
+
+    def test_get_last_voted_block_returns_the_correct_block_different_timestamps(self, b, monkeypatch):
+        genesis = b.create_genesis_block()
+
+        assert b.get_last_voted_block() == genesis
+
+        block_1 = dummy_block()
+        block_2 = dummy_block()
+        block_3 = dummy_block()
+
+        b.write_block(block_1, durability='hard')
+        b.write_block(block_2, durability='hard')
+        b.write_block(block_3, durability='hard')
+
+        # make sure all the blocks are written at different timestamps
         monkeypatch.setattr(util, 'timestamp', lambda: 1)
         b.write_vote(block_1, b.vote(block_1, b.get_last_voted_block()['id'], True))
         assert b.get_last_voted_block()['id'] == block_1['id']

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -276,7 +276,7 @@ class TestBigchainApi(object):
         b.write_block(block_3, durability='hard')
 
         # make sure all the blocks are written at the same time
-        monkeypatch.setattr(util, 'timestamp', lambda: 1)
+        monkeypatch.setattr(util, 'timestamp', lambda: '1')
 
         b.write_vote(block_1, b.vote(block_1, b.get_last_voted_block()['id'], True))
         assert b.get_last_voted_block()['id'] == block_1['id']
@@ -302,15 +302,15 @@ class TestBigchainApi(object):
         b.write_block(block_3, durability='hard')
 
         # make sure all the blocks are written at different timestamps
-        monkeypatch.setattr(util, 'timestamp', lambda: 1)
+        monkeypatch.setattr(util, 'timestamp', lambda: '1')
         b.write_vote(block_1, b.vote(block_1, b.get_last_voted_block()['id'], True))
         assert b.get_last_voted_block()['id'] == block_1['id']
 
-        monkeypatch.setattr(util, 'timestamp', lambda: 2)
+        monkeypatch.setattr(util, 'timestamp', lambda: '2')
         b.write_vote(block_2, b.vote(block_2, b.get_last_voted_block()['id'], True))
         assert b.get_last_voted_block()['id'] == block_2['id']
 
-        monkeypatch.setattr(util, 'timestamp', lambda: 3)
+        monkeypatch.setattr(util, 'timestamp', lambda: '3')
         b.write_vote(block_3, b.vote(block_3, b.get_last_voted_block()['id'], True))
         assert b.get_last_voted_block()['id'] == block_3['id']
 

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -30,8 +30,7 @@ def test_init_creates_db_tables_and_indexes():
     assert r.db(dbname).table_list().contains('backlog', 'bigchain').run(conn) is True
 
     assert r.db(dbname).table('bigchain').index_list().contains(
-        'block_timestamp',
-        'block_number').run(conn) is True
+        'block_timestamp').run(conn) is True
 
     assert r.db(dbname).table('backlog').index_list().contains(
         'transaction_timestamp',

--- a/tests/db/test_voter.py
+++ b/tests/db/test_voter.py
@@ -325,11 +325,8 @@ class TestBigchainVoter(object):
                        .run(b.conn))
 
         # retrieve votes
-        votes = r.table('votes')\
-            .order_by(r.asc((r.row['block_number'])))\
-            .run(b.conn)
+        votes = list(r.table('votes').run(b.conn))
 
-        assert blocks[0]['block_number'] == 0  # genesis block
         assert votes[0]['vote']['voting_for_block'] in (blocks[1]['id'], blocks[2]['id'])
         assert votes[1]['vote']['voting_for_block'] in (blocks[1]['id'], blocks[2]['id'])
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -210,3 +210,9 @@ def test_check_hash_and_signature_invalid_signature(monkeypatch):
         'bigchaindb.util.validate_fulfillments', lambda tx: False)
     with pytest.raises(InvalidSignature):
         check_hash_and_signature(transaction)
+
+
+def test_is_genesis_block_returns_true_if_genesis(b):
+    from bigchaindb.util import is_genesis_block
+    genesis_block = b.prepare_genesis_block()
+    assert is_genesis_block(genesis_block)


### PR DESCRIPTION
`block_number` before #379 was used in few queries to order blocks and to retrieve the Genesis block (the one with `block_number = 0`).

After #379 `block_number` has been moved to the `votes` table, losing part of it's value.

This PR is to remove `block_number` from the code–base and replace it with a `timestamp`–based ordering. In case more votes are cast during the same `timestamp` (the resolution is one second) then the attributes `previous_block` and `voting_for_block` are used to determine the order of the votes.