### PR TITLE
Add support for multiple ops in ChangeFeed

### DIFF
--- a/bigchaindb/pipelines/election.py
+++ b/bigchaindb/pipelines/election.py
@@ -44,7 +44,7 @@ class Election:
 
 
 def get_changefeed():
-    return ChangeFeed(table='votes', operation='insert')
+    return ChangeFeed(table='votes', operation=ChangeFeed.INSERT)
 
 
 def create_pipeline():

--- a/bigchaindb/pipelines/vote.py
+++ b/bigchaindb/pipelines/vote.py
@@ -144,7 +144,7 @@ def initial():
 def get_changefeed():
     """Create and return the changefeed for the bigchain table."""
 
-    return ChangeFeed('bigchain', 'insert', prefeed=initial())
+    return ChangeFeed('bigchain', operation=ChangeFeed.INSERT, prefeed=initial())
 
 
 def create_pipeline():


### PR DESCRIPTION
This PR is to add support to listen to multiple operations in the ChangeFeed class.

(PR #359 depends on this one)