### PR TITLE
get_transaction will return a tx from backlog, even if there are some in invalid blocks

### DIFF
--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -245,7 +245,7 @@ class TestBigchainApi(object):
         inputs = input_tx.to_inputs()
         tx = Transaction.transfer(inputs, [user_vk], input_tx.asset)
         tx = tx.sign([user_sk])
-        b.write_transaction(tx)
+        # There's no need to b.write_transaction(tx) to the backlog
 
         # create block
         block = b.create_block([tx])


### PR DESCRIPTION
I made a slight change to how `Bigchain.get_transaction()` works. Before, if there was a transaction with the specified `txid` in the backlog _and_ in some invalid blocks (but nowhere else), `Bigchain.get_transaction()` would return `None`. I changed it so that in that case, it returns the transaction from the backlog (and if the user asked for the transaction's status, it will be `'backlog'`).

I updated and expanded the docstring for `Bigchain.get_transaction()`.

I also made a minor change to a test: `	test_read_transaction_invalid_block` didn't need to write the transaction to the backlog, so I commented-out that line.