### PR TITLE
Feat/439/connect multiple nodes docker

### DIFF
--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -156,7 +156,11 @@ def run_start(args):
 
     if args.start_rethinkdb:
         try:
-            proc = utils.start_rethinkdb()
+            # For sake of simplicity, args.start_rethinkdb holds either true or a join address
+            if args.start_rethinkdb is True:
+                proc = utils.start_rethinkdb()
+            else:
+                proc = utils.start_rethinkdb(args.start_rethinkdb)
         except StartupError as e:
             sys.exit('Error starting RethinkDB, reason is: {}'.format(e))
         logger.info('RethinkDB started with PID %s' % proc.pid)
@@ -238,6 +242,11 @@ def main():
                         dest='start_rethinkdb',
                         action='store_true',
                         help='Run RethinkDB on start')
+
+    parser.add_argument('--experimental-join',
+                        dest='start_rethinkdb',
+                        action='store',
+                        help='Join to an existing BigChainDB Node')
 
     # all the commands are contained in the subparsers object,
     # the command selected by the user will be stored in `args.command`

--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -158,7 +158,7 @@ def run_start(args):
         try:
             if args.start_rethinkdb is True:
                 proc = utils.start_rethinkdb()
-            elif args.start_rethinkdb == '-auto':
+            elif args.start_rethinkdb == 'auto':
                 proc = utils.start_rethinkdb(utils.find_rethinkdb_host())
             else:
                 proc = utils.start_rethinkdb(args.start_rethinkdb)
@@ -247,16 +247,16 @@ def main():
     parser.add_argument('--experimental-join',
                         dest='start_rethinkdb',
                         action='store',
-                        help='Join to an existing BigChainDB Node '
+                        help='Join to an existing BigchainDB Node '
                              '- START_RETHINKDB holds the '
                              'Address of the RethinkDB server')
 
     parser.add_argument('--experimental-join-auto',
                         dest='start_rethinkdb',
                         action='store_const',
-                        const='-auto',
-                        help='Join to an existing BigChainDB '
-                             'Node supplied by looking up into the hosts file')
+                        const='auto',
+                        help='Join to an existing BigchainDB '
+                             'Node supplied by looking up into the hosts file - Container must be named `bigchaindb`')
 
     # all the commands are contained in the subparsers object,
     # the command selected by the user will be stored in `args.command`

--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -154,10 +154,12 @@ def run_start(args):
     logger.info('BigchainDB Version {}'.format(bigchaindb.__version__))
     bigchaindb.config_utils.autoconfigure(filename=args.config, force=True)
 
-    if args.start_rethinkdb:
+    if args.start_rethinkdb or args.start_rethinkdb_auto:
         try:
+            if args.start_rethinkdb_auto:
+                proc = utils.start_rethinkdb(utils.find_rethinkdb_host())
             # For sake of simplicity, args.start_rethinkdb holds either true or a join address
-            if args.start_rethinkdb is True:
+            elif args.start_rethinkdb is True:
                 proc = utils.start_rethinkdb()
             else:
                 proc = utils.start_rethinkdb(args.start_rethinkdb)
@@ -246,7 +248,15 @@ def main():
     parser.add_argument('--experimental-join',
                         dest='start_rethinkdb',
                         action='store',
-                        help='Join to an existing BigChainDB Node')
+                        help='Join to an existing BigChainDB Node '
+                             '- START_RETHINKDB holds the '
+                             'Address of the RethinkDB server')
+
+    parser.add_argument('--experimental-join-auto',
+                        dest='start_rethinkdb_auto',
+                        action='store_true',
+                        help='Join to an existing BigChainDB '
+                             'Node supplied by looking up into the hosts file')
 
     # all the commands are contained in the subparsers object,
     # the command selected by the user will be stored in `args.command`

--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -154,13 +154,12 @@ def run_start(args):
     logger.info('BigchainDB Version {}'.format(bigchaindb.__version__))
     bigchaindb.config_utils.autoconfigure(filename=args.config, force=True)
 
-    if args.start_rethinkdb or args.start_rethinkdb_auto:
+    if args.start_rethinkdb:
         try:
-            if args.start_rethinkdb_auto:
-                proc = utils.start_rethinkdb(utils.find_rethinkdb_host())
-            # For sake of simplicity, args.start_rethinkdb holds either true or a join address
-            elif args.start_rethinkdb is True:
+            if args.start_rethinkdb is True:
                 proc = utils.start_rethinkdb()
+            elif args.start_rethinkdb == '-auto':
+                proc = utils.start_rethinkdb(utils.find_rethinkdb_host())
             else:
                 proc = utils.start_rethinkdb(args.start_rethinkdb)
         except StartupError as e:
