### PR TITLE
Changed many *.readthedocs.io URLs to docs.bigchaindb.com URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,8 @@ Familiarize yourself with how we do coding and documentation in the BigchainDB p
 
 * [Install RethinkDB Server](https://rethinkdb.com/docs/install/)
 * Make sure you have Python 3.4+ (preferably in a virtualenv)
-* [Install BigchaindB Server's OS-level dependencies](http://bigchaindb.readthedocs.io/projects/server/en/latest/appendices/install-os-level-deps.html)
-* [Make sure you have the latest Python 3 version of pip and setuptools](http://bigchaindb.readthedocs.io/projects/server/en/latest/appendices/install-latest-pip.html)
+* [Install BigchaindB Server's OS-level dependencies](https://docs.bigchaindb.com/projects/server/en/latest/appendices/install-os-level-deps.html)
+* [Make sure you have the latest Python 3 version of pip and setuptools](https://docs.bigchaindb.com/projects/server/en/latest/appendices/install-latest-pip.html)
 
 ### Step 3 - Fork bigchaindb on GitHub
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![PyPI](https://img.shields.io/pypi/v/bigchaindb.svg)](https://pypi.python.org/pypi/BigchainDB)
 [![Travis branch](https://img.shields.io/travis/bigchaindb/bigchaindb/master.svg)](https://travis-ci.org/bigchaindb/bigchaindb)
 [![Codecov branch](https://img.shields.io/codecov/c/github/bigchaindb/bigchaindb/master.svg)](https://codecov.io/github/bigchaindb/bigchaindb?branch=master)
-[![Documentation Status](http://bigchaindb.readthedocs.io/projects/server/en/latest/?badge=latest)](https://bigchaindb.readthedocs.org/projects/server/en/latest/)
+[![Documentation Status](https://docs.bigchaindb.com/projects/server/en/latest/?badge=latest)](https://docs.bigchaindb.com/projects/server/en/latest/)
 [![Join the chat at https://gitter.im/bigchaindb/bigchaindb](https://badges.gitter.im/bigchaindb/bigchaindb.svg)](https://gitter.im/bigchaindb/bigchaindb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 
@@ -15,9 +15,9 @@ We're hiring! [Learn more](https://github.com/bigchaindb/org/blob/master/engjob.
 
 ## Get Started with BigchainDB Server
 
-### [Quickstart](http://bigchaindb.readthedocs.io/projects/server/en/latest/quickstart.html)
-### [Set Up & Run a Dev/Test Node](http://bigchaindb.readthedocs.io/projects/server/en/latest/dev-and-test/setup-run-node.html)
-### [Run BigchainDB Server with Docker](http://bigchaindb.readthedocs.io/projects/server/en/latest/appendices/run-with-docker.html)
+### [Quickstart](https://docs.bigchaindb.com/projects/server/en/latest/quickstart.html)
+### [Set Up & Run a Dev/Test Node](https://docs.bigchaindb.com/projects/server/en/latest/dev-and-test/setup-run-node.html)
+### [Run BigchainDB Server with Docker](https://docs.bigchaindb.com/projects/server/en/latest/appendices/run-with-docker.html)
 
 ## Links for Everyone
 
@@ -30,8 +30,8 @@ We're hiring! [Learn more](https://github.com/bigchaindb/org/blob/master/engjob.
 
 ## Links for Developers
 
-* [BigchainDB Server Documentation](https://bigchaindb.readthedocs.io/projects/server/en/latest/)
-* [All BigchainDB Documentation](http://bigchaindb.readthedocs.io/en/latest/)
+* [All BigchainDB Documentation](https://docs.bigchaindb.com/en/latest/)
+* [BigchainDB Server Documentation](https://docs.bigchaindb.com/projects/server/en/latest/index.html)
 * [CONTRIBUTING.md](CONTRIBUTING.md) - how to contribute
 * [Community guidelines](CODE_OF_CONDUCT.md)
 * [Open issues](https://github.com/bigchaindb/bigchaindb/issues)

--- a/benchmarking-tests/test1/README.md
+++ b/benchmarking-tests/test1/README.md
@@ -2,7 +2,7 @@
 
 Measure how many blocks per second are created on the _bigchain_ with a pre filled backlog.
 
-1. Deploy an aws cluster https://bigchaindb.readthedocs.io/projects/server/en/latest/clusters-feds/aws-testing-cluster.html
+1. Deploy an aws cluster https://docs.bigchaindb.com/projects/server/en/latest/clusters-feds/aws-testing-cluster.html
 2. Make a symbolic link to hostlist.py: `ln -s ../deploy-cluster-aws/hostlist.py .`
 3. Make a symbolic link to bigchaindb.pem:
 ```bash

--- a/bigchaindb/web/views/info.py
+++ b/bigchaindb/web/views/info.py
@@ -1,7 +1,7 @@
 """This module provides the blueprint for some basic API endpoints.
 
 For more information please refer to the documentation on ReadTheDocs:
- - https://bigchaindb.readthedocs.io/projects/server/en/latest/drivers-clients/http-client-server-api.html
+ - https://docs.bigchaindb.com/projects/server/en/latest/drivers-clients/http-client-server-api.html
 """
 
 import flask

--- a/bigchaindb/web/views/transactions.py
+++ b/bigchaindb/web/views/transactions.py
@@ -1,7 +1,7 @@
 """This module provides the blueprint for some basic API endpoints.
 
 For more information please refer to the documentation on ReadTheDocs:
- - https://bigchaindb.readthedocs.io/projects/server/en/latest/drivers-clients/http-client-server-api.html
+ - https://docs.bigchaindb.com/projects/server/en/latest/drivers-clients/http-client-server-api.html
 """
 from flask import current_app, request, Blueprint
 from flask_restful import Resource, Api

--- a/docs/source/appendices/install-with-lxd.md
+++ b/docs/source/appendices/install-with-lxd.md
@@ -39,5 +39,3 @@ Now, from the host (and the correct directory) where you saved `install.sh`, run
 `cat install.sh | lxc exec bigchaindb /bin/bash`
 
 If you followed the commands correctly, you will have successfully created an LXC container (using LXD) that can get you up and running with BigchainDB in <5 minutes (depending on how long it takes to download all the packages).
-
-From this point onwards, you can follow the [Python Example](https://bigchaindb.readthedocs.io/en/latest/drivers-clients/python-server-api-examples.html) .

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,7 +4,7 @@ BigchainDB Server Documentation
 .. toctree::
    :maxdepth: 1
 
-   ← Back to All BigchainDB Docs <https://bigchaindb.readthedocs.io/en/latest/index.html>
+   ← Back to All BigchainDB Docs <https://docs.bigchaindb.com/en/latest/index.html>
    introduction
    quickstart
    cloud-deployment-starter-templates/index

--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -2,7 +2,7 @@
 
 This is the documentation for BigchainDB Server, the BigchainDB software that one runs on servers (but not on clients).
 
-If you want to use BigchainDB Server, then you should first understand what BigchainDB is, plus some of the specialized BigchaindB terminology. You can read about that in [the overall BigchainDB project documentation](https://bigchaindb.readthedocs.io/en/latest/introduction.html).
+If you want to use BigchainDB Server, then you should first understand what BigchainDB is, plus some of the specialized BigchaindB terminology. You can read about that in [the overall BigchainDB project documentation](https://docs.bigchaindb.com/en/latest/index.html).
 
 Note that there are a few kinds of nodes:
 


### PR DESCRIPTION
All BigchainDB-related docs are now under https://docs.bigchaindb.com/ so I updated all the relevant URLs in this repository.