### PR TITLE
Improve the docker setup

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,12 +1,32 @@
-FROM python:3.5
+FROM ubuntu:xenial
 
-RUN apt-get update
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+    apt-get -y dist-upgrade && \
+    apt-get -y install g++ python3 python3-pip && \
+    pip3 install --upgrade pip setuptools && \
+    apt-get -y auto-remove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-
-RUN pip install --upgrade pip
-
 COPY . /usr/src/app/
+WORKDIR /usr/src/app
+RUN pip3 install --no-cache-dir -e .[dev]
 
-RUN pip install --no-cache-dir -e .[dev]
+VOLUME ["/data"]
+WORKDIR /data
+
+ENV BIGCHAINDB_CONFIG_PATH /data/.bigchaindb
+ENV BIGCHAINDB_SERVER_BIND 0.0.0.0:9984
+ENV BIGCHAINDB_API_ENDPOINT http://bdb:9984/api/v1
+ENV BIGCHAINDB_DATABASE_HOST: rdb
+ENV BIGCHAINDB_DATABASE_NAME: bigchaindb
+
+EXPOSE 9984 28015 29015
+
+COPY ./docker-start.sh /start.sh
+RUN chmod a+x /start.sh
+
+CMD ["/start.sh"]

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -13,10 +13,10 @@ RUN apt-get update && \
 RUN mkdir -p /usr/src/app
 COPY . /usr/src/app/
 WORKDIR /usr/src/app
+
 RUN pip3 install --no-cache-dir -e .[dev]
 
 VOLUME ["/data"]
-WORKDIR /data
 
 ENV BIGCHAINDB_CONFIG_PATH /data/.bigchaindb
 ENV BIGCHAINDB_SERVER_BIND 0.0.0.0:9984

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,8 @@ services:
       - ./setup.cfg:/usr/src/app/setup.cfg
       - ./pytest.ini:/usr/src/app/pytest.ini
       - ~/.bigchaindb_docker:/root/.bigchaindb_docker
+    ports:
+      - "59984:9984"
     environment:
       BIGCHAINDB_DATABASE_HOST: rdb
       BIGCHAINDB_CONFIG_PATH: /root/.bigchaindb_docker/config
-    command: bigchaindb start

--- a/docker-start-rethinkdb.sh
+++ b/docker-start-rethinkdb.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ ! -f "$BIGCHAINDB_CONFIG_PATH"  -a ! -d "$BIGCHAINDB_CONFIG_PATH" ]; then
+  bigchaindb -y configure
+fi
+
+bigchaindb --experimental-start-rethinkdb start

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+while ! timeout 1 bash -c "cat < /dev/null > /dev/tcp/$BIGCHAINDB_DATABASE_HOST/28015"; do sleep 1; done
+sleep 5
+
+if [ ! -f "$BIGCHAINDB_CONFIG_PATH"  -a ! -d "$BIGCHAINDB_CONFIG_PATH" ]; then
+  bigchaindb -y configure
+fi
+
+bigchaindb start


### PR DESCRIPTION
This change adds some best practices to the docker setup
- fully up to date operating system (Ubuntu 16.04 LTS)
- latest python3/rethink from the repo’s
- cleanup the images to decrease size
- add a default volume to persist the data
- add a start script that checks if rethink is up (otherwise the bigchain image just fails) and configures bigchain if it is not configured yet
