### PR TITLE
Add integration testing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ tests_require = [
     'pep8',
     'flake8',
     'pylint',
-    'pytest',
+    'pytest>=3.0.0',
     'pytest-cov>=2.2.1',
     'pytest-xdist',
     'pytest-flask',

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,35 @@
+import pytest
+from bigchaindb.pipelines import block, election, vote, stale
+
+# TODO: fix this import madness
+from ..db import conftest
+
+
+@pytest.fixture(scope='module', autouse=True)
+def restore_config(request, node_config):
+    from bigchaindb import config_utils
+    config_utils.set_config(node_config)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_database(request, node_config):
+    conftest.setup_database(request, node_config)
+
+
+@pytest.fixture(scope='function', autouse=True)
+def cleanup_tables(request, node_config):
+    conftest.cleanup_tables(request, node_config)
+
+
+@pytest.fixture
+def processes(b):
+    b.create_genesis_block()
+    block_maker = block.start()
+    voter = vote.start()
+    election_runner = election.start()
+    stale_monitor = stale.start()
+    yield
+    block_maker.terminate()
+    voter.terminate()
+    election_runner.terminate()
+    stale_monitor.terminate()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,0 +1,66 @@
+import time
+import pytest
+
+from bigchaindb import Bigchain
+
+
+@pytest.fixture
+def inputs(user_pk):
+    from bigchaindb.models import Transaction
+
+    b = Bigchain()
+
+    # create blocks with transactions for `USER` to spend
+    for block in range(4):
+        transactions = [
+            Transaction.create(
+                [b.me], [([user_pk], 1)],
+                metadata={'i': i})
+            .sign([b.me_private])
+            for i in range(10)
+        ]
+        block = b.create_block(transactions)
+        b.write_block(block, durability='hard')
+
+
+@pytest.mark.usefixtures('processes')
+def test_fast_double_create(b, user_pk):
+    from bigchaindb.models import Transaction
+    tx = Transaction.create([b.me], [([user_pk], 1)],
+                            metadata={'test': 'test'}) \
+            .sign([b.me_private])
+
+    # write everything fast
+    b.write_transaction(tx)
+    b.write_transaction(tx)
+
+    time.sleep(2)
+    tx_returned = b.get_transaction(tx.id)
+
+    # test that the tx can be queried
+    assert tx_returned == tx
+    # test the transaction appears only once
+    last_voted_block = b.get_last_voted_block()
+    assert len(last_voted_block.transactions) == 1
+    assert b.backend.count_blocks() == 2
+
+
+@pytest.mark.usefixtures('processes')
+def test_double_create(b, user_pk):
+    from bigchaindb.models import Transaction
+    tx = Transaction.create([b.me], [([user_pk], 1)],
+                            metadata={'test': 'test'}) \
+            .sign([b.me_private])
+
+    b.write_transaction(tx)
+    time.sleep(2)
+    b.write_transaction(tx)
+    time.sleep(2)
+    tx_returned = b.get_transaction(tx.id)
+
+    # test that the tx can be queried
+    assert tx_returned == tx
+    # test the transaction appears only once
+    last_voted_block = b.get_last_voted_block()
+    assert len(last_voted_block.transactions) == 1
+    assert b.backend.count_blocks() == 2


### PR DESCRIPTION
This PR has morphed somewhat. Main addition is a new test folder for integration tests.

The fixture starts up the `vote`, `block`, etc processes for each test.  I also included some sample tests.
