### PR TITLE
Tidied up the docs for the config settings & the CLI

### DIFF
--- a/docs/source/server-reference/bigchaindb-cli.md
+++ b/docs/source/server-reference/bigchaindb-cli.md
@@ -1,9 +1,6 @@
-# BigchainDB Command Line Interface (CLI)
+# Command Line Interface (CLI)
 
-**Note: At the time of writing, BigchainDB Server and our BigchainDB client are combined, so the BigchainDB CLI includes some server-specific commands and some client-specific commands (e.g. `bigchaindb load`). Soon, BigchainDB Server will be separate from all BigchainDB clients, and they'll all have different CLIs.**
-
-
-The command-line command to interact with BigchainDB is `bigchaindb`.
+The command-line command to interact with BigchainDB Server is `bigchaindb`.
 
 
 ## bigchaindb \-\-help

--- a/docs/source/server-reference/bigchaindb-cli.md
+++ b/docs/source/server-reference/bigchaindb-cli.md
@@ -67,6 +67,9 @@ Write transactions to the backlog (for benchmarking tests). You can learn more a
 $ bigchaindb load -h
 ```
 
+Note: This command uses the Python Server API to write transactions to the database. It _doesn't_ use the HTTP API or a driver that wraps the HTTP API.
+
+
 ## bigchaindb set-shards
 
 Set the number of shards in the underlying datastore. For example, the following command will set the number of shards to four:

--- a/docs/source/server-reference/configuration.md
+++ b/docs/source/server-reference/configuration.md
@@ -1,8 +1,6 @@
-# BigchainDB Configuration Settings
+# Configuration Settings
 
-**Note: At the time of writing, BigchainDB Server code and BigchainDB Python driver code are mixed together, so the following settings are the settings used by BigchainDB Server and also by clients written using the Python driver code. Soon, the code will be separated into server, driver and shared modules, so that BigchainDB Server and BigchainDB clients will have different configuration settings.**
-
-The value of each configuration setting is determined according to the following rules:
+The value of each BigchainDB Server configuration setting is determined according to the following rules:
 
 * If it's set by an environment variable, then use that value
 * Otherwise, if it's set in a local config file, then use that value


### PR DESCRIPTION
* Removed the bold notice at the top of the docs about the Configuration Settings and the Command Line Interface, saying that things may change a lot after the separation of client and server. (As it happens, there weren't any changes.)
* Removed the word "BigchainDB" from the title of those two pages. It's now clear from context that the the configuration settings, and the CLI, are for BigchainDB Server.
* Expanded the first sentence on both pages to clarify that we're talking about BigchainDB Server, just in case that wasn't clear (and to help search engines).
* I also clarified that `bigchaindb load` uses the Python Server API (not the HTTP API or a driver that wraps the HTTP API)