### PR TITLE
add block id query

### DIFF
--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -188,6 +188,28 @@ class Bigchain(object):
                 exceptions.FulfillmentNotInValidBlock):
             return False
 
+    def get_block(self, block_id, include_status=False):
+        """Get the block with the specified `block_id` (and optionally its status)
+
+        Returns the block corresponding to `block_id` or None if no match is
+        found.
+
+        Args:
+            block_id (str): transaction id of the transaction to get
+            include_status (bool): also return the status of the block
+                       the return value is then a tuple: (block, status)
+        """
+        block = self.backend.get_block(block_id)
+        status = None
+
+        if include_status:
+            if block:
+                status = self.block_election_status(block_id,
+                                                    block['block']['voters'])
+            return block, status
+        else:
+            return block
+
     def get_transaction(self, txid, include_status=False):
         """Get the transaction with the specified `txid` (and optionally its status)
 

--- a/bigchaindb/db/backends/rethinkdb.py
+++ b/bigchaindb/db/backends/rethinkdb.py
@@ -258,6 +258,17 @@ class RethinkDBBackend:
                 r.table('bigchain')
                 .insert(r.json(block), durability=durability))
 
+    def get_block(self, block_id):
+        """Get a block from the bigchain table
+
+        Args:
+            block_id (str): block id of the block to get
+
+        Returns:
+            block (dict): the block or `None`
+        """
+        return self.connection.run(r.table('bigchain').get(block_id))
+
     def has_transaction(self, transaction_id):
         """Check if a transaction exists in the bigchain table.
 

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -369,6 +369,15 @@ class TestBigchainApi(object):
 
         assert excinfo.value.args[0] == 'Empty block creation is not allowed'
 
+    @pytest.mark.usefixtures('inputs')
+    def test_get_block_by_id(self, b):
+        new_block = dummy_block()
+        b.write_block(new_block, durability='hard')
+
+        assert b.get_block(new_block.id) == new_block.to_dict()
+        block, status = b.get_block(new_block.id, include_status=True)
+        assert status == b.BLOCK_UNDECIDED
+
     def test_get_last_voted_block_returns_genesis_if_no_votes_has_been_casted(self, b):
         import rethinkdb as r
         from bigchaindb import util


### PR DESCRIPTION
Add a generic query to find block by `id`.  Needed by #783 