### PR TITLE
Remove extra fields from get_transaction

### DIFF
--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -237,7 +237,10 @@ class Bigchain(object):
 
         else:
             # Otherwise, check the backlog
-            response = self.connection.run(r.table('backlog').get(txid))
+            response = self.connection.run(r.table('backlog')
+                                           .get(txid)
+                                           .without('assignee', 'assignment_timestamp')
+                                           .default(None))
             if response:
                 tx_status = self.TX_IN_BACKLOG
 

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -131,8 +131,7 @@ class TestBigchainApi(object):
         b.write_transaction(tx_signed)
 
         response, status = b.get_transaction(tx_signed["id"], include_status=True)
-        response.pop('assignee')
-        response.pop('assignment_timestamp')
+
         # add validity information, which will be returned
         assert util.serialize(tx_signed) == util.serialize(response)
         assert status == b.TX_IN_BACKLOG


### PR DESCRIPTION
Using the `/api/v1/transactions/<txid>` Web API @TimDaub noticed that `assignee` and `assignment_timestamp` are returned for some calls.

After further investigation I noticed this behavior happens only when the transaction is in the `backlog` table. This PR is to fix this misbehavior.