### PR TITLE
Isolate db testcalls

### DIFF
--- a/tests/pipelines/test_election.py
+++ b/tests/pipelines/test_election.py
@@ -2,7 +2,6 @@ import time
 from unittest.mock import patch
 
 from bigchaindb.common import crypto
-import rethinkdb as r
 from multipipes import Pipe, Pipeline
 
 from bigchaindb import Bigchain
@@ -33,7 +32,8 @@ def test_check_for_quorum_invalid(b, user_pk):
                    [member.vote(test_block.id, 'abc', False) for member in test_federation[2:]]
 
     # cast votes
-    b.connection.run(r.table('votes').insert(votes, durability='hard'))
+    for vote in votes:
+        b.write_vote(vote)
 
     # since this block is now invalid, should pass to the next process
     assert e.check_for_quorum(votes[-1]) == test_block
@@ -62,7 +62,8 @@ def test_check_for_quorum_invalid_prev_node(b, user_pk):
                    [member.vote(test_block.id, 'def', True) for member in test_federation[2:]]
 
     # cast votes
-    b.connection.run(r.table('votes').insert(votes, durability='hard'))
+    for vote in votes:
+        b.write_vote(vote)
 
     # since nodes cannot agree on prev block, the block is invalid
     assert e.check_for_quorum(votes[-1]) == test_block
@@ -91,7 +92,8 @@ def test_check_for_quorum_valid(b, user_pk):
     votes = [member.vote(test_block.id, 'abc', True)
              for member in test_federation]
     # cast votes
-    b.connection.run(r.table('votes').insert(votes, durability='hard'))
+    for vote in votes:
+        b.write_vote(vote)
 
     # since this block is valid, should go nowhere
     assert e.check_for_quorum(votes[-1]) is None
@@ -107,10 +109,12 @@ def test_check_requeue_transaction(b, user_pk):
     test_block = b.create_block([tx1])
 
     e.requeue_transactions(test_block)
-    backlog_tx = b.connection.run(r.table('backlog').get(tx1.id))
-    backlog_tx.pop('assignee')
-    backlog_tx.pop('assignment_timestamp')
-    assert backlog_tx == tx1.to_dict()
+
+    backlog_tx, status = b.get_transaction(tx1.id, include_status=True)
+    #backlog_tx = b.connection.run(r.table('backlog').get(tx1.id))
+    assert status == b.TX_IN_BACKLOG
+    assert backlog_tx == tx1
+
 
 
 @patch.object(Pipeline, 'start')
@@ -157,16 +161,16 @@ def test_full_pipeline(b, user_pk):
     vote_valid = b.vote(valid_block.id, 'abc', True)
     vote_invalid = b.vote(invalid_block.id, 'abc', False)
 
-    b.connection.run(r.table('votes').insert(vote_valid, durability='hard'))
-    b.connection.run(r.table('votes').insert(vote_invalid, durability='hard'))
+    b.write_vote(vote_valid)
+    b.write_vote(vote_invalid)
 
     outpipe.get()
     pipeline.terminate()
 
     # only transactions from the invalid block should be returned to
     # the backlog
-    assert b.connection.run(r.table('backlog').count()) == 100
+    assert b.backend.count_backlog() == 100
     # NOTE: I'm still, I'm still tx from the block.
     tx_from_block = set([tx.id for tx in invalid_block.transactions])
-    tx_from_backlog = set([tx['id'] for tx in list(b.connection.run(r.table('backlog')))])
+    tx_from_backlog = set([tx['id'] for tx in list(b.backend.get_stale_transactions(0))])
     assert tx_from_block == tx_from_backlog

--- a/tests/pipelines/test_vote.py
+++ b/tests/pipelines/test_vote.py
@@ -2,7 +2,6 @@ import time
 
 from unittest.mock import patch
 
-import rethinkdb as r
 from multipipes import Pipe, Pipeline
 
 
