### PR TITLE
Allow pip caching on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
 language: python
+cache: pip
 python:
   - 3.4
   - 3.5


### PR DESCRIPTION
Travis-CI allows you to cache your pip cache between runs. Doing so may help speed up running the test suite on Travis-CI. This is intended to build on #695, but could be implemented independently as well.

For more details, see https://docs.travis-ci.com/user/caching/#pip-cache

Hope this is helpful!