### PR TITLE
fix version base58==0.2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ install_requires = [
     'statsd>=3.2.1',
     'python-rapidjson>=0.0.6',
     'logstats>=0.2.1',
-    'base58>=0.2.2',
+    'base58==0.2.2',
     'flask>=0.10.1',
     'flask-restful~=0.3.0',
     'requests~=2.9',


### PR DESCRIPTION
```
:~# docker run --rm -v "$HOME/bigchaindb_docker:/data" -ti \
>   bigchaindb/bigchaindb -y configure
Unable to find image 'bigchaindb/bigchaindb:latest' locally
latest: Pulling from bigchaindb/bigchaindb

43c265008fae: Pull complete
a92968af165a: Pull complete
009d33162daa: Pull complete
166c9b6f4428: Pull complete
9b021ff45110: Pull complete
505818406a9a: Pull complete
be69b43ecd41: Pull complete
5284073c097d: Pull complete
9a19b53183cd: Pull complete
2aab651a31ed: Pull complete
64419d0084d6: Pull complete
fb857478c1b3: Pull complete
Digest: sha256:ee1523c1c872a3745ffa08b61e33ece01785ac1f1fd5fb05fccb8be2cf7571a1
Status: Downloaded newer image for bigchaindb/bigchaindb:latest
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 658, in _build_master
    ws.require(__requires__)
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 966, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 857, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (base58 0.2.4 (/usr/local/lib/python3.4/dist-packages), Requirement.parse('base58==0.2.2'), {'cryptoconditions'})

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/bigchaindb", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 2994, in <module>
    @_call_aside
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 2980, in _call_aside
    f(*args, **kwargs)
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 3007, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 660, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 673, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 857, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (base58 0.2.4 (/usr/local/lib/python3.4/dist-packages), Requirement.parse('base58==0.2.2'), {'cryptoconditions'})
```