@@ -166,7 +165,7 @@ def test_valid_block_voting_sequential(b, monkeypatch):
         last_vote = vote_obj.vote(*vote_obj.validate_tx(tx, block_id, num_tx))
 
     vote_obj.write_vote(last_vote)
-    vote_rs = b.connection.run(r.table('votes').get_all([block.id, b.me], index='block_and_voter'))
+    vote_rs = b.backend.get_votes_by_block_id_and_voter(block_id, b.me)
     vote_doc = vote_rs.next()
 
     assert vote_doc['vote'] == {'voting_for_block': block.id,
@@ -200,7 +199,7 @@ def test_valid_block_voting_multiprocessing(b, monkeypatch):
     vote_out = outpipe.get()
     vote_pipeline.terminate()
 
-    vote_rs = b.connection.run(r.table('votes').get_all([block.id, b.me], index='block_and_voter'))
+    vote_rs = b.backend.get_votes_by_block_id_and_voter(block.id, b.me)
     vote_doc = vote_rs.next()
     assert vote_out['vote'] == vote_doc['vote']
     assert vote_doc['vote'] == {'voting_for_block': block.id,
@@ -241,7 +240,7 @@ def test_valid_block_voting_with_create_transaction(b, monkeypatch):
     vote_out = outpipe.get()
     vote_pipeline.terminate()
 
-    vote_rs = b.connection.run(r.table('votes').get_all([block.id, b.me], index='block_and_voter'))
+    vote_rs = b.backend.get_votes_by_block_id_and_voter(block.id, b.me)
     vote_doc = vote_rs.next()
     assert vote_out['vote'] == vote_doc['vote']
     assert vote_doc['vote'] == {'voting_for_block': block.id,
@@ -296,7 +295,7 @@ def test_valid_block_voting_with_transfer_transactions(monkeypatch, b):
     vote2_out = outpipe.get()
     vote_pipeline.terminate()
 
-    vote_rs = b.connection.run(r.table('votes').get_all([block.id, b.me], index='block_and_voter'))
+    vote_rs = b.backend.get_votes_by_block_id_and_voter(block.id, b.me)
     vote_doc = vote_rs.next()
     assert vote_out['vote'] == vote_doc['vote']
     assert vote_doc['vote'] == {'voting_for_block': block.id,
@@ -310,7 +309,7 @@ def test_valid_block_voting_with_transfer_transactions(monkeypatch, b):
     assert crypto.PublicKey(b.me).verify(serialized_vote,
                                             vote_doc['signature']) is True
 
-    vote2_rs = b.connection.run(r.table('votes').get_all([block2.id, b.me], index='block_and_voter'))
+    vote2_rs = b.backend.get_votes_by_block_id_and_voter(block2.id, b.me)
     vote2_doc = vote2_rs.next()
     assert vote2_out['vote'] == vote2_doc['vote']
     assert vote2_doc['vote'] == {'voting_for_block': block2.id,
@@ -347,7 +346,7 @@ def test_unsigned_tx_in_block_voting(monkeypatch, b, user_pk):
     vote_out = outpipe.get()
     vote_pipeline.terminate()
 
-    vote_rs = b.connection.run(r.table('votes').get_all([block.id, b.me], index='block_and_voter'))
+    vote_rs = b.backend.get_votes_by_block_id_and_voter(block.id, b.me)
     vote_doc = vote_rs.next()
     assert vote_out['vote'] == vote_doc['vote']
     assert vote_doc['vote'] == {'voting_for_block': block.id,
@@ -386,7 +385,7 @@ def test_invalid_id_tx_in_block_voting(monkeypatch, b, user_pk):
     vote_out = outpipe.get()
     vote_pipeline.terminate()
 
-    vote_rs = b.connection.run(r.table('votes').get_all([block['id'], b.me], index='block_and_voter'))
+    vote_rs = b.backend.get_votes_by_block_id_and_voter(block['id'], b.me)
     vote_doc = vote_rs.next()
     assert vote_out['vote'] == vote_doc['vote']
     assert vote_doc['vote'] == {'voting_for_block': block['id'],
@@ -425,7 +424,7 @@ def test_invalid_content_in_tx_in_block_voting(monkeypatch, b, user_pk):
     vote_out = outpipe.get()
     vote_pipeline.terminate()
 
-    vote_rs = b.connection.run(r.table('votes').get_all([block['id'], b.me], index='block_and_voter'))
+    vote_rs = b.backend.get_votes_by_block_id_and_voter(block['id'], b.me)
     vote_doc = vote_rs.next()
     assert vote_out['vote'] == vote_doc['vote']
     assert vote_doc['vote'] == {'voting_for_block': block['id'],
@@ -460,7 +459,7 @@ def test_invalid_block_voting(monkeypatch, b, user_pk):
     vote_out = outpipe.get()
     vote_pipeline.terminate()
 
-    vote_rs = b.connection.run(r.table('votes').get_all([block['id'], b.me], index='block_and_voter'))
+    vote_rs = b.backend.get_votes_by_block_id_and_voter(block['id'], b.me)
     vote_doc = vote_rs.next()
     assert vote_out['vote'] == vote_doc['vote']
     assert vote_doc['vote'] == {'voting_for_block': block['id'],
@@ -483,13 +482,16 @@ def test_voter_considers_unvoted_blocks_when_single_node(monkeypatch, b):
     monkeypatch.setattr('time.time', lambda: 1)
     b.create_genesis_block()
 
+    block_ids = []
     # insert blocks in the database while the voter process is not listening
     # (these blocks won't appear in the changefeed)
     monkeypatch.setattr('time.time', lambda: 2)
     block_1 = dummy_block(b)
+    block_ids.append(block_1.id)
     b.write_block(block_1, durability='hard')
     monkeypatch.setattr('time.time', lambda: 3)
     block_2 = dummy_block(b)
+    block_ids.append(block_2.id)
     b.write_block(block_2, durability='hard')
 
     vote_pipeline = vote.create_pipeline()
@@ -504,6 +506,7 @@ def test_voter_considers_unvoted_blocks_when_single_node(monkeypatch, b):
     # create a new block that will appear in the changefeed
     monkeypatch.setattr('time.time', lambda: 4)
     block_3 = dummy_block(b)
+    block_ids.append(block_3.id)
     b.write_block(block_3, durability='hard')
 
     # Same as before with the two `get`s
@@ -511,19 +514,9 @@ def test_voter_considers_unvoted_blocks_when_single_node(monkeypatch, b):
 
     vote_pipeline.terminate()
 
-    # retrieve blocks from bigchain
-    blocks = list(b.connection.run(
-                r.table('bigchain')
-                .order_by(r.asc((r.row['block']['timestamp'])))))
-
-    # FIXME: remove genesis block, we don't vote on it
-    # (might change in the future)
-    blocks.pop(0)
-    vote_pipeline.terminate()
-
     # retrieve vote
-    votes = b.connection.run(r.table('votes'))
-    votes = list(votes)
+    votes = [list(b.backend.get_votes_by_block_id(_id))[0]
+             for _id in block_ids]
 
     assert all(vote['node_pubkey'] == b.me for vote in votes)
 
@@ -536,12 +529,15 @@ def test_voter_chains_blocks_with_the_previous_ones(monkeypatch, b):
     monkeypatch.setattr('time.time', lambda: 1)
     b.create_genesis_block()
 
+    block_ids = []
     monkeypatch.setattr('time.time', lambda: 2)
     block_1 = dummy_block(b)
+    block_ids.append(block_1.id)
     b.write_block(block_1, durability='hard')
 
     monkeypatch.setattr('time.time', lambda: 3)
     block_2 = dummy_block(b)
+    block_ids.append(block_2.id)
     b.write_block(block_2, durability='hard')
 
     vote_pipeline = vote.create_pipeline()
@@ -555,15 +551,13 @@ def test_voter_chains_blocks_with_the_previous_ones(monkeypatch, b):
     vote_pipeline.terminate()
 
     # retrive blocks from bigchain
-    blocks = list(b.connection.run(
-                     r.table('bigchain')
-                     .order_by(r.asc((r.row['block']['timestamp'])))))
-
+    blocks = [b.get_block(_id) for _id in block_ids]
     # retrieve votes
-    votes = list(b.connection.run(r.table('votes')))
+    votes = [list(b.backend.get_votes_by_block_id(_id))[0]
+             for _id in block_ids]
 
-    assert votes[0]['vote']['voting_for_block'] in (blocks[1]['id'], blocks[2]['id'])
-    assert votes[1]['vote']['voting_for_block'] in (blocks[1]['id'], blocks[2]['id'])
+    assert votes[0]['vote']['voting_for_block'] in (blocks[0]['id'], blocks[1]['id'])
+    assert votes[1]['vote']['voting_for_block'] in (blocks[0]['id'], blocks[1]['id'])
 
 
 def test_voter_checks_for_previous_vote(monkeypatch, b):
@@ -578,8 +572,7 @@ def test_voter_checks_for_previous_vote(monkeypatch, b):
     monkeypatch.setattr('time.time', lambda: 2)
     block_1 = dummy_block(b)
     inpipe.put(block_1.to_dict())
-
-    assert b.connection.run(r.table('votes').count()) == 0
+    assert len(list(b.backend.get_votes_by_block_id(block_1.id))) == 0
 
     vote_pipeline = vote.create_pipeline()
     vote_pipeline.setup(indata=inpipe, outdata=outpipe)
@@ -594,14 +587,16 @@ def test_voter_checks_for_previous_vote(monkeypatch, b):
 
     # queue another block
     monkeypatch.setattr('time.time', lambda: 4)
-    inpipe.put(dummy_block(b).to_dict())
+    block_2 = dummy_block(b)
+    inpipe.put(block_2.to_dict())
 
     # wait for the result of the new block
     outpipe.get()
 
     vote_pipeline.terminate()
 
-    assert b.connection.run(r.table('votes').count()) == 2
+    assert len(list(b.backend.get_votes_by_block_id(block_1.id))) == 1
+    assert len(list(b.backend.get_votes_by_block_id(block_2.id))) == 1
 
 
 @patch.object(Pipeline, 'start')


### PR DESCRIPTION
Ready to merge:

I've made some progress getting db-specific calls out of the tests:

**Files which contain db calls not supported by `core.py`**

1. `tests/pipelines/test_vote.py` **done**
2. `tests/pipelines/test_block_creation` **done**
3. `tests/pipelines/test_election.py` **done**
4. `tests/db/test_bigchain_api.py` **done**

These are mostly refactorable, but some testing conditions are created using direct calls to RethinkDB that  I can't mimic with the existing API.

**I suggest adding the following functions to `core.py` to help** since they might be helpful in other contexts too.

1. `get_block` get a block by id #799 **merged**
2. `backlog_count` get the size of the backlog.  You do this now with `b.backend.get_stale_transactions(0)` but it's hacky #806 **merged**
3. ~~`block_count` all blocks, as filtering by validity is prohibitively expensive~~ this already exists
4.  `get_genesis_block` #809 **merged**
 
`test_vote` also uses db calls to return the entire chain/vote table, which will probably need to be rewritten.


The following will be handled in another PR:
**Files which contain db-specific tests:**  I don't think these ones can be abstracted out, or the test setup is too complicated for me to see an easy abstraction.  We'll need parallel tests for every backend:

1. `tests/test_command.py`
2. `tests/test_core.py`
3. `tests/test_run_query_util.py`
4. `tests/db/test_utils.py`

See also #784 