### PR TITLE
attempted drop to nonexistent database prints a friendly message

### DIFF
--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -22,7 +22,7 @@ from bigchaindb.client import temp_client
 from bigchaindb import db
 from bigchaindb.exceptions import (StartupError,
                                    DatabaseAlreadyExists,
-                                   KeypairNotFoundException)
+                                   KeypairNotFoundException, DatabaseDoesNotExist)
 from bigchaindb.commands import utils
 from bigchaindb.processes import Processes
 from bigchaindb import crypto
@@ -146,7 +146,13 @@ def run_init(args):
 def run_drop(args):
     """Drop the database"""
     bigchaindb.config_utils.autoconfigure(filename=args.config, force=True)
-    db.drop(assume_yes=args.yes)
+    try:
+        db_name = 'Unknown database'
+        if db != None: db_name = db.get_database_name()
+        db.drop(assume_yes=args.yes)
+    except DatabaseDoesNotExist:
+        print('Cannot drop \'{name}\'. The database does not exist.'.format(name=db_name), file=sys.stderr)
+        print('Consider initializing the database before attempting drop.', file=sys.stderr)
 
 
 def run_start(args):

--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -22,7 +22,8 @@ from bigchaindb.client import temp_client
 from bigchaindb import db
 from bigchaindb.exceptions import (StartupError,
                                    DatabaseAlreadyExists,
-                                   KeypairNotFoundException, DatabaseDoesNotExist)
+                                   KeypairNotFoundException,
+                                   DatabaseDoesNotExist)
 from bigchaindb.commands import utils
 from bigchaindb.processes import Processes
 from bigchaindb import crypto
@@ -147,10 +148,9 @@ def run_drop(args):
     """Drop the database"""
     bigchaindb.config_utils.autoconfigure(filename=args.config, force=True)
     try:
-        db_name = 'Unknown database'
-        if db != None: db_name = db.get_database_name()
         db.drop(assume_yes=args.yes)
     except DatabaseDoesNotExist:
+        db_name = db.get_database_name()
         print('Cannot drop \'{name}\'. The database does not exist.'.format(name=db_name), file=sys.stderr)
         print('Consider initializing the database before attempting drop.', file=sys.stderr)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -47,6 +47,17 @@ def mock_rethink_db_drop(monkeypatch):
 
 
 @pytest.fixture
+def mock_rethink_db_drop_not_exist(monkeypatch):
+    def mockreturn(dbname):
+        class MockDropped(object):
+            def run(self, conn):
+                from bigchaindb.exceptions import DatabaseDoesNotExist
+                raise DatabaseDoesNotExist
+        return MockDropped()
+    monkeypatch.setattr('rethinkdb.db_drop', mockreturn)
+
+
+@pytest.fixture
 def mock_generate_key_pair(monkeypatch):
     monkeypatch.setattr('bigchaindb.crypto.generate_key_pair', lambda: ('privkey', 'pubkey'))
 
@@ -164,6 +175,12 @@ def test_bigchain_run_init_when_db_exists(mock_db_init_with_existing_db):
 
 
 def test_drop_existing_db(mock_rethink_db_drop):
+    from bigchaindb.commands.bigchain import run_drop
+    args = Namespace(config=None, yes=True)
+    run_drop(args)
+
+
+def test_drop_non_existing_db(mock_rethink_db_drop_not_exist):
     from bigchaindb.commands.bigchain import run_drop
     args = Namespace(config=None, yes=True)
     run_drop(args)


### PR DESCRIPTION
Implemented a simple except clause to print a human readable error message if 'drop' is called for a non-existent database.

Update:
Tests have been properly implemented
~~No tests have been updated due to conformance with the existing unit-test scheme (test suite does not address failures)~~

Related: #437