@@ -253,8 +252,9 @@ def main():
                              'Address of the RethinkDB server')
 
     parser.add_argument('--experimental-join-auto',
-                        dest='start_rethinkdb_auto',
-                        action='store_true',
+                        dest='start_rethinkdb',
+                        action='store_const',
+                        const='-auto',
                         help='Join to an existing BigChainDB '
                              'Node supplied by looking up into the hosts file')
 

--- a/bigchaindb/commands/utils.py
+++ b/bigchaindb/commands/utils.py
@@ -14,6 +14,28 @@ from bigchaindb import db
 from bigchaindb.version import __version__
 
 
+def find_rethinkdb_host():
+    """Utility function to find the bigchainDB host
+    linked by docker with ``--link <container_name>`
+    DISCLAIMER: This is a really dummy function, but should work as long as --link
+    option in docker maintains its consistency
+
+    Returns:
+        IP Address of the host machine plus the default port to connect
+    """
+    default_port = '29015'
+
+    proc = subprocess.Popen(['cat', '/etc/hosts'],
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT,
+                            universal_newlines=True)
+    lines = proc.stdout.readlines()
+    if len(lines) < 6:
+        raise StartupError('Expected default hosts format for docker simple container.')
+    ret_value = lines[6].split("\t")[0]
+    return ret_value + ":" + default_port
+
+
 def start_rethinkdb(join_address=None):
     """Start RethinkDB as a child process and wait for it to be
     available.

--- a/bigchaindb/commands/utils.py
+++ b/bigchaindb/commands/utils.py
@@ -14,16 +14,24 @@ from bigchaindb import db
 from bigchaindb.version import __version__
 
 
-def start_rethinkdb():
+def start_rethinkdb(join_address=None):
     """Start RethinkDB as a child process and wait for it to be
     available.
