### PR TITLE
Fixed the docstring in config_utils.py

### DIFF
--- a/bigchaindb/config_utils.py
+++ b/bigchaindb/config_utils.py
@@ -3,8 +3,8 @@
 The value of each BigchainDB Server configuration setting is
 determined according to the following rules:
 
-* If it’s set by an environment variable, then use that value
-* Otherwise, if it’s set in a local config file, then use that
+* If it's set by an environment variable, then use that value
+* Otherwise, if it's set in a local config file, then use that
   value
 * Otherwise, use the default value (contained in 
   ``bigchaindb.__init__``)

--- a/bigchaindb/config_utils.py
+++ b/bigchaindb/config_utils.py
@@ -1,13 +1,13 @@
-"""Utils to configure BigchainDB.
+"""Utils for reading and setting configuration settings.
 
-By calling `file_config`, the global configuration (stored in
-`$HOME/.bigchaindb`) will be updated with the values contained
-in the configuration file.
+The value of each BigchainDB Server configuration setting is
+determined according to the following rules:
 
-Note that there is a precedence in reading configuration values:
- - local config file;
- - environment vars;
- - default config file (contained in ``bigchaindb.__init__``).
+* If it’s set by an environment variable, then use that value
+* Otherwise, if it’s set in a local config file, then use that
+  value
+* Otherwise, use the default value (contained in 
+  ``bigchaindb.__init__``)
 """
 
 


### PR DESCRIPTION
I noticed that the docstring in `config_utils.py` was out-of-date. The order of precedence has changed; see the `autoconfigure()` function.

The changed docstring is copied from the current BigchainDB Server docs, e.g. https://docs.bigchaindb.com/projects/server/en/latest/server-reference/configuration.html

@vrde can you take a look and verify that I got the order of precedence right?
