### PR TITLE
Refactor method signature

### DIFF
--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -526,22 +526,22 @@ class Bigchain(object):
 
         return block
 
-    def vote(self, block, previous_block_id, decision, invalid_reason=None):
+    def vote(self, block_id, previous_block_id, decision, invalid_reason=None):
         """Cast your vote on the block given the previous_block_hash and the decision (valid/invalid)
         return the block to the updated in the database.
 
         Args:
-            block (dict): Block to vote.
+            block_id (str): The id of the block to vote.
             previous_block_id (str): The id of the previous block.
             decision (bool): Whether the block is valid or invalid.
             invalid_reason (Optional[str]): Reason the block is invalid
         """
 
-        if block['id'] == previous_block_id:
+        if block_id == previous_block_id:
             raise exceptions.CyclicBlockchainError()
 
         vote = {
-            'voting_for_block': block['id'],
+            'voting_for_block': block_id,
             'previous_block': previous_block_id,
             'is_block_valid': decision,
             'invalid_reason': invalid_reason,

--- a/bigchaindb/voter.py
+++ b/bigchaindb/voter.py
@@ -136,7 +136,7 @@ class Voter(object):
                 return
 
             validated_block, previous_block_id, decision = elem
-            vote = b.vote(validated_block, previous_block_id, decision)
+            vote = b.vote(validated_block['id'], previous_block_id, decision)
             self.q_voted_block.put((validated_block, vote))
 
     def update_block(self):

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -139,7 +139,7 @@ class TestBigchainApi(object):
         b.write_block(block, durability='hard')
 
         # vote the block invalid
-        vote = b.vote(block, b.get_last_voted_block()['id'], False)
+        vote = b.vote(block['id'], b.get_last_voted_block()['id'], False)
         b.write_vote(block, vote)
         response = b.get_transaction(tx_signed["id"])
 
@@ -280,13 +280,13 @@ class TestBigchainApi(object):
         # make sure all the blocks are written at the same time
         monkeypatch.setattr(util, 'timestamp', lambda: '1')
 
-        b.write_vote(block_1, b.vote(block_1, b.get_last_voted_block()['id'], True))
+        b.write_vote(block_1, b.vote(block_1['id'], b.get_last_voted_block()['id'], True))
         assert b.get_last_voted_block()['id'] == block_1['id']
 
-        b.write_vote(block_2, b.vote(block_2, b.get_last_voted_block()['id'], True))
+        b.write_vote(block_2, b.vote(block_2['id'], b.get_last_voted_block()['id'], True))
         assert b.get_last_voted_block()['id'] == block_2['id']
 
-        b.write_vote(block_3, b.vote(block_3, b.get_last_voted_block()['id'], True))
+        b.write_vote(block_3, b.vote(block_3['id'], b.get_last_voted_block()['id'], True))
         assert b.get_last_voted_block()['id'] == block_3['id']
 
 
@@ -305,15 +305,15 @@ class TestBigchainApi(object):
 
         # make sure all the blocks are written at different timestamps
         monkeypatch.setattr(util, 'timestamp', lambda: '1')
-        b.write_vote(block_1, b.vote(block_1, b.get_last_voted_block()['id'], True))
+        b.write_vote(block_1, b.vote(block_1['id'], b.get_last_voted_block()['id'], True))
         assert b.get_last_voted_block()['id'] == block_1['id']
 
         monkeypatch.setattr(util, 'timestamp', lambda: '2')
-        b.write_vote(block_2, b.vote(block_2, b.get_last_voted_block()['id'], True))
+        b.write_vote(block_2, b.vote(block_2['id'], b.get_last_voted_block()['id'], True))
         assert b.get_last_voted_block()['id'] == block_2['id']
 
         monkeypatch.setattr(util, 'timestamp', lambda: '3')
-        b.write_vote(block_3, b.vote(block_3, b.get_last_voted_block()['id'], True))
+        b.write_vote(block_3, b.vote(block_3['id'], b.get_last_voted_block()['id'], True))
         assert b.get_last_voted_block()['id'] == block_3['id']
 
     def test_no_vote_written_if_block_already_has_vote(self, b):
@@ -323,11 +323,11 @@ class TestBigchainApi(object):
 
         b.write_block(block_1, durability='hard')
 
-        b.write_vote(block_1, b.vote(block_1, genesis['id'], True))
+        b.write_vote(block_1, b.vote(block_1['id'], genesis['id'], True))
         retrieved_block_1 = r.table('bigchain').get(block_1['id']).run(b.conn)
 
         # try to vote again on the retrieved block, should do nothing
-        b.write_vote(retrieved_block_1, b.vote(retrieved_block_1, genesis['id'], True))
+        b.write_vote(retrieved_block_1, b.vote(retrieved_block_1['id'], genesis['id'], True))
         retrieved_block_2 = r.table('bigchain').get(block_1['id']).run(b.conn)
 
         assert retrieved_block_1 == retrieved_block_2
@@ -337,8 +337,8 @@ class TestBigchainApi(object):
         block_1 = dummy_block()
         b.write_block(block_1, durability='hard')
         # insert duplicate votes
-        vote_1 = b.vote(block_1, b.get_last_voted_block()['id'], True)
-        vote_2 = b.vote(block_1, b.get_last_voted_block()['id'], True)
+        vote_1 = b.vote(block_1['id'], b.get_last_voted_block()['id'], True)
+        vote_2 = b.vote(block_1['id'], b.get_last_voted_block()['id'], True)
         vote_2['node_pubkey'] = 'aaaaaaa'
         r.table('votes').insert(vote_1).run(b.conn)
         r.table('votes').insert(vote_2).run(b.conn)
@@ -355,7 +355,7 @@ class TestBigchainApi(object):
         b.write_block(block_1, durability='hard')
         # insert duplicate votes
         for i in range(2):
-            r.table('votes').insert(b.vote(block_1, genesis['id'], True)).run(b.conn)
+            r.table('votes').insert(b.vote(block_1['id'], genesis['id'], True)).run(b.conn)
 
         from bigchaindb.exceptions import MultipleVotesError
         with pytest.raises(MultipleVotesError) as excinfo:
@@ -372,7 +372,7 @@ class TestBigchainApi(object):
         b.create_genesis_block()
         block_1 = dummy_block()
         b.write_block(block_1, durability='hard')
-        vote_1 = b.vote(block_1, b.get_last_voted_block()['id'], True)
+        vote_1 = b.vote(block_1['id'], b.get_last_voted_block()['id'], True)
         # mangle the signature
         vote_1['signature'] = 'a' * 87
         r.table('votes').insert(vote_1).run(b.conn)
@@ -816,9 +816,9 @@ class TestBigchainBlock(object):
         b.write_block(block_2, durability='hard')
         b.write_block(block_3, durability='hard')
 
-        b.write_vote(block_1, b.vote(block_1, b.get_last_voted_block()['id'], True))
-        b.write_vote(block_2, b.vote(block_2, b.get_last_voted_block()['id'], True))
-        b.write_vote(block_3, b.vote(block_3, b.get_last_voted_block()['id'], True))
+        b.write_vote(block_1, b.vote(block_1['id'], b.get_last_voted_block()['id'], True))
+        b.write_vote(block_2, b.vote(block_2['id'], b.get_last_voted_block()['id'], True))
+        b.write_vote(block_3, b.vote(block_3['id'], b.get_last_voted_block()['id'], True))
 
         q_revert_delete = mp.Queue()
 
@@ -1115,7 +1115,7 @@ class TestMultipleInputs(object):
         b.write_block(block, durability='hard')
 
         # vote the block VALID
-        vote = b.vote(block, genesis['id'], True)
+        vote = b.vote(block['id'], genesis['id'], True)
         b.write_vote(block, vote)
 
         # get input
@@ -1131,7 +1131,7 @@ class TestMultipleInputs(object):
         b.write_block(block, durability='hard')
 
         # vote the block invalid
-        vote = b.vote(block, b.get_last_voted_block()['id'], False)
+        vote = b.vote(block['id'], b.get_last_voted_block()['id'], False)
         b.write_vote(block, vote)
 
         owned_inputs_user1 = b.get_owned_ids(user_vk)
@@ -1245,7 +1245,7 @@ class TestMultipleInputs(object):
         b.write_block(block, durability='hard')
 
         # vote the block VALID
-        vote = b.vote(block, genesis['id'], True)
+        vote = b.vote(block['id'], genesis['id'], True)
         b.write_vote(block, vote)
 
         # get input
@@ -1262,7 +1262,7 @@ class TestMultipleInputs(object):
         b.write_block(block, durability='hard')
 
         # vote the block invalid
-        vote = b.vote(block, b.get_last_voted_block()['id'], False)
+        vote = b.vote(block['id'], b.get_last_voted_block()['id'], False)
         b.write_vote(block, vote)
         response = b.get_transaction(tx_signed["id"])
         spent_inputs_user1 = b.get_spent(owned_inputs_user1[0])

--- a/tests/db/test_voter.py
+++ b/tests/db/test_voter.py
@@ -237,7 +237,7 @@ class TestBigchainVoter(object):
         # create valid block
         block = dummy_block()
         # retrieve vote
-        vote = b.vote(block, 'abc', True)
+        vote = b.vote(block['id'], 'abc', True)
 
         # assert vote is correct
         assert vote['vote']['voting_for_block'] == block['id']
@@ -251,7 +251,7 @@ class TestBigchainVoter(object):
         # create valid block
         block = dummy_block()
         # retrieve vote
-        vote = b.vote(block, 'abc', False)
+        vote = b.vote(block['id'], 'abc', False)
 
         # assert vote is correct
         assert vote['vote']['voting_for_block'] == block['id']
@@ -372,15 +372,15 @@ class TestBlockElection(object):
         test_block['block']['voters'] = [key_pair[1] for key_pair in key_pairs]
 
         # fake "yes" votes
-        valid_vote = [member.vote(test_block, 'abc', True)
+        valid_vote = [member.vote(test_block['id'], 'abc', True)
                       for member in test_federation]
 
         # fake "no" votes
-        invalid_vote = [member.vote(test_block, 'abc', False)
+        invalid_vote = [member.vote(test_block['id'], 'abc', False)
                         for member in test_federation]
 
         # fake "yes" votes with incorrect signatures
-        improperly_signed_valid_vote = [member.vote(test_block, 'abc', True) for
+        improperly_signed_valid_vote = [member.vote(test_block['id'], 'abc', True) for
                                         member in test_federation]
         [vote['vote'].update(this_should_ruin_things='lol')
          for vote in improperly_signed_valid_vote]
@@ -448,11 +448,11 @@ class TestBlockElection(object):
         test_block['block']['voters'] = [key_pair[1] for key_pair in key_pairs]
 
         # fake "yes" votes
-        valid_vote = [member.vote(test_block, 'abc', True)
+        valid_vote = [member.vote(test_block['id'], 'abc', True)
                       for member in test_federation]
 
         # fake "no" votes
-        invalid_vote = [member.vote(test_block, 'abc', False)
+        invalid_vote = [member.vote(test_block['id'], 'abc', False)
                         for member in test_federation]
 
         r.table('votes').insert(valid_vote[:2], durability='hard').run(b.conn)
@@ -490,12 +490,12 @@ class TestBlockElection(object):
         test_block_2['block']['voters'] = [key_pair[1] for key_pair in key_pairs]
 
         # votes for block one
-        vote_1 = [member.vote(test_block_1, 'abc', True)
+        vote_1 = [member.vote(test_block_1['id'], 'abc', True)
                       for member in test_federation]
 
         # votes for block two
-        vote_2 = [member.vote(test_block_2, 'abc', True) for member in test_federation[:2]] + \
-                       [member.vote(test_block_2, 'abc', False) for member in test_federation[2:]]
+        vote_2 = [member.vote(test_block_2['id'], 'abc', True) for member in test_federation[:2]] + \
+                       [member.vote(test_block_2['id'], 'abc', False) for member in test_federation[2:]]
 
         # construct valid block
         r.table('votes').insert(vote_1, durability='hard').run(b.conn)


### PR DESCRIPTION
The method in `bigchaindb/core.py::Bigchain::vote` accepts as first argument a `block` dictionary but in the code only the `block['id']` is used.

Having simpler requirements for the method will also help another refactoring I'm doing.