### PR TITLE
Format http api docs to 79 chars

### DIFF
--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -3,21 +3,35 @@ The HTTP Client-Server API
 
 .. note::
 
-   The HTTP client-server API is currently quite rudimentary. For example, there is no ability to do complex queries using the HTTP API. We plan to add querying capabilities in the future.
+   The HTTP client-server API is currently quite rudimentary. For example,
+   there is no ability to do complex queries using the HTTP API. We plan to add
+   querying capabilities in the future.
 
-When you start Bigchaindb using `bigchaindb start`, an HTTP API is exposed at the address stored in the BigchainDB node configuration settings. The default is:
+When you start Bigchaindb using `bigchaindb start`, an HTTP API is exposed at
+the address stored in the BigchainDB node configuration settings. The default
+is:
 
 `http://localhost:9984/api/v1/ <http://localhost:9984/api/v1/>`_
 
-but that address can be changed by changing the "API endpoint" configuration setting (e.g. in a local config file). There's more information about setting the API endpoint in :doc:`the section about BigchainDB Configuration Settings <../server-reference/configuration>`.
+but that address can be changed by changing the "API endpoint" configuration
+setting (e.g. in a local config file). There's more information about setting
+the API endpoint in :doc:`the section about BigchainDB Configuration Settings
+<../server-reference/configuration>`.
 
-There are other configuration settings related to the web server (serving the HTTP API). In particular, the default is for the web server socket to bind to ``localhost:9984`` but that can be changed (e.g. to ``0.0.0.0:9984``). For more details, see the "server" settings ("bind", "workers" and "threads") in :doc:`the section about BigchainDB Configuration Settings <../server-reference/configuration>`.
+There are other configuration settings related to the web server (serving the
+HTTP API). In particular, the default is for the web server socket to bind to
+``localhost:9984`` but that can be changed (e.g. to ``0.0.0.0:9984``). For more
+details, see the "server" settings ("bind", "workers" and "threads") in
+:doc:`the section about BigchainDB Configuration Settings
+<../server-reference/configuration>`.
 
 
 API Root
 --------
 
-If you send an HTTP GET request to e.g. ``http://localhost:9984`` (with no ``/api/v1/`` on the end), then you should get an HTTP response with something like the following in the body:
+If you send an HTTP GET request to e.g. ``http://localhost:9984`` (with no
+``/api/v1/`` on the end), then you should get an HTTP response with something
+like the following in the body:
 
 .. code-block:: json
 
@@ -39,8 +53,13 @@ POST /transactions/
 .. http:post:: /transactions/
 
    Push a new transaction.
-   
-   Note: The posted transaction should be valid `transaction <https://bigchaindb.readthedocs.io/en/latest/data-models/transaction-model.html>`_. The steps to build a valid transaction are beyond the scope of this page. One would normally use a driver such as the `BigchainDB Python Driver <https://docs.bigchaindb.com/projects/py-driver/en/latest/index.html>`_ to build a valid transaction.
+
+   Note: The posted transaction should be valid `transaction
+   <https://bigchaindb.readthedocs.io/en/latest/data-models/transaction-model.html>`_.
+   The steps to build a valid transaction are beyond the scope of this page.
+   One would normally use a driver such as the `BigchainDB Python Driver
+   <https://docs.bigchaindb.com/projects/py-driver/en/latest/index.html>`_ to
+   build a valid transaction.
 
    **Example request**:
 
@@ -158,9 +177,11 @@ GET /transactions/{tx_id}/status
 
 .. http:get:: /transactions/{tx_id}/status
 
-   Get the status of the transaction with the ID ``tx_id``, if a transaction with that ``tx_id`` exists.
+   Get the status of the transaction with the ID ``tx_id``, if a transaction
+   with that ``tx_id`` exists.
 
-   The possible status values are ``backlog``, ``undecided``, ``valid`` or ``invalid``.
+   The possible status values are ``backlog``, ``undecided``, ``valid`` or
+   ``invalid``.
 
    :param tx_id: transaction ID
    :type tx_id: hex string
@@ -194,7 +215,8 @@ GET /transactions/{tx_id}
 
    Get the transaction with the ID ``tx_id``.
 
-   This endpoint returns only a transaction from a ``VALID`` or ``UNDECIDED`` block on ``bigchain``, if exists.
+   This endpoint returns only a transaction from a ``VALID`` or ``UNDECIDED``
+   block on ``bigchain``, if exists.
 
    :param tx_id: transaction ID
    :type tx_id: hex string


### PR DESCRIPTION
@ttmc I hope this change is OK.

If not, I guess I can also work with more chars per line, but in vim that's kinda tricky.