### PR TITLE
Allow temporary keypair if no conf file found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV BIGCHAINDB_CONFIG_PATH /data/.bigchaindb
 ENV BIGCHAINDB_SERVER_BIND 0.0.0.0:9984
 ENV BIGCHAINDB_API_ENDPOINT http://bigchaindb:9984/api/v1
 
-ENTRYPOINT ["bigchaindb", "--experimental-start-rethinkdb"]
+ENTRYPOINT ["bigchaindb", "--dev-start-rethinkdb", "--dev-allow-temp-keypair"]
 
 CMD ["start"]
 

--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -245,8 +245,7 @@ def run_set_replicas(args):
         except r.ReqlOpFailedError as e:
             logger.warn(e)
 
-
-def main():
+def create_parser():
     parser = argparse.ArgumentParser(
         description='Control your BigchainDB node.',
         parents=[utils.base_parser])
@@ -325,8 +324,8 @@ def main():
                                   'is set, the count is distributed equally to all the '
                                   'processes')
 
-    utils.start(parser, globals())
+    return parser
 
 
-if __name__ == '__main__':
-    main()
+def main():
+    utils.start(create_parser(), sys.argv[1:], globals())

--- a/bigchaindb/commands/utils.py
+++ b/bigchaindb/commands/utils.py
@@ -59,7 +59,7 @@ def start_rethinkdb():
     raise StartupError(line)
 
 
-def start(parser, scope):
+def start(parser, argv, scope):
     """Utility function to execute a subcommand.
 
     The function will look up in the ``scope``
@@ -74,11 +74,11 @@ def start(parser, scope):
         NotImplementedError: if ``scope`` doesn't contain a function called
                              ``run_<parser.args.command>``.
     """
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if not args.command:
         parser.print_help()
-        return
+        raise SystemExit()
 
     # look up in the current scope for a function called 'run_<command>'
     # replacing all the dashes '-' with the lowercase character '_'
@@ -96,7 +96,7 @@ def start(parser, scope):
     elif args.multiprocess is None:
         args.multiprocess = mp.cpu_count()
 
-    func(args)
+    return func(args)
 
 
 base_parser = argparse.ArgumentParser(add_help=False, prog='bigchaindb')

--- a/bigchaindb/commands/utils.py
+++ b/bigchaindb/commands/utils.py
@@ -68,6 +68,7 @@ def start(parser, argv, scope):
 
     Args:
         parser: an ArgumentParser instance.
+        argv: the list of command line arguments without the script name.
         scope (dict): map containing (eventually) the functions to be called.
 
     Raises:

--- a/docs/source/server-reference/bigchaindb-cli.md
+++ b/docs/source/server-reference/bigchaindb-cli.md
@@ -58,8 +58,9 @@ Drop (erase) the RethinkDB database. You will be prompted to make sure. If you w
 ## bigchaindb start
 
 Start BigchainDB. It always begins by trying a `bigchaindb init` first. See the note in the documentation for `bigchaindb init`.
-You can also use the `--experimental-start-rethinkdb` command line option to automatically start rethinkdb with bigchaindb if rethinkdb is not already running,
-e.g. `bigchaindb --experimental-start-rethinkdb start`. Note that this will also shutdown rethinkdb when the bigchaindb process stops.
+You can also use the `--dev-start-rethinkdb` command line option to automatically start rethinkdb with bigchaindb if rethinkdb is not already running,
+e.g. `bigchaindb --dev-start-rethinkdb start`. Note that this will also shutdown rethinkdb when the bigchaindb process stops.
+The option `--dev-allow-temp-keypair` will generate a keypair on the fly if no keypair is found, this is useful when you want to run a temporary instance of BigchainDB in a Docker container, for example.
 
 
 ## bigchaindb load

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -103,11 +103,11 @@ def test_start_raises_if_no_arguments_given():
 
 @patch('multiprocessing.cpu_count', return_value=42)
 def test_start_sets_multiprocess_var_based_on_cli_args(mock_cpu_count):
-    def run_load(args):
-        return args
-
     from bigchaindb.commands.bigchain import utils
     from bigchaindb.commands.bigchain import create_parser
+
+    def run_load(args):
+        return args
 
     parser = create_parser()
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -66,6 +66,7 @@ def test_make_sure_we_dont_remove_any_command():
     # thanks to: http://stackoverflow.com/a/18161115/597097
     from bigchaindb.commands.bigchain import utils
     from bigchaindb.commands.bigchain import create_parser
+
     parser = create_parser()
 
     with pytest.raises(SystemExit):
@@ -80,6 +81,32 @@ def test_make_sure_we_dont_remove_any_command():
     assert parser.parse_args(['set-shards', '1']).command
     assert parser.parse_args(['set-replicas', '1']).command
     assert parser.parse_args(['load']).command
