### PR TITLE
Added a readthedocs.yml config file

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,14 @@
+# See http://read-the-docs.readthedocs.io/en/latest/yaml-config.html
+
+# Build HTML zip, PDF & ePub
+formats:
+    - htmlzip
+    - epub
+    - pdf
+
+requirements_file: docs/requirements.txt
+
+python:
+   version: 3
+   setup_py_install: false
+   pip_install: true


### PR DESCRIPTION
Our ReadTheDocs builds have been getting stuck in a "Cloning" state indefinitely (instead of building through to completion). See:

https://readthedocs.org/projects/bigchaindb/builds/

When I searched to see if others were having the same problem, I found that there's a new [`readthedocs.yml` config file](http://read-the-docs.readthedocs.io/en/latest/yaml-config.html) in beta and that might be able to help.

I made a `readthedocs.yml` file. I think the only _change_ it makes is to switch from the default of using Python 2 to using Python 3. I don't know if that will help or not. Locally, I always build the docs using Python 3 (because I use the same virtualenv as for developing BigchainDB).