### PR TITLE
Bug/593/write transaction no sideeffects

### DIFF
--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -1,6 +1,7 @@
 import random
 import math
 import collections
+from copy import deepcopy
 
 from itertools import compress
 import rethinkdb as r
@@ -130,6 +131,9 @@ class Bigchain(object):
             # I am the only node
             assignee = self.me
 
+        # We copy the transaction here to not add `assignee` to the transaction
+        # dictionary passed to this method (as it would update by reference).
+        signed_transaction = deepcopy(signed_transaction)
         # update the transaction
         signed_transaction.update({'assignee': assignee})
 
@@ -151,7 +155,7 @@ class Bigchain(object):
         Returns:
             A dict with the transaction details if the transaction was found.
             Will add the transaction status to payload ('valid', 'undecided',
-            or 'backlog'). If no transaction with that `txid` was found it 
+            or 'backlog'). If no transaction with that `txid` was found it
             returns `None`
         """
 

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -83,7 +83,6 @@ class TestBigchainApi(object):
         assert b.validate_fulfillments(tx) == False
         assert b.validate_fulfillments(tx_signed) == True
 
-
     def test_transaction_signature(self, b, user_sk, user_vk):
         tx = b.create_transaction(user_vk, user_vk, None, 'CREATE')
         tx_signed = b.sign_transaction(tx, user_sk)
@@ -132,6 +131,7 @@ class TestBigchainApi(object):
         b.write_transaction(tx_signed)
 
         response, status = b.get_transaction(tx_signed["id"], include_status=True)
+        response.pop('assignee')
         # add validity information, which will be returned
         assert util.serialize(tx_signed) == util.serialize(response)
         assert status == b.TX_IN_BACKLOG

--- a/tests/pipelines/test_block_creation.py
+++ b/tests/pipelines/test_block_creation.py
@@ -76,7 +76,9 @@ def test_delete_tx(b, user_vk):
     tx = b.sign_transaction(tx, b.me_private)
     b.write_transaction(tx)
 
-    assert r.table('backlog').get(tx['id']).run(b.conn) == tx
+    tx_backlog = r.table('backlog').get(tx['id']).run(b.conn)
+    tx_backlog.pop('assignee')
+    assert tx_backlog == tx
 
     returned_tx = block_maker.delete_tx(tx)
 

--- a/tests/pipelines/test_election.py
+++ b/tests/pipelines/test_election.py
@@ -97,8 +97,10 @@ def test_check_requeue_transaction(b, user_vk):
     test_block = b.create_block([tx1])
 
     e.requeue_transactions(test_block)
+    tx_backlog = r.table('backlog').get(tx1['id']).run(b.conn)
+    tx_backlog.pop('assignee')
 
-    assert r.table('backlog').get(tx1['id']).run(b.conn) == tx1
+    assert tx_backlog == tx1
 
 
 @patch.object(Pipeline, 'start')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -95,3 +95,14 @@ def test_transaction_exists(monkeypatch, items, exists):
         RqlQuery, 'run', lambda x, y: namedtuple('response', 'items')(items))
     bigchain = Bigchain(public_key='pubkey', private_key='privkey')
     assert bigchain.transaction_exists('txid') is exists
+
+
+def test_write_transaction_no_sideffects(b):
+    from rethinkdb.errors import ReqlOpFailedError
+    transaction = {'id': 'abc'}
+    expected = {'id': 'abc'}
+    with pytest.raises(ReqlOpFailedError):
+        b.write_transaction(transaction)
+    assert transaction == expected
+    with pytest.raises(KeyError):
+        transaction['assignee']


### PR DESCRIPTION
Had troubles with passing the tests in the driver as bigchaindb's http server adds `assignee` as a key to a transaction submitted to be written into the backlog.
This PR simply removes the reference to the passed transaction dict in `write_transaction` by copying the dict