+
+    Args:
+        join_address (string): starts rethink db joining an existent node if provided
 
     Raises:
         ``bigchaindb.exceptions.StartupError`` if RethinkDB cannot
         be started.
     """
 
-    proc = subprocess.Popen(['rethinkdb', '--bind', 'all'],
+    def_args = ['rethinkdb', '--bind', 'all']
+
+    if join_address is not None:
+        def_args += ['--join', join_address]
+
+    proc = subprocess.Popen(def_args,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT,
                             universal_newlines=True)

--- a/bigchaindb/commands/utils.py
+++ b/bigchaindb/commands/utils.py
@@ -18,22 +18,21 @@ def find_rethinkdb_host():
     """Utility function to find the bigchainDB host
     linked by docker with ``--link <container_name>`
     DISCLAIMER: This is a really dummy function, but should work as long as --link
-    option in docker maintains its consistency
+    option in docker maintains its consistency (and the container name is called ``bigchaindb``
 
     Returns:
         IP Address of the host machine plus the default port to connect
     """
     default_port = '29015'
 
-    proc = subprocess.Popen(['cat', '/etc/hosts'],
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.STDOUT,
-                            universal_newlines=True)
-    lines = proc.stdout.readlines()
-    if len(lines) < 6:
-        raise StartupError('Expected default hosts format for docker simple container.')
-    ret_value = lines[6].split("\t")[0]
-    return ret_value + ":" + default_port
+    with open('/etc/hosts', encoding='utf-8') as fin:
+        for line in fin:
+            if line.find('bigchaindb') != -1:
+                fin.close()
+                return line.split("\t")[0] + ":" + default_port
+        fin.close()
+        raise StartupError('Expected default hosts format for docker simple container. '
+                           'Does your linked machine has a different name then `bigchaindb`?')
 
 
 def start_rethinkdb(join_address=None):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -361,3 +361,12 @@ def test_find_rethinkdb_host():
     with patch('builtins.open', return_value=fake_file, create=True):
         from bigchaindb.commands import utils
         assert utils.find_rethinkdb_host() == "127.0.0.1:29015"
+
+
+def test_find_rethinkdb_host_fails():
+    fake_file = StringIO('#EXAMPLE HOSTS FILE\n127.0.0.1\tnotBigchaindb\n')
+    with patch('builtins.open', return_value=fake_file, create=True):
+        from bigchaindb.commands import utils
+        from bigchaindb import exceptions
+        with pytest.raises(exceptions.StartupError):
+            utils.find_rethinkdb_host()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -91,6 +91,15 @@ def test_bigchain_run_start_with_rethinkdb_join(mock_start_rethinkdb,
 
     mock_start_rethinkdb.assert_called_with('127.0.0.1')
 
+    
+def test_bigchain_run_start_with_rethinkdb_join_fails():
+
+    from bigchaindb.commands.bigchain import run_start
+    args = Namespace(start_rethinkdb='invalid_host', config=None, yes=True)
+    with pytest.raises(SystemExit):
+        run_start(args)
+
+
 @patch('bigchaindb.commands.utils.start_rethinkdb')
 def test_bigchain_run_start_with_rethinkdb_join_auto(mock_start_rethinkdb,
                                            mock_run_configure,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,5 +1,6 @@
 import json
-from unittest.mock import Mock, patch
+from io import StringIO
+from unittest.mock import Mock, patch, mock_open
 from argparse import Namespace
 import copy
 
@@ -328,3 +329,10 @@ def test_start_rethinkdb_join_exits_when_cannot_start(mock_popen):
     mock_popen.return_value = Mock(stdout=['Nopety nope - no joining'])
     with pytest.raises(exceptions.StartupError):
         utils.start_rethinkdb('127.0.0.1')
+
+
+def test_find_rethinkdb_host():
+    fake_file = StringIO('#EXAMPLE HOSTS FILE\n127.0.0.1\tbigchaindb\n')
+    with patch('builtins.open', return_value=fake_file, create=True):
+        from bigchaindb.commands import utils
+        assert utils.find_rethinkdb_host() == "127.0.0.1:29015"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -91,6 +91,19 @@ def test_bigchain_run_start_with_rethinkdb_join(mock_start_rethinkdb,
 
     mock_start_rethinkdb.assert_called_with('127.0.0.1')
 
+@patch('bigchaindb.commands.utils.start_rethinkdb')
+def test_bigchain_run_start_with_rethinkdb_join_auto(mock_start_rethinkdb,
+                                           mock_run_configure,
+                                           mock_processes_start,
+                                           mock_db_init_with_existing_db):
+    fake_file = StringIO('#EXAMPLE HOSTS FILE\n127.0.0.1\tbigchaindb\n')
+    with patch('builtins.open', return_value=fake_file, create=True):
+        from bigchaindb.commands.bigchain import run_start
+        args = Namespace(start_rethinkdb='auto', config=None, yes=True)
+        run_start(args)
+
+        mock_start_rethinkdb.assert_called_with('127.0.0.1:29015')
+
 
 @pytest.mark.skipif(reason="BigchainDB doesn't support the automatic creation of a config file anymore")
 def test_bigchain_run_start_assume_yes_create_default_config(monkeypatch, mock_processes_start,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -80,6 +80,18 @@ def test_bigchain_run_start_with_rethinkdb(mock_start_rethinkdb,
     mock_start_rethinkdb.assert_called_with()
 
 
+@patch('bigchaindb.commands.utils.start_rethinkdb')
+def test_bigchain_run_start_with_rethinkdb_join(mock_start_rethinkdb,
+                                           mock_run_configure,
+                                           mock_processes_start,
+                                           mock_db_init_with_existing_db):
+    from bigchaindb.commands.bigchain import run_start
+    args = Namespace(start_rethinkdb='127.0.0.1', config=None, yes=True)
+    run_start(args)
+
+    mock_start_rethinkdb.assert_called_with('127.0.0.1')
+
+
 @pytest.mark.skipif(reason="BigchainDB doesn't support the automatic creation of a config file anymore")
 def test_bigchain_run_start_assume_yes_create_default_config(monkeypatch, mock_processes_start,
                                                              mock_generate_key_pair, mock_db_init_with_existing_db):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -312,3 +312,19 @@ def test_set_replicas_raises_exception(mock_log, monkeypatch, b):
     run_set_replicas(args)
 
     assert mock_log.called
+
+
+@patch('subprocess.Popen')
+def test_start_rethinkdb_join_returns_a_process_when_successful(mock_popen):
+    from bigchaindb.commands import utils
+    mock_popen.return_value = Mock(stdout=['Server ready - Gonna join ya'])
+    assert utils.start_rethinkdb('127.0.0.1') is mock_popen.return_value
+
+
+@patch('subprocess.Popen')
+def test_start_rethinkdb_join_exits_when_cannot_start(mock_popen):
+    from bigchaindb import exceptions
+    from bigchaindb.commands import utils
+    mock_popen.return_value = Mock(stdout=['Nopety nope - no joining'])
+    with pytest.raises(exceptions.StartupError):
+        utils.start_rethinkdb('127.0.0.1')


### PR DESCRIPTION
Assuming that:

We're using the flag **--link** when creating the docker containers that will link to the first one.

Lacking tests for the two commands i've created as I didn't see a easy way through connecting the test tools to the creation of docker containers (I could've tested it natively but was having a lot of trouble with conflicts)