### PR TITLE
Updated some docs urls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,8 @@ Familiarize yourself with how we do coding and documentation in the BigchainDB p
 
 * [Install RethinkDB Server](https://rethinkdb.com/docs/install/)
 * Make sure you have Python 3.4+ (preferably in a virtualenv)
-* [Install BigchaindB Server's OS-level dependencies](http://bigchaindb.readthedocs.io/en/latest/appendices/install-os-level-deps.html)
-* [Make sure you have the latest Python 3 version of pip and setuptools](http://bigchaindb.readthedocs.io/en/latest/appendices/install-latest-pip.html)
+* [Install BigchaindB Server's OS-level dependencies](http://bigchaindb.readthedocs.io/projects/server/en/latest/appendices/install-os-level-deps.html)
+* [Make sure you have the latest Python 3 version of pip and setuptools](http://bigchaindb.readthedocs.io/projects/server/en/latest/appendices/install-latest-pip.html)
 
 ### Step 3 - Fork bigchaindb on GitHub
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![PyPI](https://img.shields.io/pypi/v/bigchaindb.svg)](https://pypi.python.org/pypi/BigchainDB)
 [![Travis branch](https://img.shields.io/travis/bigchaindb/bigchaindb/master.svg)](https://travis-ci.org/bigchaindb/bigchaindb)
 [![Codecov branch](https://img.shields.io/codecov/c/github/bigchaindb/bigchaindb/master.svg)](https://codecov.io/github/bigchaindb/bigchaindb?branch=master)
-[![Documentation Status](https://readthedocs.org/projects/bigchaindb/badge/?version=latest)](https://bigchaindb.readthedocs.org/en/latest/)
+[![Documentation Status](http://bigchaindb.readthedocs.io/projects/server/en/latest/?badge=latest)](https://bigchaindb.readthedocs.org/projects/server/en/latest/)
 [![Join the chat at https://gitter.im/bigchaindb/bigchaindb](https://badges.gitter.im/bigchaindb/bigchaindb.svg)](https://gitter.im/bigchaindb/bigchaindb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 
@@ -15,11 +15,12 @@ We're hiring! [Learn more](https://github.com/bigchaindb/org/blob/master/engjob.
 
 ## Get Started with BigchainDB Server
 
-### [Quickstart](http://bigchaindb.readthedocs.io/en/latest/quickstart.html)
-### [Set Up & Run a Dev/Test Node](http://bigchaindb.readthedocs.io/en/latest/dev-and-test/setup-run-node.html)
-### [Run BigchainDB Server with Docker](http://bigchaindb.readthedocs.io/en/latest/appendices/run-with-docker.html)
+### [Quickstart](http://bigchaindb.readthedocs.io/projects/server/en/latest/quickstart.html)
+### [Set Up & Run a Dev/Test Node](http://bigchaindb.readthedocs.io/projects/server/en/latest/dev-and-test/setup-run-node.html)
+### [Run BigchainDB Server with Docker](http://bigchaindb.readthedocs.io/projects/server/en/latest/appendices/run-with-docker.html)
 
 ## Links for Everyone
+
 * [BigchainDB.com](https://www.bigchaindb.com/) - the main BigchainDB website, including newsletter signup
 * [Whitepaper](https://www.bigchaindb.com/whitepaper/) - outlines the motivations, goals and core algorithms of BigchainDB
 * [Roadmap](https://github.com/bigchaindb/org/blob/master/ROADMAP.md)
@@ -28,7 +29,9 @@ We're hiring! [Learn more](https://github.com/bigchaindb/org/blob/master/engjob.
 * [Google Group](https://groups.google.com/forum/#!forum/bigchaindb)
 
 ## Links for Developers
-* [BigchainDB Server Documentation](http://bigchaindb.readthedocs.io/en/latest/) - for developers
+
+* [BigchainDB Server Documentation](https://bigchaindb.readthedocs.io/projects/server/en/latest/)
+* [All BigchainDB Documentation](http://bigchaindb.readthedocs.io/en/latest/)
 * [CONTRIBUTING.md](CONTRIBUTING.md) - how to contribute
 * [Community guidelines](CODE_OF_CONDUCT.md)
 * [Open issues](https://github.com/bigchaindb/bigchaindb/issues)
@@ -36,6 +39,7 @@ We're hiring! [Learn more](https://github.com/bigchaindb/org/blob/master/engjob.
 * [Gitter chatroom](https://gitter.im/bigchaindb/bigchaindb)
 
 ## Legal
+
 * [Licenses](LICENSES.md) - open source & open content
 * [Imprint](https://www.bigchaindb.com/imprint/)
 * [Contact Us](https://www.bigchaindb.com/contact/)

--- a/benchmarking-tests/test1/README.md
+++ b/benchmarking-tests/test1/README.md
@@ -2,7 +2,7 @@
 
 Measure how many blocks per second are created on the _bigchain_ with a pre filled backlog.
 
-1. Deploy an aws cluster http://bigchaindb.readthedocs.io/en/latest/deploy-on-aws.html
+1. Deploy an aws cluster https://bigchaindb.readthedocs.io/projects/server/en/latest/clusters-feds/aws-testing-cluster.html
 2. Make a symbolic link to hostlist.py: `ln -s ../deploy-cluster-aws/hostlist.py .`
 3. Make a symbolic link to bigchaindb.pem:
 ```bash

--- a/bigchaindb/web/views/info.py
+++ b/bigchaindb/web/views/info.py
@@ -1,7 +1,7 @@
 """This module provides the blueprint for some basic API endpoints.
 
 For more information please refer to the documentation on ReadTheDocs:
- - https://bigchaindb.readthedocs.io/en/latest/drivers-clients/http-client-server-api.html
+ - https://bigchaindb.readthedocs.io/projects/server/en/latest/drivers-clients/http-client-server-api.html
 """
 
 import flask

--- a/bigchaindb/web/views/transactions.py
+++ b/bigchaindb/web/views/transactions.py
@@ -1,7 +1,7 @@
 """This module provides the blueprint for some basic API endpoints.
 
 For more information please refer to the documentation on ReadTheDocs:
- - https://bigchaindb.readthedocs.io/en/latest/drivers-clients/http-client-server-api.html
+ - https://bigchaindb.readthedocs.io/projects/server/en/latest/drivers-clients/http-client-server-api.html
 """
 from flask import current_app, request, Blueprint
 from flask_restful import Resource, Api

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,12 +1,10 @@
 BigchainDB Server Documentation
 ===============================
 
-Table of Contents
------------------
-
 .. toctree::
    :maxdepth: 1
 
+   ← Back to All BigchainDB Docs <https://bigchaindb.readthedocs.io/en/latest/index.html>
    introduction
    quickstart
    cloud-deployment-starter-templates/index


### PR DESCRIPTION
The URL of the **BigchainDB Server Docs** has changed from

https://bigchaindb.readthedocs.io/en/latest/index.html

to

https://bigchaindb.readthedocs.io/projects/server/en/latest/index.html

so I updated a bunch of links.

I also added a new direct link from the sidebar navigation menu to **All BigchainDB Docs** (i.e. to https://bigchaindb.readthedocs.io/en/latest/index.html which is now the URL of the top-level BigchainDB project docs).