+
+
+def test_start_raises_if_command_not_implemented():
+    from bigchaindb.commands.bigchain import utils
+    from bigchaindb.commands.bigchain import create_parser
+
+    parser = create_parser()
+
+    with pytest.raises(NotImplementedError):
+        # Will raise because `scope`, the third parameter,
+        # doesn't contain the function `run_configure`
+        utils.start(parser, ['configure'], {})
+
+
+@patch('multiprocessing.cpu_count', return_value=42)
+def test_start_sets_multiprocess_var_based_on_cli_args(mock_cpu_count):
+    def run_load(args):
+        return args
+
+    from bigchaindb.commands.bigchain import utils
+    from bigchaindb.commands.bigchain import create_parser
+
+    parser = create_parser()
+
+    assert utils.start(parser, ['load'], {'run_load': run_load}).multiprocess == 1
+    assert utils.start(parser, ['load', '--multiprocess'], {'run_load': run_load}).multiprocess == 42
 
 
 @patch('bigchaindb.commands.utils.start')

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -316,14 +316,17 @@ def test_allow_temp_keypair_doesnt_override_if_keypair_found(mock_gen_keypair,
     from bigchaindb.commands.bigchain import run_start
 
     # Preconditions for the test
-    assert isinstance(bigchaindb.config['keypair']['private'], str)
-    assert isinstance(bigchaindb.config['keypair']['public'], str)
+    original_private_key = bigchaindb.config['keypair']['private']
+    original_public_key = bigchaindb.config['keypair']['public']
+
+    assert isinstance(original_public_key, str)
+    assert isinstance(original_private_key, str)
 
     args = Namespace(allow_temp_keypair=True, start_rethinkdb=False, config=None, yes=True)
     run_start(args)
 
-    assert bigchaindb.config['keypair']['private'] != 'private_key'
-    assert bigchaindb.config['keypair']['public'] != 'public_key'
+    assert bigchaindb.config['keypair']['private'] == original_private_key
+    assert bigchaindb.config['keypair']['public'] == original_public_key
 
 
 @patch('rethinkdb.ast.Table.reconfigure')

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -62,6 +62,34 @@ def mock_bigchaindb_backup_config(monkeypatch):
     monkeypatch.setattr('bigchaindb._config', config)
 
 
+def test_make_sure_we_dont_remove_any_command():
+    # thanks to: http://stackoverflow.com/a/18161115/597097
+    from bigchaindb.commands.bigchain import utils
+    from bigchaindb.commands.bigchain import create_parser
+    parser = create_parser()
+
+    with pytest.raises(SystemExit):
+        utils.start(parser, [], {})
+
+    assert parser.parse_args(['configure']).command
+    assert parser.parse_args(['show-config']).command
+    assert parser.parse_args(['export-my-pubkey']).command
+    assert parser.parse_args(['init']).command
+    assert parser.parse_args(['drop']).command
+    assert parser.parse_args(['start']).command
+    assert parser.parse_args(['set-shards', '1']).command
+    assert parser.parse_args(['set-replicas', '1']).command
+    assert parser.parse_args(['load']).command
+
+
+@patch('bigchaindb.commands.utils.start')
+def test_main_entrypoint(mock_start):
+    from bigchaindb.commands.bigchain import main
+    main()
+
+    assert mock_start.called
+
+
 def test_bigchain_run_start(mock_run_configure, mock_processes_start, mock_db_init_with_existing_db):
     from bigchaindb.commands.bigchain import run_start
     args = Namespace(start_rethinkdb=False, allow_temp_keypair=False, config=None, yes=True)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -64,13 +64,9 @@ def mock_bigchaindb_backup_config(monkeypatch):
 
 def test_make_sure_we_dont_remove_any_command():
     # thanks to: http://stackoverflow.com/a/18161115/597097
-    from bigchaindb.commands.bigchain import utils
     from bigchaindb.commands.bigchain import create_parser
 
     parser = create_parser()
-
-    with pytest.raises(SystemExit):
-        utils.start(parser, [], {})
 
     assert parser.parse_args(['configure']).command
     assert parser.parse_args(['show-config']).command
@@ -93,6 +89,16 @@ def test_start_raises_if_command_not_implemented():
         # Will raise because `scope`, the third parameter,
         # doesn't contain the function `run_configure`
         utils.start(parser, ['configure'], {})
+
+
+def test_start_raises_if_no_arguments_given():
+    from bigchaindb.commands.bigchain import utils
+    from bigchaindb.commands.bigchain import create_parser
+
+    parser = create_parser()
+
+    with pytest.raises(SystemExit):
+        utils.start(parser, [], {})
 
 
 @patch('multiprocessing.cpu_count', return_value=42)


### PR DESCRIPTION
I've updated also the `Dockerfile` to use the new `--allow-temp-keypair` on startup.

Closes #482, closes #559 
