### PR TITLE
Changed BANNER message & link so it doesn't point to Apiary any more

### DIFF
--- a/bigchaindb/processes.py
+++ b/bigchaindb/processes.py
@@ -14,7 +14,7 @@ BANNER = """
 *   Initialization complete. BigchainDB Server is ready and waiting.       *
 *   You can send HTTP requests via the HTTP API documented in the          *
 *   BigchainDB Server docs at:                                             *
-*    https://docs.bigchaindb.com/projects/server/en/latest/index.html      *
+*    https://bigchaindb.com/http-api                                       *
 *                                                                          *
 *   Listening to client connections on: {:<15}                    *
 *                                                                          *

--- a/bigchaindb/processes.py
+++ b/bigchaindb/processes.py
@@ -11,9 +11,10 @@ logger = logging.getLogger(__name__)
 BANNER = """
 ****************************************************************************
 *                                                                          *
-*   Initialization complete. BigchainDB is ready and waiting for events.   *
-*   You can send events through the API documented at:                     *
-*    - http://docs.bigchaindb.apiary.io/                                   *
+*   Initialization complete. BigchainDB Server is ready and waiting.       *
+*   You can send HTTP requests via the HTTP API documented in the          *
+*   BigchainDB Server docs at:                                             *
+*    https://docs.bigchaindb.com/projects/server/en/latest/index.html      *
 *                                                                          *
 *   Listening to client connections on: {:<15}                    *
 *                                                                          *


### PR DESCRIPTION
Resolves #577 
Resolves #671 

I made some minor changes to the text in the banner, and changed the link to the HTTP API documentation to be the top-level URL for the BigchainDB Server docs. I didn't give the deep link because that might change, and moreover, it's a really long link. I think one can find the HTTP API documentation fairly easily once in the BigchainDB Server docs.