### PR TITLE
Update version to 0.7.0.dev

### DIFF
--- a/bigchaindb/version.py
+++ b/bigchaindb/version.py
@@ -1,2 +1,2 @@
-__version__ = '0.6.0'
-__short_version__ = '0.6'
+__version__ = '0.7.0.dev'
+__short_version__ = '0.7.dev'


### PR DESCRIPTION
**tl;dr** Allows python packages that depend on bigchaindb's master branch, to be installable via `python setup.py install`

for more see discussion on https://github.com/bigchaindb/org/issues/24#issuecomment-256596998