### PR TITLE
Do not pin version of requests in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
         'logstats==0.2.1',
         'base58==0.2.2',
         'flask==0.10.1',
-        'requests==2.9',
+        'requests~=2.9',
         'gunicorn~=19.0',
         'multipipes~=0.1.0',
     ],


### PR DESCRIPTION
According to the [Python Packaging User Guide](https://packaging.python.org/) under the [install_requires](https://packaging.python.org/requirements/#install-requires) section:

> `install_requires` is a setuptools `setup.py` keyword that should be used to specify what a project **minimally** needs to run correctly. When the project is installed by pip, this is the specification that is used to install its dependencies.

and 

> It is not considered best practice to use `install_requires` to pin dependencies to specific versions, or to specify sub-dependencies (i.e. dependencies of your dependencies). This is overly-restrictive, and prevents the user from gaining the benefit of dependency upgrades.

On travis, the following occurred when testing the client code, which required `requests==2.11.1`

```bash
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.5.2/lib/python3.5/site-packages/pkg_resources/__init__.py", line 612, in _build_master
    ws.require(__requires__)
  File "/home/travis/virtualenv/python3.5.2/lib/python3.5/site-packages/pkg_resources/__init__.py", line 918, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/home/travis/virtualenv/python3.5.2/lib/python3.5/site-packages/pkg_resources/__init__.py", line 810, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (requests 2.11.1 (/home/travis/virtualenv/python3.5.2/lib/python3.5/site-packages), Requirement.parse('requests==2.9'), {'BigchainDB'})
 ```

Hence, if a dependency version is pinned, users of are constrained to use that version.