### PR TITLE
Added installation of libffi-dev (or libffi-devel) to install docs, scripts, Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rethinkdb:2.3
 
 RUN apt-get update
-RUN apt-get -y install python3 python3-pip
+RUN apt-get -y install python3 python3-pip libffi-dev
 RUN pip3 install --upgrade pip
 RUN pip3 install --upgrade setuptools
 

--- a/deploy-cluster-aws/fabfile.py
+++ b/deploy-cluster-aws/fabfile.py
@@ -77,7 +77,7 @@ def install_base_software():
     sudo('dpkg --configure -a')
     sudo('apt-get -y -f install')
     # Install the base dependencies not already installed.
-    sudo('apt-get -y install git g++ python3-dev')
+    sudo('apt-get -y install git g++ python3-dev libffi-dev')
     sudo('apt-get -y -f install')
 
 

--- a/docs/source/appendices/install-os-level-deps.md
+++ b/docs/source/appendices/install-os-level-deps.md
@@ -5,13 +5,13 @@ BigchainDB Server has some OS-level dependencies that must be installed.
 On Ubuntu 14.04 and 16.04, we found that the following was enough:
 ```text
 sudo apt-get update
-sudo apt-get install g++ python3-dev
+sudo apt-get install g++ python3-dev libffi-dev
 ```
 
 On Fedora 23 and 24, we found that the following was enough:
 ```text
 sudo dnf update
-sudo dnf install gcc-c++ redhat-rpm-config python3-devel
+sudo dnf install gcc-c++ redhat-rpm-config python3-devel libffi-devel
 ```
 
 (If you're using a version of Fedora before version 22, you may have to use `yum` instead of `dnf`.)

--- a/docs/source/nodes/setup-run-node.md
+++ b/docs/source/nodes/setup-run-node.md
@@ -99,13 +99,13 @@ BigchainDB Server has some OS-level dependencies that must be installed.
 On Ubuntu 14.04, we found that the following was enough:
 ```text
 sudo apt-get update
-sudo apt-get install g++ python3-dev
+sudo apt-get install g++ python3-dev libffi-dev
 ```
 
 On Fedora 23, we found that the following was enough (tested in February 2015):
 ```text
 sudo dnf update
-sudo dnf install gcc-c++ redhat-rpm-config python3-devel
+sudo dnf install gcc-c++ redhat-rpm-config python3-devel libffi-devel
 ```
 
 (If you're using a version of Fedora before version 22, you may have to use `yum` instead of `dnf`.)

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -12,7 +12,7 @@ rethinkdb
 C. Ubuntu 14.04 already has Python 3.4, so you don't need to install it, but you do need to install a couple other things:
 ```text
 sudo apt-get update
-sudo apt-get install g++ python3-dev
+sudo apt-get install g++ python3-dev libffi-dev
 ```
 
 D. Get the latest version of pip and setuptools:

--- a/ntools/one-m/ansible/roles/bigchaindb/tasks/main.yml
+++ b/ntools/one-m/ansible/roles/bigchaindb/tasks/main.yml
@@ -13,6 +13,7 @@
     - git
     - g++
     - python3-dev
+    - libffi-dev
     - python3-setuptools  # mainly for easy_install3, which is used to get latest pip3
 
 # This should make both pip and pip3 be pip version >=8.1.2 (python 3.4).


### PR DESCRIPTION
This resolves #694 

I tested it on a bare-bones Ubuntu 14.04 instance on AWS and I didn't get the error message about a missing `ffi.h`

@r-marques Can you test that `sudo dnf install gcc-c++ redhat-rpm-config python3-devel libffi-devel` works on Fedora?

@sbellem Can you take a look to ensure I didn't miss some Docker-related files?
