### PR TITLE
Feat/746/new naming convention for keys

### DIFF
--- a/bigchaindb/common/crypto.py
+++ b/bigchaindb/common/crypto.py
@@ -14,5 +14,5 @@ def generate_key_pair():
     private_key, public_key = crypto.ed25519_generate_key_pair()
     return private_key.decode(), public_key.decode()
 
-SigningKey = crypto.Ed25519SigningKey
-VerifyingKey = crypto.Ed25519VerifyingKey
+PrivateKey = crypto.Ed25519SigningKey
+PublicKey = crypto.Ed25519VerifyingKey

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -7,7 +7,7 @@ from cryptoconditions import (Fulfillment as CCFulfillment,
                               PreimageSha256Fulfillment)
 from cryptoconditions.exceptions import ParsingError
 
-from bigchaindb.common.crypto import SigningKey, hash_data
+from bigchaindb.common.crypto import PrivateKey, hash_data
 from bigchaindb.common.exceptions import (KeypairMismatchException,
                                           InvalidHash, InvalidSignature)
 from bigchaindb.common.util import serialize, gen_timestamp
@@ -865,8 +865,8 @@ class Transaction(object):
             # to decode to convert the bytestring into a python str
             return public_key.decode()
 
-        key_pairs = {gen_public_key(SigningKey(private_key)):
-                     SigningKey(private_key) for private_key in private_keys}
+        key_pairs = {gen_public_key(PrivateKey(private_key)):
+                     PrivateKey(private_key) for private_key in private_keys}
 
         zippedIO = enumerate(zip(self.fulfillments, self.conditions))
         for index, (fulfillment, condition) in zippedIO:

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -567,7 +567,7 @@ class Bigchain(object):
         }
 
         vote_data = serialize(vote)
-        signature = crypto.SigningKey(self.me_private).sign(vote_data.encode())
+        signature = crypto.PrivateKey(self.me_private).sign(vote_data.encode())
 
         vote_signed = {
             'node_pubkey': self.me,

--- a/bigchaindb/util.py
+++ b/bigchaindb/util.py
@@ -130,13 +130,13 @@ def verify_vote_signature(voters, signed_vote):
     """
 
     signature = signed_vote['signature']
-    vk_base58 = signed_vote['node_pubkey']
+    pk_base58 = signed_vote['node_pubkey']
 
     # immediately return False if the voter is not in the block voter list
-    if vk_base58 not in voters:
+    if pk_base58 not in voters:
         return False
 
-    public_key = crypto.PublicKey(vk_base58)
+    public_key = crypto.PublicKey(pk_base58)
     return public_key.verify(serialize(signed_vote['vote']).encode(), signature)
 
 

--- a/bigchaindb/util.py
+++ b/bigchaindb/util.py
@@ -136,7 +136,7 @@ def verify_vote_signature(voters, signed_vote):
     if vk_base58 not in voters:
         return False
 
-    public_key = crypto.VerifyingKey(vk_base58)
+    public_key = crypto.PublicKey(vk_base58)
     return public_key.verify(serialize(signed_vote['vote']).encode(), signature)
 
 

--- a/deploy-cluster-aws/write_keypairs_file.py
+++ b/deploy-cluster-aws/write_keypairs_file.py
@@ -10,8 +10,8 @@ Using the list in other Python scripts:
     # in a Python 2 script:
     from keypairs import keypairs_list
     # keypairs_list is a list of (sk, pk) tuples
-    # sk = signing key (private key)
-    # pk = verifying key (public key)
+    # sk = private key
+    # pk = public key
 """
 
 import argparse

--- a/docs/root/source/data-models/block-model.rst
+++ b/docs/root/source/data-models/block-model.rst
@@ -10,8 +10,8 @@ A block has the following structure:
       "block": {
         "timestamp": "<block-creation timestamp>",
         "transactions": ["<list of transactions>"],
-        "node_pubkey": "<public/verifying key of the node creating the block>",
-        "voters": ["<list of federation nodes verifying keys>"]
+        "node_pubkey": "<public key of the node creating the block>",
+        "voters": ["<list of federation nodes public keys>"]
       },
       "signature": "<signature of block>"
     }
@@ -22,12 +22,12 @@ A block has the following structure:
 - ``block``:
     - ``timestamp``: The Unix time when the block was created. It's provided by the node that created the block. See `the page about timestamps <https://docs.bigchaindb.com/en/latest/timestamps.html>`_.
     - ``transactions``: A list of the transactions included in the block.
-    - ``node_pubkey``: The public/verifying key of the node that created the block.
-    - ``voters``: A list of the verifying keys of federation nodes at the time the block was created.
+    - ``node_pubkey``: The public key of the node that created the block.
+    - ``voters``: A list of the public keys of federation nodes at the time the block was created.
       It's the list of federation nodes which can cast a vote on this block.
       This list can change from block to block, as nodes join and leave the federation.
 
-- ``signature``: Cryptographic signature of the block by the node that created the block. (To create the signature, the node serializes the block contents and signs that with its signing key.)
+- ``signature``: Cryptographic signature of the block by the node that created the block. (To create the signature, the node serializes the block contents and signs it with its private key.)
 
 
 Working with Blocks

--- a/docs/root/source/transaction-concepts.md
+++ b/docs/root/source/transaction-concepts.md
@@ -1,29 +1,58 @@
 # Transaction Concepts
 
-In BigchainDB, _Transactions_ are used to register, issue, create or transfer things (e.g. assets).
+In BigchainDB, _Transactions_ are used to register, issue, create or transfer
+things (e.g. assets).
 
-Transactions are the most basic kind of record stored by BigchainDB. There are two kinds: creation transactions and transfer transactions.
+Transactions are the most basic kind of record stored by BigchainDB. There are
+two kinds: creation transactions and transfer transactions.
 
-A _creation transaction_ can be used to register, issue, create or otherwise initiate the history of a single thing (or asset) in BigchainDB. For example, one might register an identity or a creative work. The things are often called "assets" but they might not be literal assets.
+A _creation transaction_ can be used to register, issue, create or otherwise
+initiate the history of a single thing (or asset) in BigchainDB. For example,
+one might register an identity or a creative work. The things are often called
+"assets" but they might not be literal assets.
 
-Currently, BigchainDB only supports indivisible assets. You can't split an asset apart into multiple assets, nor can you combine several assets together into one. [Issue #129](https://github.com/bigchaindb/bigchaindb/issues/129) is an enhancement proposal to support divisible assets.
+Currently, BigchainDB only supports indivisible assets. You can't split an
+asset apart into multiple assets, nor can you combine several assets together
+into one. [Issue #129](https://github.com/bigchaindb/bigchaindb/issues/129) is
+an enhancement proposal to support divisible assets.
 
-A creation transaction also establishes the conditions that must be met to transfer the asset. For example, there may be a condition that any transfer must be signed (cryptographically) by the signing/private key associated with a given verifying/public key. More sophisticated conditions are possible. BigchainDB's conditions are based on the crypto-conditions of the [Interledger Protocol (ILP)](https://interledger.org/).
+A creation transaction also establishes the conditions that must be met to
+transfer the asset. For example, there may be a condition that any transfer
+must be signed (cryptographically) by the private key associated with a
+given public key. More sophisticated conditions are possible.
+BigchainDB's conditions are based on the crypto-conditions of the [Interledger
+Protocol (ILP)](https://interledger.org/).
 
-A _transfer transaction_ can transfer an asset by fulfilling the current conditions on the asset. It can also specify new transfer conditions.
+A _transfer transaction_ can transfer an asset by fulfilling the current
+conditions on the asset. It can also specify new transfer conditions.
 
-Today, every transaction contains one fulfillment-condition pair. The fulfillment in a transfer transaction must fulfill a condition in a previous transaction.
+Today, every transaction contains one fulfillment-condition pair. The
+fulfillment in a transfer transaction must fulfill a condition in a previous
+transaction.
 
-When a node is asked to check if a transaction is valid, it checks several things. Some things it checks are:
+When a node is asked to check if a transaction is valid, it checks several
+things. Some things it checks are:
 
-* Are all the fulfillments valid? (Do they correctly satisfy the conditions they claim to satisfy?)
+* Are all the fulfillments valid? (Do they correctly satisfy the conditions
+  they claim to satisfy?)
 * If it's a creation transaction, is the asset valid?
 * If it's a transfer transaction:
    * Is it trying to fulfill a condition in a nonexistent transaction?
-   * Is it trying to fulfill a condition that's not in a valid transaction? (It's okay if the condition is in a transaction in an invalid block; those transactions are ignored. Transactions in the backlog or undecided blocks are not ignored.)
-   * Is it trying to fulfill a condition that has already been fulfilled, or that some other pending transaction (in the backlog or an undecided block) also aims to fulfill?
-   * Is the asset ID in the transaction the same as the asset ID in all transactions whose conditions are being fulfilled?
+   * Is it trying to fulfill a condition that's not in a valid transaction?
+     (It's okay if the condition is in a transaction in an invalid block; those
+     transactions are ignored. Transactions in the backlog or undecided blocks
+     are not ignored.)
+   * Is it trying to fulfill a condition that has already been fulfilled, or
+     that some other pending transaction (in the backlog or an undecided block)
+     also aims to fulfill?
+   * Is the asset ID in the transaction the same as the asset ID in all
+     transactions whose conditions are being fulfilled?
 
-If you're curious about the details of transaction validation, the code is in the `validate` method of the `Transaction` class, in `bigchaindb/models.py` (at the time of writing).
+If you're curious about the details of transaction validation, the code is in
+the `validate` method of the `Transaction` class, in `bigchaindb/models.py` (at
+the time of writing).
 
-Note: The check to see if the transaction ID is equal to the hash of the transaction body is actually done whenever the transaction is converted from a Python dict to a Transaction object, which must be done before the `validate` method can be called (since it's called on a Transaction object).
+Note: The check to see if the transaction ID is equal to the hash of the
+transaction body is actually done whenever the transaction is converted from a
+Python dict to a Transaction object, which must be done before the `validate`
+method can be called (since it's called on a Transaction object).

--- a/docs/server/source/appendices/cryptography.md
+++ b/docs/server/source/appendices/cryptography.md
@@ -1,12 +1,16 @@
 # Cryptography
 
-The section documents the cryptographic algorithms and Python implementations that we use.
+The section documents the cryptographic algorithms and Python implementations
+that we use.
 
-Before hashing or computing the signature of a JSON document, we serialize it as described in [the section on JSON serialization](json-serialization.html).
+Before hashing or computing the signature of a JSON document, we serialize it
+as described in [the section on JSON serialization](json-serialization.html).
 
 ## Hashes
 
-We compute hashes using the SHA3-256 algorithm and [pysha3](https://bitbucket.org/tiran/pykeccak) as the Python implementation. We store the hex-encoded hash in the database. For example:
+We compute hashes using the SHA3-256 algorithm and
+[pysha3](https://bitbucket.org/tiran/pykeccak) as the Python implementation. We
+store the hex-encoded hash in the database. For example:
 
 ```python
 import hashlib
@@ -19,8 +23,16 @@ tx_hash = hashlib.sha3_256(data).hexdigest()
 
 ## Signature Algorithm and Keys
 
-BigchainDB uses the [Ed25519](https://ed25519.cr.yp.to/) public-key signature system for generating its public/private key pairs (also called verifying/signing keys). Ed25519 is an instance of the [Edwards-curve Digital Signature Algorithm (EdDSA)](https://en.wikipedia.org/wiki/EdDSA). As of April 2016, EdDSA was in ["Internet-Draft" status with the IETF](https://tools.ietf.org/html/draft-irtf-cfrg-eddsa-05) but was [already widely used](https://ianix.com/pub/ed25519-deployment.html).
+BigchainDB uses the [Ed25519](https://ed25519.cr.yp.to/) public-key signature
+system for generating its public/private key pairs. Ed25519 is an instance of
+the [Edwards-curve Digital Signature Algorithm
+(EdDSA)](https://en.wikipedia.org/wiki/EdDSA). As of April 2016, EdDSA was in
+["Internet-Draft" status with the
+IETF](https://tools.ietf.org/html/draft-irtf-cfrg-eddsa-05) but was [already
+widely used](https://ianix.com/pub/ed25519-deployment.html).
 
-BigchainDB uses the the [ed25519](https://github.com/warner/python-ed25519) Python package, overloaded by the [cryptoconditions library](https://github.com/bigchaindb/cryptoconditions).
+BigchainDB uses the the [ed25519](https://github.com/warner/python-ed25519)
+Python package, overloaded by the [cryptoconditions
+library](https://github.com/bigchaindb/cryptoconditions).
 
 All keys are represented with the base58 encoding by default.

--- a/docs/server/source/appendices/json-serialization.md
+++ b/docs/server/source/appendices/json-serialization.md
@@ -52,5 +52,5 @@ signature = sk.sign(tx_serialized)
 
 # verify signature
 tx_serialized = bytes(serialize(tx))
-vk.verify(signature, tx_serialized)
+pk.verify(signature, tx_serialized)
 ```

--- a/tests/assets/test_digital_assets.py
+++ b/tests/assets/test_digital_assets.py
@@ -145,15 +145,15 @@ def test_get_txs_by_asset_id(b, user_pk, user_sk):
 
 
 @pytest.mark.usefixtures('inputs')
-def test_get_asset_by_id(b, user_vk, user_sk):
+def test_get_asset_by_id(b, user_pk, user_sk):
     from bigchaindb.models import Transaction
 
-    tx_create = b.get_owned_ids(user_vk).pop()
+    tx_create = b.get_owned_ids(user_pk).pop()
     tx_create = b.get_transaction(tx_create.txid)
     asset_id = tx_create.asset.data_id
 
     # create a transfer transaction
-    tx_transfer = Transaction.transfer(tx_create.to_inputs(), [([user_vk], 1)],
+    tx_transfer = Transaction.transfer(tx_create.to_inputs(), [([user_pk], 1)],
                                        tx_create.asset)
     tx_transfer_signed = tx_transfer.sign([user_sk])
     # create the block
@@ -170,7 +170,7 @@ def test_get_asset_by_id(b, user_vk, user_sk):
     assert asset == tx_create.asset
 
 
-def test_create_invalid_divisible_asset(b, user_vk, user_sk):
+def test_create_invalid_divisible_asset(b, user_pk, user_sk):
     from bigchaindb.models import Transaction, Asset
     from bigchaindb.common.exceptions import AmountError
 
@@ -178,19 +178,19 @@ def test_create_invalid_divisible_asset(b, user_vk, user_sk):
     # Transaction.__init__ should raise an exception
     asset = Asset(divisible=False)
     with pytest.raises(AmountError):
-        Transaction.create([user_vk], [([user_vk], 2)], asset=asset)
+        Transaction.create([user_pk], [([user_pk], 2)], asset=asset)
 
     # divisible assets need to have an amount > 1
     # Transaction.__init__ should raise an exception
     asset = Asset(divisible=True)
     with pytest.raises(AmountError):
-        Transaction.create([user_vk], [([user_vk], 1)], asset=asset)
+        Transaction.create([user_pk], [([user_pk], 1)], asset=asset)
 
     # even if a transaction is badly constructed the server should raise the
     # exception
     asset = Asset(divisible=False)
     with patch.object(Asset, 'validate_asset', return_value=None):
-        tx = Transaction.create([user_vk], [([user_vk], 2)], asset=asset)
+        tx = Transaction.create([user_pk], [([user_pk], 2)], asset=asset)
         tx_signed = tx.sign([user_sk])
     with pytest.raises(AmountError):
         tx_signed.validate(b)
@@ -198,17 +198,17 @@ def test_create_invalid_divisible_asset(b, user_vk, user_sk):
 
     asset = Asset(divisible=True)
     with patch.object(Asset, 'validate_asset', return_value=None):
-        tx = Transaction.create([user_vk], [([user_vk], 1)], asset=asset)
+        tx = Transaction.create([user_pk], [([user_pk], 1)], asset=asset)
         tx_signed = tx.sign([user_sk])
     with pytest.raises(AmountError):
         tx_signed.validate(b)
     assert b.is_valid_transaction(tx_signed) is False
 
 
-def test_create_valid_divisible_asset(b, user_vk, user_sk):
+def test_create_valid_divisible_asset(b, user_pk, user_sk):
     from bigchaindb.models import Transaction, Asset
 
     asset = Asset(divisible=True)
-    tx = Transaction.create([user_vk], [([user_vk], 2)], asset=asset)
+    tx = Transaction.create([user_pk], [([user_pk], 2)], asset=asset)
     tx_signed = tx.sign([user_sk])
     assert b.is_valid_transaction(tx_signed)

--- a/tests/assets/test_divisible_assets.py
+++ b/tests/assets/test_divisible_assets.py
@@ -10,12 +10,12 @@ from ..db.conftest import inputs  # noqa
 # Single owners_before
 # Single output
 # Single owners_after
-def test_single_in_single_own_single_out_single_own_create(b, user_vk):
+def test_single_in_single_own_single_out_single_own_create(b, user_pk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
     asset = Asset(divisible=True)
-    tx = Transaction.create([b.me], [([user_vk], 100)], asset=asset)
+    tx = Transaction.create([b.me], [([user_pk], 100)], asset=asset)
     tx_signed = tx.sign([b.me_private])
 
     assert tx_signed.validate(b) == tx_signed
@@ -29,12 +29,12 @@ def test_single_in_single_own_single_out_single_own_create(b, user_vk):
 # Single owners_before
 # Multiple outputs
 # Single owners_after per output
-def test_single_in_single_own_multiple_out_single_own_create(b, user_vk):
+def test_single_in_single_own_multiple_out_single_own_create(b, user_pk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
     asset = Asset(divisible=True)
-    tx = Transaction.create([b.me], [([user_vk], 50), ([user_vk], 50)],
+    tx = Transaction.create([b.me], [([user_pk], 50), ([user_pk], 50)],
                             asset=asset)
     tx_signed = tx.sign([b.me_private])
 
@@ -50,12 +50,12 @@ def test_single_in_single_own_multiple_out_single_own_create(b, user_vk):
 # Single owners_before
 # Single output
 # Multiple owners_after
-def test_single_in_single_own_single_out_multiple_own_create(b, user_vk):
+def test_single_in_single_own_single_out_multiple_own_create(b, user_pk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
     asset = Asset(divisible=True)
-    tx = Transaction.create([b.me], [([user_vk, user_vk], 100)], asset=asset)
+    tx = Transaction.create([b.me], [([user_pk, user_pk], 100)], asset=asset)
     tx_signed = tx.sign([b.me_private])
 
     assert tx_signed.validate(b) == tx_signed
@@ -75,13 +75,13 @@ def test_single_in_single_own_single_out_multiple_own_create(b, user_vk):
 # Multiple outputs
 # Mix: one output with a single owners_after, one output with multiple
 #      owners_after
-def test_single_in_single_own_multiple_out_mix_own_create(b, user_vk):
+def test_single_in_single_own_multiple_out_mix_own_create(b, user_pk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
     asset = Asset(divisible=True)
     tx = Transaction.create([b.me],
-                            [([user_vk], 50), ([user_vk, user_vk], 50)],
+                            [([user_pk], 50), ([user_pk, user_pk], 50)],
                             asset=asset)
     tx_signed = tx.sign([b.me_private])
 
@@ -101,13 +101,13 @@ def test_single_in_single_own_multiple_out_mix_own_create(b, user_vk):
 # Single input
 # Multiple owners_before
 # Output combinations already tested above
-def test_single_in_multiple_own_single_out_single_own_create(b, user_vk,
+def test_single_in_multiple_own_single_out_single_own_create(b, user_pk,
                                                              user_sk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
     asset = Asset(divisible=True)
-    tx = Transaction.create([b.me, user_vk], [([user_vk], 100)], asset=asset)
+    tx = Transaction.create([b.me, user_pk], [([user_pk], 100)], asset=asset)
     tx_signed = tx.sign([b.me_private, user_sk])
     assert tx_signed.validate(b) == tx_signed
     assert len(tx_signed.conditions) == 1
@@ -129,14 +129,14 @@ def test_single_in_multiple_own_single_out_single_own_create(b, user_vk,
 #       fail.
 #       Is there a better way of doing this?
 @pytest.mark.usefixtures('inputs')
-def test_single_in_single_own_single_out_single_own_transfer(b, user_vk,
+def test_single_in_single_own_single_out_single_own_transfer(b, user_pk,
                                                              user_sk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset
     asset = Asset(divisible=True)
-    tx_create = Transaction.create([b.me], [([user_vk], 100)], asset=asset)
+    tx_create = Transaction.create([b.me], [([user_pk], 100)], asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
     block = b.create_block([tx_create_signed])
@@ -163,14 +163,14 @@ def test_single_in_single_own_single_out_single_own_transfer(b, user_vk,
 # Multiple output
 # Single owners_after
 @pytest.mark.usefixtures('inputs')
-def test_single_in_single_own_multiple_out_single_own_transfer(b, user_vk,
+def test_single_in_single_own_multiple_out_single_own_transfer(b, user_pk,
                                                                user_sk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset
     asset = Asset(divisible=True)
-    tx_create = Transaction.create([b.me], [([user_vk], 100)], asset=asset)
+    tx_create = Transaction.create([b.me], [([user_pk], 100)], asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
     block = b.create_block([tx_create_signed])
@@ -199,14 +199,14 @@ def test_single_in_single_own_multiple_out_single_own_transfer(b, user_vk,
 # Single output
 # Multiple owners_after
 @pytest.mark.usefixtures('inputs')
-def test_single_in_single_own_single_out_multiple_own_transfer(b, user_vk,
+def test_single_in_single_own_single_out_multiple_own_transfer(b, user_pk,
                                                                user_sk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset
     asset = Asset(divisible=True)
-    tx_create = Transaction.create([b.me], [([user_vk], 100)], asset=asset)
+    tx_create = Transaction.create([b.me], [([user_pk], 100)], asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
     block = b.create_block([tx_create_signed])
@@ -240,14 +240,14 @@ def test_single_in_single_own_single_out_multiple_own_transfer(b, user_vk,
 # Mix: one output with a single owners_after, one output with multiple
 #      owners_after
 @pytest.mark.usefixtures('inputs')
-def test_single_in_single_own_multiple_out_mix_own_transfer(b, user_vk,
+def test_single_in_single_own_multiple_out_mix_own_transfer(b, user_pk,
                                                             user_sk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset
     asset = Asset(divisible=True)
-    tx_create = Transaction.create([b.me], [([user_vk], 100)], asset=asset)
+    tx_create = Transaction.create([b.me], [([user_pk], 100)], asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
     block = b.create_block([tx_create_signed])
@@ -281,14 +281,14 @@ def test_single_in_single_own_multiple_out_mix_own_transfer(b, user_vk,
 # Single output
 # Single owners_after
 @pytest.mark.usefixtures('inputs')
-def test_single_in_multiple_own_single_out_single_own_transfer(b, user_vk,
+def test_single_in_multiple_own_single_out_single_own_transfer(b, user_pk,
                                                                user_sk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset
     asset = Asset(divisible=True)
-    tx_create = Transaction.create([b.me], [([b.me, user_vk], 100)],
+    tx_create = Transaction.create([b.me], [([b.me, user_pk], 100)],
                                    asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
@@ -320,14 +320,14 @@ def test_single_in_multiple_own_single_out_single_own_transfer(b, user_vk,
 # Single output
 # Single owners_after
 @pytest.mark.usefixtures('inputs')
-def test_multiple_in_single_own_single_out_single_own_transfer(b, user_vk,
+def test_multiple_in_single_own_single_out_single_own_transfer(b, user_pk,
                                                                user_sk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset
     asset = Asset(divisible=True)
-    tx_create = Transaction.create([b.me], [([user_vk], 50), ([user_vk], 50)],
+    tx_create = Transaction.create([b.me], [([user_pk], 50), ([user_pk], 50)],
                                    asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
@@ -355,7 +355,7 @@ def test_multiple_in_single_own_single_out_single_own_transfer(b, user_vk,
 # Single output
 # Single owners_after
 @pytest.mark.usefixtures('inputs')
-def test_multiple_in_multiple_own_single_out_single_own_transfer(b, user_vk,
+def test_multiple_in_multiple_own_single_out_single_own_transfer(b, user_pk,
                                                                  user_sk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
@@ -363,8 +363,8 @@ def test_multiple_in_multiple_own_single_out_single_own_transfer(b, user_vk,
     # CREATE divisible asset
     asset = Asset(divisible=True)
     tx_create = Transaction.create([b.me],
-                                   [([user_vk, b.me], 50),
-                                    ([user_vk, b.me], 50)],
+                                   [([user_pk, b.me], 50),
+                                    ([user_pk, b.me], 50)],
                                    asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
@@ -400,7 +400,7 @@ def test_multiple_in_multiple_own_single_out_single_own_transfer(b, user_vk,
 # Single output
 # Single owners_after
 @pytest.mark.usefixtures('inputs')
-def test_muiltiple_in_mix_own_multiple_out_single_own_transfer(b, user_vk,
+def test_muiltiple_in_mix_own_multiple_out_single_own_transfer(b, user_pk,
                                                                user_sk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
@@ -408,8 +408,8 @@ def test_muiltiple_in_mix_own_multiple_out_single_own_transfer(b, user_vk,
     # CREATE divisible asset
     asset = Asset(divisible=True)
     tx_create = Transaction.create([b.me],
-                                   [([user_vk], 50),
-                                    ([user_vk, b.me], 50)],
+                                   [([user_pk], 50),
+                                    ([user_pk, b.me], 50)],
                                    asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
@@ -445,7 +445,7 @@ def test_muiltiple_in_mix_own_multiple_out_single_own_transfer(b, user_vk,
 # Mix: one output with a single owners_after, one output with multiple
 #      owners_after
 @pytest.mark.usefixtures('inputs')
-def test_muiltiple_in_mix_own_multiple_out_mix_own_transfer(b, user_vk,
+def test_muiltiple_in_mix_own_multiple_out_mix_own_transfer(b, user_pk,
                                                             user_sk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
@@ -453,8 +453,8 @@ def test_muiltiple_in_mix_own_multiple_out_mix_own_transfer(b, user_vk,
     # CREATE divisible asset
     asset = Asset(divisible=True)
     tx_create = Transaction.create([b.me],
-                                   [([user_vk], 50),
-                                    ([user_vk, b.me], 50)],
+                                   [([user_pk], 50),
+                                    ([user_pk, b.me], 50)],
                                    asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
@@ -467,7 +467,7 @@ def test_muiltiple_in_mix_own_multiple_out_mix_own_transfer(b, user_vk,
 
     # TRANSFER
     tx_transfer = Transaction.transfer(tx_create.to_inputs(),
-                                       [([b.me], 50), ([b.me, user_vk], 50)],
+                                       [([b.me], 50), ([b.me, user_pk], 50)],
                                        asset=tx_create.asset)
     tx_transfer_signed = tx_transfer.sign([b.me_private, user_sk])
 
@@ -496,16 +496,16 @@ def test_muiltiple_in_mix_own_multiple_out_mix_own_transfer(b, user_vk,
 # Single output
 # Single owners_after
 @pytest.mark.usefixtures('inputs')
-def test_multiple_in_different_transactions(b, user_vk, user_sk):
+def test_multiple_in_different_transactions(b, user_pk, user_sk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset
     # `b` creates a divisible asset and assigns 50 shares to `b` and
-    # 50 shares to `user_vk`
+    # 50 shares to `user_pk`
     asset = Asset(divisible=True)
     tx_create = Transaction.create([b.me],
-                                   [([user_vk], 50),
+                                   [([user_pk], 50),
                                     ([b.me], 50)],
                                    asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
@@ -518,11 +518,11 @@ def test_multiple_in_different_transactions(b, user_vk, user_sk):
     b.write_vote(vote)
 
     # TRANSFER divisible asset
-    # `b` transfers its 50 shares to `user_vk`
-    # after this transaction `user_vk` will have a total of 100 shares
+    # `b` transfers its 50 shares to `user_pk`
+    # after this transaction `user_pk` will have a total of 100 shares
     # split across two different transactions
     tx_transfer1 = Transaction.transfer(tx_create.to_inputs([1]),
-                                        [([user_vk], 50)],
+                                        [([user_pk], 50)],
                                         asset=tx_create.asset)
     tx_transfer1_signed = tx_transfer1.sign([b.me_private])
     # create block
@@ -534,7 +534,7 @@ def test_multiple_in_different_transactions(b, user_vk, user_sk):
     b.write_vote(vote)
 
     # TRANSFER
-    # `user_vk` combines two different transaction with 50 shares each and
+    # `user_pk` combines two different transaction with 50 shares each and
     # transfers a total of 100 shares back to `b`
     tx_transfer2 = Transaction.transfer(tx_create.to_inputs([0]) +
                                         tx_transfer1.to_inputs([0]),
@@ -557,14 +557,14 @@ def test_multiple_in_different_transactions(b, user_vk, user_sk):
 # inputs needs to match the amount being sent in the outputs.
 # In other words `amount_in_inputs - amount_in_outputs == 0`
 @pytest.mark.usefixtures('inputs')
-def test_amount_error_transfer(b, user_vk, user_sk):
+def test_amount_error_transfer(b, user_pk, user_sk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
     from bigchaindb.common.exceptions import AmountError
 
     # CREATE divisible asset
     asset = Asset(divisible=True)
-    tx_create = Transaction.create([b.me], [([user_vk], 100)], asset=asset)
+    tx_create = Transaction.create([b.me], [([user_pk], 100)], asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
     block = b.create_block([tx_create_signed])
@@ -593,7 +593,7 @@ def test_amount_error_transfer(b, user_vk, user_sk):
 
 @pytest.mark.skip(reason='Figure out how to handle this case')
 @pytest.mark.usefixtures('inputs')
-def test_threshold_same_public_key(b, user_vk, user_sk):
+def test_threshold_same_public_key(b, user_pk, user_sk):
     # If we try to fulfill a threshold condition where each subcondition has
     # the same key get_subcondition_from_vk will always return the first
     # subcondition. This means that only the 1st subfulfillment will be
@@ -606,7 +606,7 @@ def test_threshold_same_public_key(b, user_vk, user_sk):
 
     # CREATE divisible asset
     asset = Asset(divisible=True)
-    tx_create = Transaction.create([b.me], [([user_vk, user_vk], 100)],
+    tx_create = Transaction.create([b.me], [([user_pk, user_pk], 100)],
                                    asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
@@ -626,16 +626,16 @@ def test_threshold_same_public_key(b, user_vk, user_sk):
 
 
 @pytest.mark.usefixtures('inputs')
-def test_sum_amount(b, user_vk, user_sk):
+def test_sum_amount(b, user_pk, user_sk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset with 3 outputs with amount 1
     asset = Asset(divisible=True)
     tx_create = Transaction.create([b.me],
-                                   [([user_vk], 1),
-                                    ([user_vk], 1),
-                                    ([user_vk], 1)],
+                                   [([user_pk], 1),
+                                    ([user_pk], 1),
+                                    ([user_pk], 1)],
                                    asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
@@ -658,13 +658,13 @@ def test_sum_amount(b, user_vk, user_sk):
 
 
 @pytest.mark.usefixtures('inputs')
-def test_divide(b, user_vk, user_sk):
+def test_divide(b, user_pk, user_sk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset with 1 output with amount 3
     asset = Asset(divisible=True)
-    tx_create = Transaction.create([b.me], [([user_vk], 3)],
+    tx_create = Transaction.create([b.me], [([user_pk], 3)],
                                    asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
@@ -690,14 +690,14 @@ def test_divide(b, user_vk, user_sk):
 
 # Check that negative inputs are caught when creating a TRANSFER transaction
 @pytest.mark.usefixtures('inputs')
-def test_non_positive_amounts_on_transfer(b, user_vk):
+def test_non_positive_amounts_on_transfer(b, user_pk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
     from bigchaindb.common.exceptions import AmountError
 
     # CREATE divisible asset with 1 output with amount 3
     asset = Asset(divisible=True)
-    tx_create = Transaction.create([b.me], [([user_vk], 3)],
+    tx_create = Transaction.create([b.me], [([user_pk], 3)],
                                    asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
@@ -716,14 +716,14 @@ def test_non_positive_amounts_on_transfer(b, user_vk):
 
 # Check that negative inputs are caught when validating a TRANSFER transaction
 @pytest.mark.usefixtures('inputs')
-def test_non_positive_amounts_on_transfer_validate(b, user_vk, user_sk):
+def test_non_positive_amounts_on_transfer_validate(b, user_pk, user_sk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
     from bigchaindb.common.exceptions import AmountError
 
     # CREATE divisible asset with 1 output with amount 3
     asset = Asset(divisible=True)
-    tx_create = Transaction.create([b.me], [([user_vk], 3)],
+    tx_create = Transaction.create([b.me], [([user_pk], 3)],
                                    asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
@@ -748,7 +748,7 @@ def test_non_positive_amounts_on_transfer_validate(b, user_vk, user_sk):
 
 # Check that negative inputs are caught when creating a CREATE transaction
 @pytest.mark.usefixtures('inputs')
-def test_non_positive_amounts_on_create(b, user_vk):
+def test_non_positive_amounts_on_create(b, user_pk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
     from bigchaindb.common.exceptions import AmountError
@@ -756,20 +756,20 @@ def test_non_positive_amounts_on_create(b, user_vk):
     # CREATE divisible asset with 1 output with amount 3
     asset = Asset(divisible=True)
     with pytest.raises(AmountError):
-        Transaction.create([b.me], [([user_vk], -3)],
+        Transaction.create([b.me], [([user_pk], -3)],
                            asset=asset)
 
 
 # Check that negative inputs are caught when validating a CREATE transaction
 @pytest.mark.usefixtures('inputs')
-def test_non_positive_amounts_on_create_validate(b, user_vk):
+def test_non_positive_amounts_on_create_validate(b, user_pk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
     from bigchaindb.common.exceptions import AmountError
 
     # CREATE divisible asset with 1 output with amount 3
     asset = Asset(divisible=True)
-    tx_create = Transaction.create([b.me], [([user_vk], 3)],
+    tx_create = Transaction.create([b.me], [([user_pk], 3)],
                                    asset=asset)
     tx_create.conditions[0].amount = -3
     with patch.object(Asset, 'validate_asset', return_value=None):

--- a/tests/common/test_transaction.py
+++ b/tests/common/test_transaction.py
@@ -553,12 +553,12 @@ def test_sign_with_invalid_parameters(utx, user_priv):
 
 def test_validate_tx_simple_create_signature(user_ffill, user_cond, user_priv):
     from copy import deepcopy
-    from bigchaindb.common.crypto import SigningKey
+    from bigchaindb.common.crypto import PrivateKey
     from bigchaindb.common.transaction import Transaction, Asset
 
     tx = Transaction(Transaction.CREATE, Asset(), [user_ffill], [user_cond])
     expected = deepcopy(user_cond)
-    expected.fulfillment.sign(str(tx).encode(), SigningKey(user_priv))
+    expected.fulfillment.sign(str(tx).encode(), PrivateKey(user_priv))
     tx.sign([user_priv])
 
     assert tx.fulfillments[0].to_dict()['fulfillment'] == \
@@ -611,7 +611,7 @@ def test_validate_fulfillment_with_invalid_parameters(utx):
 def test_validate_multiple_fulfillments(user_ffill, user_cond, user_priv):
     from copy import deepcopy
 
-    from bigchaindb.common.crypto import SigningKey
+    from bigchaindb.common.crypto import PrivateKey
     from bigchaindb.common.transaction import Transaction, Asset
 
     tx = Transaction(Transaction.CREATE, Asset(),
@@ -627,10 +627,10 @@ def test_validate_multiple_fulfillments(user_ffill, user_cond, user_priv):
 
     expected_first_bytes = str(expected_first).encode()
     expected_first.fulfillments[0].fulfillment.sign(expected_first_bytes,
-                                                    SigningKey(user_priv))
+                                                    PrivateKey(user_priv))
     expected_second_bytes = str(expected_second).encode()
     expected_second.fulfillments[0].fulfillment.sign(expected_second_bytes,
-                                                     SigningKey(user_priv))
+                                                     PrivateKey(user_priv))
     tx.sign([user_priv])
 
     assert tx.fulfillments[0].to_dict()['fulfillment'] == \
@@ -648,16 +648,16 @@ def test_validate_tx_threshold_create_signature(user_user2_threshold_ffill,
                                                 user2_priv):
     from copy import deepcopy
 
-    from bigchaindb.common.crypto import SigningKey
+    from bigchaindb.common.crypto import PrivateKey
     from bigchaindb.common.transaction import Transaction, Asset
 
     tx = Transaction(Transaction.CREATE, Asset(), [user_user2_threshold_ffill],
                      [user_user2_threshold_cond])
     expected = deepcopy(user_user2_threshold_cond)
     expected.fulfillment.subconditions[0]['body'].sign(str(tx).encode(),
-                                                       SigningKey(user_priv))
+                                                       PrivateKey(user_priv))
     expected.fulfillment.subconditions[1]['body'].sign(str(tx).encode(),
-                                                       SigningKey(user2_priv))
+                                                       PrivateKey(user2_priv))
     tx.sign([user_priv, user2_priv])
 
     assert tx.fulfillments[0].to_dict()['fulfillment'] == \
@@ -965,7 +965,7 @@ def test_conditions_to_inputs(tx):
 def test_create_transfer_transaction_single_io(tx, user_pub, user2_pub,
                                                user2_cond, user_priv, data_id):
     from copy import deepcopy
-    from bigchaindb.common.crypto import SigningKey
+    from bigchaindb.common.crypto import PrivateKey
     from bigchaindb.common.transaction import Transaction, Asset
     from bigchaindb.common.util import serialize
 
@@ -1004,7 +1004,7 @@ def test_create_transfer_transaction_single_io(tx, user_pub, user2_pub,
     expected['id'] = transfer_tx['id']
     expected['transaction']['timestamp'] = transfer_tx_body['timestamp']
     expected_input.fulfillment.sign(serialize(expected).encode(),
-                                    SigningKey(user_priv))
+                                    PrivateKey(user_priv))
     expected_ffill = expected_input.fulfillment.serialize_uri()
     transfer_ffill = transfer_tx_body['fulfillments'][0]['fulfillment']
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,8 @@ CONFIG = {
 }
 
 # Test user. inputs will be created for this user. Cryptography Keys
-USER_SIGNING_KEY = '8eJ8q9ZQpReWyQT5aFCiwtZ5wDZC4eDnCen88p3tQ6ie'
-USER_VERIFYING_KEY = 'JEAkEJqLbbgDRAtMm8YAjGp759Aq2qTn9eaEHUj2XePE'
+USER_PRIVATE_KEY = '8eJ8q9ZQpReWyQT5aFCiwtZ5wDZC4eDnCen88p3tQ6ie'
+USER_PUBLIC_KEY = 'JEAkEJqLbbgDRAtMm8YAjGp759Aq2qTn9eaEHUj2XePE'
 
 
 # We need this function to avoid loading an existing
@@ -54,12 +54,12 @@ def node_config():
 
 @pytest.fixture
 def user_sk():
-    return USER_SIGNING_KEY
+    return USER_PRIVATE_KEY
 
 
 @pytest.fixture
 def user_vk():
-    return USER_VERIFYING_KEY
+    return USER_PUBLIC_KEY
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def user_sk():
 
 
 @pytest.fixture
-def user_vk():
+def user_pk():
     return USER_PUBLIC_KEY
 
 
@@ -70,9 +70,9 @@ def b(request, node_config):
 
 
 @pytest.fixture
-def create_tx(b, user_vk):
+def create_tx(b, user_pk):
     from bigchaindb.models import Transaction
-    return Transaction.create([b.me], [user_vk])
+    return Transaction.create([b.me], [user_pk])
 
 
 @pytest.fixture
@@ -81,8 +81,8 @@ def signed_create_tx(b, create_tx):
 
 
 @pytest.fixture
-def signed_transfer_tx(signed_create_tx, user_vk, user_sk):
+def signed_transfer_tx(signed_create_tx, user_pk, user_sk):
     from bigchaindb.models import Transaction
     inputs = signed_create_tx.to_inputs()
-    tx = Transaction.transfer(inputs, [user_vk], signed_create_tx.asset)
+    tx = Transaction.transfer(inputs, [user_pk], signed_create_tx.asset)
     return tx.sign([user_sk])

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -14,7 +14,7 @@ from bigchaindb.db import get_conn, init_database
 from bigchaindb.common import crypto
 from bigchaindb.common.exceptions import DatabaseAlreadyExists
 
-USER2_SK, USER2_VK = crypto.generate_key_pair()
+USER2_SK, USER2_PK = crypto.generate_key_pair()
 
 
 @pytest.fixture(autouse=True)
@@ -70,7 +70,7 @@ def cleanup_tables(request, node_config):
 
 
 @pytest.fixture
-def inputs(user_vk):
+def inputs(user_pk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.exceptions import GenesisBlockAlreadyExistsError
     # 1. create the genesis block
@@ -84,7 +84,7 @@ def inputs(user_vk):
     prev_block_id = g.id
     for block in range(4):
         transactions = [
-            Transaction.create([b.me], [user_vk]).sign([b.me_private])
+            Transaction.create([b.me], [user_pk]).sign([b.me_private])
             for i in range(10)
         ]
         block = b.create_block(transactions)
@@ -102,12 +102,12 @@ def user2_sk():
 
 
 @pytest.fixture
-def user2_vk():
-    return USER2_VK
+def user2_pk():
+    return USER2_PK
 
 
 @pytest.fixture
-def inputs_shared(user_vk, user2_vk):
+def inputs_shared(user_pk, user2_pk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.exceptions import GenesisBlockAlreadyExistsError
     # 1. create the genesis block
@@ -122,7 +122,7 @@ def inputs_shared(user_vk, user2_vk):
     for block in range(4):
         transactions = [
             Transaction.create(
-                [b.me], [user_vk, user2_vk], payload={'i': i}).sign([b.me_private])
+                [b.me], [user_pk, user2_pk], payload={'i': i}).sign([b.me_private])
             for i in range(10)
         ]
         block = b.create_block(transactions)

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -30,7 +30,7 @@ def dummy_block():
 
 class TestBigchainApi(object):
     def test_get_last_voted_block_cyclic_blockchain(self, b, monkeypatch):
-        from bigchaindb.common.crypto import SigningKey
+        from bigchaindb.common.crypto import PrivateKey
         from bigchaindb.common.exceptions import CyclicBlockchainError
         from bigchaindb.common.util import serialize
         from bigchaindb.models import Transaction
@@ -47,7 +47,7 @@ class TestBigchainApi(object):
         vote = b.vote(block1.id, b.get_last_voted_block().id, True)
         vote['vote']['previous_block'] = block1.id
         vote_data = serialize(vote['vote'])
-        vote['signature'] = SigningKey(b.me_private).sign(vote_data.encode())
+        vote['signature'] = PrivateKey(b.me_private).sign(vote_data.encode())
         b.write_vote(vote)
 
         with pytest.raises(CyclicBlockchainError):
@@ -734,7 +734,7 @@ class TestBlockValidation(object):
         #       skipped
         block_data = util.serialize_block(block)
         block_hash = crypto.hash_data(block_data)
-        block_signature = crypto.SigningKey(b.me_private).sign(block_data)
+        block_signature = crypto.PrivateKey(b.me_private).sign(block_data)
 
         block = {
             'id': block_hash,
@@ -758,7 +758,7 @@ class TestBlockValidation(object):
         block = dummy_block()
 
         # replace the block signature with an invalid one
-        block.signature = crypto.SigningKey(b.me_private).sign(b'wrongdata')
+        block.signature = crypto.PrivateKey(b.me_private).sign(b'wrongdata')
 
         # check that validate_block raises an InvalidSignature exception
         with pytest.raises(InvalidSignature):

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -594,12 +594,12 @@ class TestBigchainApi(object):
         with pytest.raises(TransactionDoesNotExist):
             tx.validate(Bigchain())
 
-    def test_count_backlog(self, b, user_vk):
+    def test_count_backlog(self, b, user_pk):
         from bigchaindb.models import Transaction
 
         for _ in range(4):
             tx = Transaction.create([b.me],
-                                    [([user_vk], 1)]).sign([b.me_private])
+                                    [([user_pk], 1)]).sign([b.me_private])
             b.write_transaction(tx)
 
         assert b.backend.count_backlog() == 4

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -181,11 +181,11 @@ class TestBigchainApi(object):
         assert b.get_transaction(tx1.id) is None
         assert b.get_transaction(tx2.id) == tx2
 
-    def test_get_transactions_for_metadata(self, b, user_vk):
+    def test_get_transactions_for_metadata(self, b, user_pk):
         from bigchaindb.models import Transaction
 
         metadata = {'msg': 'Hello BigchainDB!'}
-        tx = Transaction.create([b.me], [user_vk], metadata=metadata)
+        tx = Transaction.create([b.me], [user_pk], metadata=metadata)
 
         block = b.create_block([tx])
         b.write_block(block, durability='hard')
@@ -194,18 +194,18 @@ class TestBigchainApi(object):
         assert len(matches) == 1
         assert matches[0].id == tx.id
 
-    def test_get_transactions_for_metadata(self, b, user_vk):
+    def test_get_transactions_for_metadata(self, b, user_pk):
         matches = b.get_tx_by_metadata_id('missing')
         assert not matches
 
     @pytest.mark.usefixtures('inputs')
-    def test_write_transaction(self, b, user_vk, user_sk):
+    def test_write_transaction(self, b, user_pk, user_sk):
         from bigchaindb.models import Transaction
 
-        input_tx = b.get_owned_ids(user_vk).pop()
+        input_tx = b.get_owned_ids(user_pk).pop()
         input_tx = b.get_transaction(input_tx.txid)
         inputs = input_tx.to_inputs()
-        tx = Transaction.transfer(inputs, [user_vk], input_tx.asset)
+        tx = Transaction.transfer(inputs, [user_pk], input_tx.asset)
         tx = tx.sign([user_sk])
         response = b.write_transaction(tx)
 
@@ -217,13 +217,13 @@ class TestBigchainApi(object):
         assert response['inserted'] == 1
 
     @pytest.mark.usefixtures('inputs')
-    def test_read_transaction(self, b, user_vk, user_sk):
+    def test_read_transaction(self, b, user_pk, user_sk):
         from bigchaindb.models import Transaction
 
-        input_tx = b.get_owned_ids(user_vk).pop()
+        input_tx = b.get_owned_ids(user_pk).pop()
         input_tx = b.get_transaction(input_tx.txid)
         inputs = input_tx.to_inputs()
-        tx = Transaction.transfer(inputs, [user_vk], input_tx.asset)
+        tx = Transaction.transfer(inputs, [user_pk], input_tx.asset)
         tx = tx.sign([user_sk])
         b.write_transaction(tx)
 
@@ -237,13 +237,13 @@ class TestBigchainApi(object):
         assert status == b.TX_UNDECIDED
 
     @pytest.mark.usefixtures('inputs')
-    def test_read_transaction_invalid_block(self, b, user_vk, user_sk):
+    def test_read_transaction_invalid_block(self, b, user_pk, user_sk):
         from bigchaindb.models import Transaction
 
-        input_tx = b.get_owned_ids(user_vk).pop()
+        input_tx = b.get_owned_ids(user_pk).pop()
         input_tx = b.get_transaction(input_tx.txid)
         inputs = input_tx.to_inputs()
-        tx = Transaction.transfer(inputs, [user_vk], input_tx.asset)
+        tx = Transaction.transfer(inputs, [user_pk], input_tx.asset)
         tx = tx.sign([user_sk])
         # There's no need to b.write_transaction(tx) to the backlog
 
@@ -261,13 +261,13 @@ class TestBigchainApi(object):
         assert response is None
 
     @pytest.mark.usefixtures('inputs')
-    def test_read_transaction_invalid_block_and_backlog(self, b, user_vk, user_sk):
+    def test_read_transaction_invalid_block_and_backlog(self, b, user_pk, user_sk):
         from bigchaindb.models import Transaction
 
-        input_tx = b.get_owned_ids(user_vk).pop()
+        input_tx = b.get_owned_ids(user_pk).pop()
         input_tx = b.get_transaction(input_tx.txid)
         inputs = input_tx.to_inputs()
-        tx = Transaction.transfer(inputs, [user_vk], input_tx.asset)
+        tx = Transaction.transfer(inputs, [user_pk], input_tx.asset)
         tx = tx.sign([user_sk])
 
         # Make sure there's a copy of tx in the backlog
@@ -520,15 +520,15 @@ class TestBigchainApi(object):
                                         'vote from public key {me}'.format(block_id=block_1.id, me=b.me)
 
     @pytest.mark.usefixtures('inputs')
-    def test_assign_transaction_one_node(self, b, user_vk, user_sk):
+    def test_assign_transaction_one_node(self, b, user_pk, user_sk):
         import rethinkdb as r
         from bigchaindb.models import Transaction
         from bigchaindb.db.utils import get_conn
 
-        input_tx = b.get_owned_ids(user_vk).pop()
+        input_tx = b.get_owned_ids(user_pk).pop()
         input_tx = b.get_transaction(input_tx.txid)
         inputs = input_tx.to_inputs()
-        tx = Transaction.transfer(inputs, [user_vk], input_tx.asset)
+        tx = Transaction.transfer(inputs, [user_pk], input_tx.asset)
         tx = tx.sign([user_sk])
         b.write_transaction(tx)
 
@@ -539,7 +539,7 @@ class TestBigchainApi(object):
         assert response['assignee'] == b.me
 
     @pytest.mark.usefixtures('inputs')
-    def test_assign_transaction_multiple_nodes(self, b, user_vk, user_sk):
+    def test_assign_transaction_multiple_nodes(self, b, user_pk, user_sk):
         import rethinkdb as r
         from bigchaindb.common.crypto import generate_key_pair
         from bigchaindb.models import Transaction
@@ -551,10 +551,10 @@ class TestBigchainApi(object):
 
         # test assignee for several transactions
         for _ in range(20):
-            input_tx = b.get_owned_ids(user_vk).pop()
+            input_tx = b.get_owned_ids(user_pk).pop()
             input_tx = b.get_transaction(input_tx.txid)
             inputs = input_tx.to_inputs()
-            tx = Transaction.transfer(inputs, [user_vk], input_tx.asset)
+            tx = Transaction.transfer(inputs, [user_pk], input_tx.asset)
             tx = tx.sign([user_sk])
             b.write_transaction(tx)
 
@@ -566,7 +566,7 @@ class TestBigchainApi(object):
 
 
     @pytest.mark.usefixtures('inputs')
-    def test_non_create_input_not_found(self, b, user_vk):
+    def test_non_create_input_not_found(self, b, user_pk):
         from cryptoconditions import Ed25519Fulfillment
         from bigchaindb.common.exceptions import TransactionDoesNotExist
         from bigchaindb.common.transaction import (Fulfillment, Asset,
@@ -575,17 +575,17 @@ class TestBigchainApi(object):
         from bigchaindb import Bigchain
 
         # Create a fulfillment for a non existing transaction
-        fulfillment = Fulfillment(Ed25519Fulfillment(public_key=user_vk),
-                                  [user_vk],
+        fulfillment = Fulfillment(Ed25519Fulfillment(public_key=user_pk),
+                                  [user_pk],
                                   TransactionLink('somethingsomething', 0))
-        tx = Transaction.transfer([fulfillment], [user_vk], Asset())
+        tx = Transaction.transfer([fulfillment], [user_pk], Asset())
 
         with pytest.raises(TransactionDoesNotExist) as excinfo:
             tx.validate(Bigchain())
 
 
 class TestTransactionValidation(object):
-    def test_create_operation_with_inputs(self, b, user_vk, create_tx):
+    def test_create_operation_with_inputs(self, b, user_pk, create_tx):
         from bigchaindb.common.transaction import TransactionLink
 
         # Manipulate fulfillment so that it has a `tx_input` defined even
@@ -595,7 +595,7 @@ class TestTransactionValidation(object):
             b.validate_transaction(create_tx)
         assert excinfo.value.args[0] == 'A CREATE operation has no inputs'
 
-    def test_transfer_operation_no_inputs(self, b, user_vk,
+    def test_transfer_operation_no_inputs(self, b, user_pk,
                                           signed_transfer_tx):
         signed_transfer_tx.fulfillments[0].tx_input = None
         with pytest.raises(ValueError) as excinfo:
@@ -603,7 +603,7 @@ class TestTransactionValidation(object):
 
         assert excinfo.value.args[0] == 'Only `CREATE` transactions can have null inputs'
 
-    def test_non_create_input_not_found(self, b, user_vk, signed_transfer_tx):
+    def test_non_create_input_not_found(self, b, user_pk, signed_transfer_tx):
         from bigchaindb.common.exceptions import TransactionDoesNotExist
         from bigchaindb.common.transaction import TransactionLink
 
@@ -612,15 +612,15 @@ class TestTransactionValidation(object):
             b.validate_transaction(signed_transfer_tx)
 
     @pytest.mark.usefixtures('inputs')
-    def test_non_create_valid_input_wrong_owner(self, b, user_vk):
+    def test_non_create_valid_input_wrong_owner(self, b, user_pk):
         from bigchaindb.common.crypto import generate_key_pair
         from bigchaindb.common.exceptions import InvalidSignature
         from bigchaindb.models import Transaction
 
-        input_tx = b.get_owned_ids(user_vk).pop()
+        input_tx = b.get_owned_ids(user_pk).pop()
         input_transaction = b.get_transaction(input_tx.txid)
-        sk, vk = generate_key_pair()
-        tx = Transaction.create([vk], [user_vk])
+        sk, pk = generate_key_pair()
+        tx = Transaction.create([pk], [user_pk])
         tx.operation = 'TRANSFER'
         tx.asset = input_transaction.asset
         tx.fulfillments[0].tx_input = input_tx
@@ -657,14 +657,14 @@ class TestTransactionValidation(object):
 
     @pytest.mark.usefixtures('inputs')
     def test_valid_non_create_transaction_after_block_creation(self, b,
-                                                               user_vk,
+                                                               user_pk,
                                                                user_sk):
         from bigchaindb.models import Transaction
 
-        input_tx = b.get_owned_ids(user_vk).pop()
+        input_tx = b.get_owned_ids(user_pk).pop()
         input_tx = b.get_transaction(input_tx.txid)
         inputs = input_tx.to_inputs()
-        transfer_tx = Transaction.transfer(inputs, [user_vk], input_tx.asset)
+        transfer_tx = Transaction.transfer(inputs, [user_pk], input_tx.asset)
         transfer_tx = transfer_tx.sign([user_sk])
 
         assert transfer_tx == b.validate_transaction(transfer_tx)
@@ -679,16 +679,16 @@ class TestTransactionValidation(object):
         assert transfer_tx == b.validate_transaction(transfer_tx)
 
     @pytest.mark.usefixtures('inputs')
-    def test_fulfillment_not_in_valid_block(self, b, user_vk, user_sk):
+    def test_fulfillment_not_in_valid_block(self, b, user_pk, user_sk):
         from bigchaindb.models import Transaction
         from bigchaindb.common.exceptions import FulfillmentNotInValidBlock
 
-        input_tx = b.get_owned_ids(user_vk).pop()
+        input_tx = b.get_owned_ids(user_pk).pop()
         input_tx = b.get_transaction(input_tx.txid)
         inputs = input_tx.to_inputs()
 
         # create a transaction that's valid but not in a voted valid block
-        transfer_tx = Transaction.transfer(inputs, [user_vk], input_tx.asset)
+        transfer_tx = Transaction.transfer(inputs, [user_pk], input_tx.asset)
         transfer_tx = transfer_tx.sign([user_sk])
 
         assert transfer_tx == b.validate_transaction(transfer_tx)
@@ -698,7 +698,7 @@ class TestTransactionValidation(object):
         b.write_block(block, durability='hard')
 
         # create transaction with the undecided input
-        tx_invalid = Transaction.transfer(transfer_tx.to_inputs(), [user_vk],
+        tx_invalid = Transaction.transfer(transfer_tx.to_inputs(), [user_pk],
                                          transfer_tx.asset)
         tx_invalid = tx_invalid.sign([user_sk])
 
@@ -709,7 +709,7 @@ class TestTransactionValidation(object):
 class TestBlockValidation(object):
     @pytest.mark.skipif(reason='Separated tx validation from block creation.')
     @pytest.mark.usefixtures('inputs')
-    def test_invalid_transactions_in_block(self, b, user_vk):
+    def test_invalid_transactions_in_block(self, b, user_pk):
         from bigchaindb.common import crypto
         from bigchaindb.common.exceptions import TransactionOwnerError
         from bigchaindb.common.util import gen_timestamp
@@ -717,7 +717,7 @@ class TestBlockValidation(object):
         from bigchaindb import util
 
         # invalid transaction
-        valid_input = b.get_owned_ids(user_vk).pop()
+        valid_input = b.get_owned_ids(user_pk).pop()
         tx_invalid = b.create_transaction('a', 'b', valid_input, 'c')
 
         block = b.create_block([tx_invalid])
@@ -773,10 +773,10 @@ class TestBlockValidation(object):
         block = dummy_block()
 
         # create some temp keys
-        tmp_sk, tmp_vk = crypto.generate_key_pair()
+        tmp_sk, tmp_pk = crypto.generate_key_pair()
 
         # change the block node_pubkey
-        block.node_pubkey = tmp_vk
+        block.node_pubkey = tmp_pk
 
         # just to make sure lets re-hash the block and create a valid signature
         # from a non federation node
@@ -788,16 +788,16 @@ class TestBlockValidation(object):
 
 
 class TestMultipleInputs(object):
-    def test_transfer_single_owner_single_input(self, b, inputs, user_vk,
+    def test_transfer_single_owner_single_input(self, b, inputs, user_pk,
                                                 user_sk):
         from bigchaindb.common import crypto
         from bigchaindb.models import Transaction
-        user2_sk, user2_vk = crypto.generate_key_pair()
+        user2_sk, user2_pk = crypto.generate_key_pair()
 
-        tx_link = b.get_owned_ids(user_vk).pop()
+        tx_link = b.get_owned_ids(user_pk).pop()
         input_tx = b.get_transaction(tx_link.txid)
         inputs = input_tx.to_inputs()
-        tx = Transaction.transfer(inputs, [user2_vk], input_tx.asset)
+        tx = Transaction.transfer(inputs, [user2_pk], input_tx.asset)
         tx = tx.sign([user_sk])
 
         # validate transaction
@@ -809,18 +809,18 @@ class TestMultipleInputs(object):
                                 'same asset. Remove this after implementing ',
                                 'multiple assets'))
     @pytest.mark.usefixtures('inputs')
-    def test_transfer_single_owners_multiple_inputs(self, b, user_sk, user_vk):
+    def test_transfer_single_owners_multiple_inputs(self, b, user_sk, user_pk):
         from bigchaindb.common import crypto
         from bigchaindb.models import Transaction
 
-        user2_sk, user2_vk = crypto.generate_key_pair()
+        user2_sk, user2_pk = crypto.generate_key_pair()
 
         # get inputs
-        owned_inputs = b.get_owned_ids(user_vk)
+        owned_inputs = b.get_owned_ids(user_pk)
         input_txs = [b.get_transaction(tx_link.txid) for tx_link
                      in owned_inputs]
         inputs = sum([input_tx.to_inputs() for input_tx in input_txs], [])
-        tx = Transaction.transfer(inputs, len(inputs) * [[user_vk]])
+        tx = Transaction.transfer(inputs, len(inputs) * [[user_pk]])
         tx = tx.sign([user_sk])
         assert b.validate_transaction(tx) == tx
         assert len(tx.fulfillments) == len(inputs)
@@ -832,18 +832,18 @@ class TestMultipleInputs(object):
     @pytest.mark.usefixtures('inputs')
     def test_transfer_single_owners_single_input_from_multiple_outputs(self, b,
                                                                        user_sk,
-                                                                       user_vk):
+                                                                       user_pk):
         from bigchaindb.common import crypto
         from bigchaindb.models import Transaction
 
-        user2_sk, user2_vk = crypto.generate_key_pair()
+        user2_sk, user2_pk = crypto.generate_key_pair()
 
         # get inputs
-        owned_inputs = b.get_owned_ids(user_vk)
+        owned_inputs = b.get_owned_ids(user_pk)
         input_txs = [b.get_transaction(tx_link.txid) for tx_link
                      in owned_inputs]
         inputs = sum([input_tx.to_inputs() for input_tx in input_txs], [])
-        tx = Transaction.transfer(inputs, len(inputs) * [[user2_vk]])
+        tx = Transaction.transfer(inputs, len(inputs) * [[user2_pk]])
         tx = tx.sign([user_sk])
 
         # create block with the transaction
@@ -855,13 +855,13 @@ class TestMultipleInputs(object):
         b.write_vote(vote)
 
         # get inputs from user2
-        owned_inputs = b.get_owned_ids(user2_vk)
+        owned_inputs = b.get_owned_ids(user2_pk)
         assert len(owned_inputs) == len(inputs)
 
         # create a transaction with a single input from a multiple output transaction
         tx_link = owned_inputs.pop()
         inputs = b.get_transaction(tx_link.txid).to_inputs([0])
-        tx = Transaction.transfer(inputs, [user_vk])
+        tx = Transaction.transfer(inputs, [user_pk])
         tx = tx.sign([user2_sk])
 
         assert b.is_valid_transaction(tx) == tx
@@ -870,18 +870,18 @@ class TestMultipleInputs(object):
 
     def test_single_owner_before_multiple_owners_after_single_input(self, b,
                                                                     user_sk,
-                                                                    user_vk,
+                                                                    user_pk,
                                                                     inputs):
         from bigchaindb.common import crypto
         from bigchaindb.models import Transaction
 
-        user2_sk, user2_vk = crypto.generate_key_pair()
-        user3_sk, user3_vk = crypto.generate_key_pair()
+        user2_sk, user2_pk = crypto.generate_key_pair()
+        user3_sk, user3_pk = crypto.generate_key_pair()
 
-        owned_inputs = b.get_owned_ids(user_vk)
+        owned_inputs = b.get_owned_ids(user_pk)
         tx_link = owned_inputs.pop()
         input_tx = b.get_transaction(tx_link.txid)
-        tx = Transaction.transfer(input_tx.to_inputs(), [[user2_vk, user3_vk]], input_tx.asset)
+        tx = Transaction.transfer(input_tx.to_inputs(), [[user2_pk, user3_pk]], input_tx.asset)
         tx = tx.sign([user_sk])
 
         assert b.is_valid_transaction(tx) == tx
@@ -894,19 +894,19 @@ class TestMultipleInputs(object):
     @pytest.mark.usefixtures('inputs')
     def test_single_owner_before_multiple_owners_after_multiple_inputs(self, b,
                                                                        user_sk,
-                                                                       user_vk):
+                                                                       user_pk):
         from bigchaindb.common import crypto
         from bigchaindb.models import Transaction
 
-        user2_sk, user2_vk = crypto.generate_key_pair()
-        user3_sk, user3_vk = crypto.generate_key_pair()
+        user2_sk, user2_pk = crypto.generate_key_pair()
+        user3_sk, user3_pk = crypto.generate_key_pair()
 
-        owned_inputs = b.get_owned_ids(user_vk)
+        owned_inputs = b.get_owned_ids(user_pk)
         input_txs = [b.get_transaction(tx_link.txid) for tx_link
                      in owned_inputs]
         inputs = sum([input_tx.to_inputs() for input_tx in input_txs], [])
 
-        tx = Transaction.transfer(inputs, len(inputs) * [[user2_vk, user3_vk]])
+        tx = Transaction.transfer(inputs, len(inputs) * [[user2_pk, user3_pk]])
         tx = tx.sign([user_sk])
 
         # create block with the transaction
@@ -925,14 +925,14 @@ class TestMultipleInputs(object):
     @pytest.mark.usefixtures('inputs')
     def test_multiple_owners_before_single_owner_after_single_input(self, b,
                                                                     user_sk,
-                                                                    user_vk):
+                                                                    user_pk):
         from bigchaindb.common import crypto
         from bigchaindb.models import Transaction
 
-        user2_sk, user2_vk = crypto.generate_key_pair()
-        user3_sk, user3_vk = crypto.generate_key_pair()
+        user2_sk, user2_pk = crypto.generate_key_pair()
+        user3_sk, user3_pk = crypto.generate_key_pair()
 
-        tx = Transaction.create([b.me], [user_vk, user2_vk])
+        tx = Transaction.create([b.me], [user_pk, user2_pk])
         tx = tx.sign([b.me_private])
         block = b.create_block([tx])
         b.write_block(block, durability='hard')
@@ -941,11 +941,11 @@ class TestMultipleInputs(object):
         vote = b.vote(block.id, b.get_last_voted_block().id, True)
         b.write_vote(vote)
 
-        owned_input = b.get_owned_ids(user_vk).pop()
+        owned_input = b.get_owned_ids(user_pk).pop()
         input_tx = b.get_transaction(owned_input.txid)
         inputs = input_tx.to_inputs()
 
-        transfer_tx = Transaction.transfer(inputs, [user3_vk], input_tx.asset)
+        transfer_tx = Transaction.transfer(inputs, [user3_pk], input_tx.asset)
         transfer_tx = transfer_tx.sign([user_sk, user2_sk])
 
         # validate transaction
@@ -958,18 +958,18 @@ class TestMultipleInputs(object):
                                 'multiple assets'))
     @pytest.mark.usefixtures('inputs_shared')
     def test_multiple_owners_before_single_owner_after_multiple_inputs(self, b,
-                                          user_sk, user_vk, user2_vk, user2_sk):
+                                          user_sk, user_pk, user2_pk, user2_sk):
         from bigchaindb.common import crypto
         from bigchaindb.models import Transaction
 
         # create a new users
-        user3_sk, user3_vk = crypto.generate_key_pair()
+        user3_sk, user3_pk = crypto.generate_key_pair()
 
-        tx_links = b.get_owned_ids(user_vk)
+        tx_links = b.get_owned_ids(user_pk)
         inputs = sum([b.get_transaction(tx_link.txid).to_inputs() for tx_link
                       in tx_links], [])
 
-        tx = Transaction.transfer(inputs, len(inputs) * [[user3_vk]])
+        tx = Transaction.transfer(inputs, len(inputs) * [[user3_pk]])
         tx = tx.sign([user_sk, user2_sk])
 
         assert b.is_valid_transaction(tx) == tx
@@ -979,15 +979,15 @@ class TestMultipleInputs(object):
     @pytest.mark.usefixtures('inputs')
     def test_multiple_owners_before_multiple_owners_after_single_input(self, b,
                                                                        user_sk,
-                                                                       user_vk):
+                                                                       user_pk):
         from bigchaindb.common import crypto
         from bigchaindb.models import Transaction
 
-        user2_sk, user2_vk = crypto.generate_key_pair()
-        user3_sk, user3_vk = crypto.generate_key_pair()
-        user4_sk, user4_vk = crypto.generate_key_pair()
+        user2_sk, user2_pk = crypto.generate_key_pair()
+        user3_sk, user3_pk = crypto.generate_key_pair()
+        user4_sk, user4_pk = crypto.generate_key_pair()
 
-        tx = Transaction.create([b.me], [user_vk, user2_vk])
+        tx = Transaction.create([b.me], [user_pk, user2_pk])
         tx = tx.sign([b.me_private])
         block = b.create_block([tx])
         b.write_block(block, durability='hard')
@@ -997,10 +997,10 @@ class TestMultipleInputs(object):
         b.write_vote(vote)
 
         # get input
-        tx_link = b.get_owned_ids(user_vk).pop()
+        tx_link = b.get_owned_ids(user_pk).pop()
         tx_input = b.get_transaction(tx_link.txid)
 
-        tx = Transaction.transfer(tx_input.to_inputs(), [[user3_vk, user4_vk]], tx_input.asset)
+        tx = Transaction.transfer(tx_input.to_inputs(), [[user3_pk, user4_pk]], tx_input.asset)
         tx = tx.sign([user_sk, user2_sk])
 
         assert b.is_valid_transaction(tx) == tx
@@ -1012,64 +1012,64 @@ class TestMultipleInputs(object):
                                 'multiple assets'))
     @pytest.mark.usefixtures('inputs_shared')
     def test_multiple_owners_before_multiple_owners_after_multiple_inputs(self, b,
-                                                                user_sk, user_vk,
-                                                                user2_sk, user2_vk):
+                                                                user_sk, user_pk,
+                                                                user2_sk, user2_pk):
         from bigchaindb.common import crypto
         from bigchaindb.models import Transaction
 
         # create a new users
-        user3_sk, user3_vk = crypto.generate_key_pair()
-        user4_sk, user4_vk = crypto.generate_key_pair()
+        user3_sk, user3_pk = crypto.generate_key_pair()
+        user4_sk, user4_pk = crypto.generate_key_pair()
 
-        tx_links = b.get_owned_ids(user_vk)
+        tx_links = b.get_owned_ids(user_pk)
         inputs = sum([b.get_transaction(tx_link.txid).to_inputs() for tx_link
                       in tx_links], [])
 
-        tx = Transaction.transfer(inputs, len(inputs) * [[user3_vk, user4_vk]])
+        tx = Transaction.transfer(inputs, len(inputs) * [[user3_pk, user4_pk]])
         tx = tx.sign([user_sk, user2_sk])
 
         assert b.is_valid_transaction(tx) == tx
         assert len(tx.fulfillments) == len(inputs)
         assert len(tx.conditions) == len(inputs)
 
-    def test_get_owned_ids_single_tx_single_output(self, b, user_sk, user_vk):
+    def test_get_owned_ids_single_tx_single_output(self, b, user_sk, user_pk):
         from bigchaindb.common import crypto
         from bigchaindb.common.transaction import TransactionLink
         from bigchaindb.models import Transaction
 
-        user2_sk, user2_vk = crypto.generate_key_pair()
+        user2_sk, user2_pk = crypto.generate_key_pair()
 
-        tx = Transaction.create([b.me], [user_vk])
+        tx = Transaction.create([b.me], [user_pk])
         tx = tx.sign([b.me_private])
         block = b.create_block([tx])
         b.write_block(block, durability='hard')
 
-        owned_inputs_user1 = b.get_owned_ids(user_vk)
-        owned_inputs_user2 = b.get_owned_ids(user2_vk)
+        owned_inputs_user1 = b.get_owned_ids(user_pk)
+        owned_inputs_user2 = b.get_owned_ids(user2_pk)
         assert owned_inputs_user1 == [TransactionLink(tx.id, 0)]
         assert owned_inputs_user2 == []
 
-        tx = Transaction.transfer(tx.to_inputs(), [user2_vk], tx.asset)
+        tx = Transaction.transfer(tx.to_inputs(), [user2_pk], tx.asset)
         tx = tx.sign([user_sk])
         block = b.create_block([tx])
         b.write_block(block, durability='hard')
 
-        owned_inputs_user1 = b.get_owned_ids(user_vk)
-        owned_inputs_user2 = b.get_owned_ids(user2_vk)
+        owned_inputs_user1 = b.get_owned_ids(user_pk)
+        owned_inputs_user2 = b.get_owned_ids(user2_pk)
         assert owned_inputs_user1 == []
         assert owned_inputs_user2 == [TransactionLink(tx.id, 0)]
 
     def test_get_owned_ids_single_tx_single_output_invalid_block(self, b,
                                                                  user_sk,
-                                                                 user_vk):
+                                                                 user_pk):
         from bigchaindb.common import crypto
         from bigchaindb.common.transaction import TransactionLink
         from bigchaindb.models import Transaction
 
         genesis = b.create_genesis_block()
-        user2_sk, user2_vk = crypto.generate_key_pair()
+        user2_sk, user2_pk = crypto.generate_key_pair()
 
-        tx = Transaction.create([b.me], [user_vk])
+        tx = Transaction.create([b.me], [user_pk])
         tx = tx.sign([b.me_private])
         block = b.create_block([tx])
         b.write_block(block, durability='hard')
@@ -1078,14 +1078,14 @@ class TestMultipleInputs(object):
         vote = b.vote(block.id, genesis.id, True)
         b.write_vote(vote)
 
-        owned_inputs_user1 = b.get_owned_ids(user_vk)
-        owned_inputs_user2 = b.get_owned_ids(user2_vk)
+        owned_inputs_user1 = b.get_owned_ids(user_pk)
+        owned_inputs_user2 = b.get_owned_ids(user2_pk)
         assert owned_inputs_user1 == [TransactionLink(tx.id, 0)]
         assert owned_inputs_user2 == []
 
         # NOTE: The transaction itself is valid, still will mark the block
         #       as invalid to mock the behavior.
-        tx_invalid = Transaction.transfer(tx.to_inputs(), [user2_vk], tx.asset)
+        tx_invalid = Transaction.transfer(tx.to_inputs(), [user2_pk], tx.asset)
         tx_invalid = tx_invalid.sign([user_sk])
         block = b.create_block([tx_invalid])
         b.write_block(block, durability='hard')
@@ -1094,8 +1094,8 @@ class TestMultipleInputs(object):
         vote = b.vote(block.id, b.get_last_voted_block().id, False)
         b.write_vote(vote)
 
-        owned_inputs_user1 = b.get_owned_ids(user_vk)
-        owned_inputs_user2 = b.get_owned_ids(user2_vk)
+        owned_inputs_user1 = b.get_owned_ids(user_pk)
+        owned_inputs_user2 = b.get_owned_ids(user2_pk)
 
         # should be the same as before (note tx, not tx_invalid)
         assert owned_inputs_user1 == [TransactionLink(tx.id, 0)]
@@ -1105,26 +1105,26 @@ class TestMultipleInputs(object):
                                 'same asset. Remove this after implementing ',
                                 'multiple assets'))
     def test_get_owned_ids_single_tx_multiple_outputs(self, b, user_sk,
-                                                      user_vk):
+                                                      user_pk):
         import random
         from bigchaindb.common import crypto
         from bigchaindb.common.transaction import TransactionLink
         from bigchaindb.models import Transaction
 
-        user2_sk, user2_vk = crypto.generate_key_pair()
+        user2_sk, user2_pk = crypto.generate_key_pair()
 
         transactions = []
         for i in range(2):
             payload = {'somedata': random.randint(0, 255)}
-            tx = Transaction.create([b.me], [user_vk], payload)
+            tx = Transaction.create([b.me], [user_pk], payload)
             tx = tx.sign([b.me_private])
             transactions.append(tx)
         block = b.create_block(transactions)
         b.write_block(block, durability='hard')
 
         # get input
-        owned_inputs_user1 = b.get_owned_ids(user_vk)
-        owned_inputs_user2 = b.get_owned_ids(user2_vk)
+        owned_inputs_user1 = b.get_owned_ids(user_pk)
+        owned_inputs_user2 = b.get_owned_ids(user2_pk)
 
         expected_owned_inputs_user1 = [TransactionLink(tx.id, 0) for tx
                                        in transactions]
@@ -1132,59 +1132,59 @@ class TestMultipleInputs(object):
         assert owned_inputs_user2 == []
 
         inputs = sum([tx.to_inputs() for tx in transactions], [])
-        tx = Transaction.transfer(inputs, len(inputs) * [[user2_vk]])
+        tx = Transaction.transfer(inputs, len(inputs) * [[user2_pk]])
         tx = tx.sign([user_sk])
         block = b.create_block([tx])
         b.write_block(block, durability='hard')
 
-        owned_inputs_user1 = b.get_owned_ids(user_vk)
-        owned_inputs_user2 = b.get_owned_ids(user2_vk)
+        owned_inputs_user1 = b.get_owned_ids(user_pk)
+        owned_inputs_user2 = b.get_owned_ids(user2_pk)
         assert owned_inputs_user1 == []
         assert owned_inputs_user2 == [TransactionLink(tx.id, 0),
                                       TransactionLink(tx.id, 1)]
 
-    def test_get_owned_ids_multiple_owners(self, b, user_sk, user_vk):
+    def test_get_owned_ids_multiple_owners(self, b, user_sk, user_pk):
         from bigchaindb.common import crypto
         from bigchaindb.common.transaction import TransactionLink
         from bigchaindb.models import Transaction
 
-        user2_sk, user2_vk = crypto.generate_key_pair()
-        user3_sk, user3_vk = crypto.generate_key_pair()
+        user2_sk, user2_pk = crypto.generate_key_pair()
+        user3_sk, user3_pk = crypto.generate_key_pair()
 
-        tx = Transaction.create([b.me], [user_vk, user2_vk])
+        tx = Transaction.create([b.me], [user_pk, user2_pk])
         tx = tx.sign([b.me_private])
         block = b.create_block([tx])
         b.write_block(block, durability='hard')
 
-        owned_inputs_user1 = b.get_owned_ids(user_vk)
-        owned_inputs_user2 = b.get_owned_ids(user2_vk)
+        owned_inputs_user1 = b.get_owned_ids(user_pk)
+        owned_inputs_user2 = b.get_owned_ids(user2_pk)
         expected_owned_inputs_user1 = [TransactionLink(tx.id, 0)]
 
         assert owned_inputs_user1 == owned_inputs_user2
         assert owned_inputs_user1 == expected_owned_inputs_user1
 
-        tx = Transaction.transfer(tx.to_inputs(), [user3_vk], tx.asset)
+        tx = Transaction.transfer(tx.to_inputs(), [user3_pk], tx.asset)
         tx = tx.sign([user_sk, user2_sk])
         block = b.create_block([tx])
         b.write_block(block, durability='hard')
 
-        owned_inputs_user1 = b.get_owned_ids(user_vk)
-        owned_inputs_user2 = b.get_owned_ids(user2_vk)
+        owned_inputs_user1 = b.get_owned_ids(user_pk)
+        owned_inputs_user2 = b.get_owned_ids(user2_pk)
         assert owned_inputs_user1 == owned_inputs_user2
         assert owned_inputs_user1 == []
 
-    def test_get_spent_single_tx_single_output(self, b, user_sk, user_vk):
+    def test_get_spent_single_tx_single_output(self, b, user_sk, user_pk):
         from bigchaindb.common import crypto
         from bigchaindb.models import Transaction
 
-        user2_sk, user2_vk = crypto.generate_key_pair()
+        user2_sk, user2_pk = crypto.generate_key_pair()
 
-        tx = Transaction.create([b.me], [user_vk])
+        tx = Transaction.create([b.me], [user_pk])
         tx = tx.sign([b.me_private])
         block = b.create_block([tx])
         b.write_block(block, durability='hard')
 
-        owned_inputs_user1 = b.get_owned_ids(user_vk).pop()
+        owned_inputs_user1 = b.get_owned_ids(user_pk).pop()
 
         # check spents
         input_txid = owned_inputs_user1.txid
@@ -1193,7 +1193,7 @@ class TestMultipleInputs(object):
         assert spent_inputs_user1 is None
 
         # create a transaction and block
-        tx = Transaction.transfer(tx.to_inputs(), [user2_vk], tx.asset)
+        tx = Transaction.transfer(tx.to_inputs(), [user2_pk], tx.asset)
         tx = tx.sign([user_sk])
         block = b.create_block([tx])
         b.write_block(block, durability='hard')
@@ -1201,16 +1201,16 @@ class TestMultipleInputs(object):
         spent_inputs_user1 = b.get_spent(input_txid, input_cid)
         assert spent_inputs_user1 == tx
 
-    def test_get_spent_single_tx_single_output_invalid_block(self, b, user_sk, user_vk):
+    def test_get_spent_single_tx_single_output_invalid_block(self, b, user_sk, user_pk):
         from bigchaindb.common import crypto
         from bigchaindb.models import Transaction
 
         genesis = b.create_genesis_block()
 
         # create a new users
-        user2_sk, user2_vk = crypto.generate_key_pair()
+        user2_sk, user2_pk = crypto.generate_key_pair()
 
-        tx = Transaction.create([b.me], [user_vk])
+        tx = Transaction.create([b.me], [user_pk])
         tx = tx.sign([b.me_private])
         block = b.create_block([tx])
         b.write_block(block, durability='hard')
@@ -1219,7 +1219,7 @@ class TestMultipleInputs(object):
         vote = b.vote(block.id, genesis.id, True)
         b.write_vote(vote)
 
-        owned_inputs_user1 = b.get_owned_ids(user_vk).pop()
+        owned_inputs_user1 = b.get_owned_ids(user_pk).pop()
 
         # check spents
         input_txid = owned_inputs_user1.txid
@@ -1228,7 +1228,7 @@ class TestMultipleInputs(object):
         assert spent_inputs_user1 is None
 
         # create a transaction and block
-        tx = Transaction.transfer(tx.to_inputs(), [user2_vk], tx.asset)
+        tx = Transaction.transfer(tx.to_inputs(), [user2_pk], tx.asset)
         tx = tx.sign([user_sk])
         block = b.create_block([tx])
         b.write_block(block, durability='hard')
@@ -1246,24 +1246,24 @@ class TestMultipleInputs(object):
     @pytest.mark.skipif(reason=('Multiple inputs are only allowed for the '
                                 'same asset. Remove this after implementing ',
                                 'multiple assets'))
-    def test_get_spent_single_tx_multiple_outputs(self, b, user_sk, user_vk):
+    def test_get_spent_single_tx_multiple_outputs(self, b, user_sk, user_pk):
         import random
         from bigchaindb.common import crypto
         from bigchaindb.models import Transaction
 
         # create a new users
-        user2_sk, user2_vk = crypto.generate_key_pair()
+        user2_sk, user2_pk = crypto.generate_key_pair()
 
         transactions = []
         for i in range(3):
             payload = {'somedata': random.randint(0, 255)}
-            tx = Transaction.create([b.me], [user_vk], payload)
+            tx = Transaction.create([b.me], [user_pk], payload)
             tx = tx.sign([b.me_private])
             transactions.append(tx)
         block = b.create_block(transactions)
         b.write_block(block, durability='hard')
 
-        owned_inputs_user1 = b.get_owned_ids(user_vk)
+        owned_inputs_user1 = b.get_owned_ids(user_pk)
 
         # check spents
         for input_tx in owned_inputs_user1:
@@ -1273,7 +1273,7 @@ class TestMultipleInputs(object):
         inputs = sum([tx.to_inputs() for tx in transactions[:2]], [])
 
         # create a transaction and block
-        tx = Transaction.transfer(inputs, len(inputs) * [[user2_vk]])
+        tx = Transaction.transfer(inputs, len(inputs) * [[user2_pk]])
         tx = tx.sign([user_sk])
         block = b.create_block([tx])
         b.write_block(block, durability='hard')
@@ -1286,31 +1286,31 @@ class TestMultipleInputs(object):
         # spendable by BigchainDB
         assert b.get_spent(transactions[2].id, 0) is None
 
-    def test_get_spent_multiple_owners(self, b, user_sk, user_vk):
+    def test_get_spent_multiple_owners(self, b, user_sk, user_pk):
         import random
         from bigchaindb.common import crypto
         from bigchaindb.models import Transaction
 
-        user2_sk, user2_vk = crypto.generate_key_pair()
-        user3_sk, user3_vk = crypto.generate_key_pair()
+        user2_sk, user2_pk = crypto.generate_key_pair()
+        user3_sk, user3_pk = crypto.generate_key_pair()
 
         transactions = []
         for i in range(3):
             payload = {'somedata': random.randint(0, 255)}
-            tx = Transaction.create([b.me], [user_vk, user2_vk], payload)
+            tx = Transaction.create([b.me], [user_pk, user2_pk], payload)
             tx = tx.sign([b.me_private])
             transactions.append(tx)
         block = b.create_block(transactions)
         b.write_block(block, durability='hard')
 
-        owned_inputs_user1 = b.get_owned_ids(user_vk)
+        owned_inputs_user1 = b.get_owned_ids(user_pk)
 
         # check spents
         for input_tx in owned_inputs_user1:
             assert b.get_spent(input_tx.txid, input_tx.cid) is None
 
         # create a transaction
-        tx = Transaction.transfer(transactions[0].to_inputs(), [user3_vk], transactions[0].asset)
+        tx = Transaction.transfer(transactions[0].to_inputs(), [user3_pk], transactions[0].asset)
         tx = tx.sign([user_sk, user2_sk])
         block = b.create_block([tx])
         b.write_block(block, durability='hard')

--- a/tests/doc/run_doc_python_server_api_examples.py
+++ b/tests/doc/run_doc_python_server_api_examples.py
@@ -229,9 +229,9 @@ threshold_tx_fulfillment_message = util.get_fulfillment_message(threshold_tx_tra
 threshold_fulfillment.subconditions = []
 
 # sign and add the subconditions until threshold of 2 is reached
-subfulfillment1.sign(threshold_tx_fulfillment_message, crypto.SigningKey(thresholduser1_priv))
+subfulfillment1.sign(threshold_tx_fulfillment_message, crypto.PrivateKey(thresholduser1_priv))
 threshold_fulfillment.add_subfulfillment(subfulfillment1)
-subfulfillment2.sign(threshold_tx_fulfillment_message, crypto.SigningKey(thresholduser2_priv))
+subfulfillment2.sign(threshold_tx_fulfillment_message, crypto.PrivateKey(thresholduser2_priv))
 threshold_fulfillment.add_subfulfillment(subfulfillment2)
 
 # Add remaining (unfulfilled) fulfillment as a condition
@@ -436,7 +436,7 @@ escrow_fulfillment.subconditions = []
 
 # fulfill execute branch
 fulfillment_execute = cc.ThresholdSha256Fulfillment(threshold=2)
-subfulfillment_testuser1.sign(tx_escrow_execute_fulfillment_message, crypto.SigningKey(testuser1_priv))
+subfulfillment_testuser1.sign(tx_escrow_execute_fulfillment_message, crypto.PrivateKey(testuser1_priv))
 fulfillment_execute.add_subfulfillment(subfulfillment_testuser1)
 fulfillment_execute.add_subfulfillment(subfulfillment_timeout)
 escrow_fulfillment.add_subfulfillment(fulfillment_execute)
@@ -476,7 +476,7 @@ escrow_fulfillment.add_subcondition(condition_execute.condition)
 
 # Fulfill abort branch
 fulfillment_abort = cc.ThresholdSha256Fulfillment(threshold=2)
-subfulfillment_testuser2.sign(tx_escrow_abort_fulfillment_message, crypto.SigningKey(testuser2_priv))
+subfulfillment_testuser2.sign(tx_escrow_abort_fulfillment_message, crypto.PrivateKey(testuser2_priv))
 fulfillment_abort.add_subfulfillment(subfulfillment_testuser2)
 fulfillment_abort.add_subfulfillment(subfulfillment_timeout_inverted)
 escrow_fulfillment.add_subfulfillment(fulfillment_abort)

--- a/tests/pipelines/test_block_creation.py
+++ b/tests/pipelines/test_block_creation.py
@@ -38,14 +38,14 @@ def test_validate_transaction(b, create_tx):
     assert block_maker.validate_tx(valid_tx.to_dict()) == valid_tx
 
 
-def test_create_block(b, user_vk):
+def test_create_block(b, user_pk):
     from bigchaindb.models import Transaction
     from bigchaindb.pipelines.block import BlockPipeline
 
     block_maker = BlockPipeline()
 
     for i in range(100):
-        tx = Transaction.create([b.me], [user_vk])
+        tx = Transaction.create([b.me], [user_pk])
         tx = tx.sign([b.me_private])
         block_maker.create(tx)
 
@@ -55,7 +55,7 @@ def test_create_block(b, user_vk):
     assert len(block_doc.transactions) == 100
 
 
-def test_write_block(b, user_vk):
+def test_write_block(b, user_pk):
     from bigchaindb.models import Block, Transaction
     from bigchaindb.pipelines.block import BlockPipeline
 
@@ -63,7 +63,7 @@ def test_write_block(b, user_vk):
 
     txs = []
     for i in range(100):
-        tx = Transaction.create([b.me], [user_vk])
+        tx = Transaction.create([b.me], [user_pk])
         tx = tx.sign([b.me_private])
         txs.append(tx)
 
@@ -75,14 +75,14 @@ def test_write_block(b, user_vk):
     assert expected == block_doc
 
 
-def test_duplicate_transaction(b, user_vk):
+def test_duplicate_transaction(b, user_pk):
     from bigchaindb.models import Transaction
     from bigchaindb.pipelines import block
     block_maker = block.BlockPipeline()
 
     txs = []
     for i in range(10):
-        tx = Transaction.create([b.me], [user_vk])
+        tx = Transaction.create([b.me], [user_pk])
         tx = tx.sign([b.me_private])
         txs.append(tx)
 
@@ -104,12 +104,12 @@ def test_duplicate_transaction(b, user_vk):
     assert b.connection.run(r.table('backlog').get(txs[0].id)) is None
 
 
-def test_delete_tx(b, user_vk):
+def test_delete_tx(b, user_pk):
     from bigchaindb.models import Transaction
     from bigchaindb.pipelines.block import BlockPipeline
     block_maker = BlockPipeline()
     for i in range(100):
-        tx = Transaction.create([b.me], [user_vk])
+        tx = Transaction.create([b.me], [user_pk])
         tx = tx.sign([b.me_private])
         block_maker.create(tx)
         # make sure the tx appears in the backlog
@@ -132,13 +132,13 @@ def test_delete_tx(b, user_vk):
         assert b.connection.run(r.table('backlog').get(tx['id'])) is None
 
 
-def test_prefeed(b, user_vk):
+def test_prefeed(b, user_pk):
     import random
     from bigchaindb.models import Transaction
     from bigchaindb.pipelines.block import initial
 
     for i in range(100):
-        tx = Transaction.create([b.me], [user_vk], {'msg': random.random()})
+        tx = Transaction.create([b.me], [user_pk], {'msg': random.random()})
         tx = tx.sign([b.me_private])
         b.write_transaction(tx)
 
@@ -158,7 +158,7 @@ def test_start(create_pipeline):
     assert pipeline == create_pipeline.return_value
 
 
-def test_full_pipeline(b, user_vk):
+def test_full_pipeline(b, user_pk):
     import random
     from bigchaindb.models import Block, Transaction
     from bigchaindb.pipelines.block import create_pipeline, get_changefeed
@@ -167,7 +167,7 @@ def test_full_pipeline(b, user_vk):
 
     count_assigned_to_me = 0
     for i in range(100):
-        tx = Transaction.create([b.me], [user_vk], {'msg': random.random()})
+        tx = Transaction.create([b.me], [user_pk], {'msg': random.random()})
         tx = tx.sign([b.me_private]).to_dict()
         assignee = random.choice([b.me, 'aaa', 'bbb', 'ccc'])
         tx['assignee'] = assignee

--- a/tests/pipelines/test_election.py
+++ b/tests/pipelines/test_election.py
@@ -9,13 +9,13 @@ from bigchaindb import Bigchain
 from bigchaindb.pipelines import election
 
 
-def test_check_for_quorum_invalid(b, user_vk):
+def test_check_for_quorum_invalid(b, user_pk):
     from bigchaindb.models import Transaction
 
     e = election.Election()
 
     # create blocks with transactions
-    tx1 = Transaction.create([b.me], [user_vk])
+    tx1 = Transaction.create([b.me], [user_pk])
     test_block = b.create_block([tx1])
 
     # simulate a federation with four voters
@@ -39,12 +39,12 @@ def test_check_for_quorum_invalid(b, user_vk):
     assert e.check_for_quorum(votes[-1]) == test_block
 
 
-def test_check_for_quorum_invalid_prev_node(b, user_vk):
+def test_check_for_quorum_invalid_prev_node(b, user_pk):
     from bigchaindb.models import Transaction
     e = election.Election()
 
     # create blocks with transactions
-    tx1 = Transaction.create([b.me], [user_vk])
+    tx1 = Transaction.create([b.me], [user_pk])
     test_block = b.create_block([tx1])
 
     # simulate a federation with four voters
@@ -68,13 +68,13 @@ def test_check_for_quorum_invalid_prev_node(b, user_vk):
     assert e.check_for_quorum(votes[-1]) == test_block
 
 
-def test_check_for_quorum_valid(b, user_vk):
+def test_check_for_quorum_valid(b, user_pk):
     from bigchaindb.models import Transaction
 
     e = election.Election()
 
     # create blocks with transactions
-    tx1 = Transaction.create([b.me], [user_vk])
+    tx1 = Transaction.create([b.me], [user_pk])
     test_block = b.create_block([tx1])
 
     # simulate a federation with four voters
@@ -97,13 +97,13 @@ def test_check_for_quorum_valid(b, user_vk):
     assert e.check_for_quorum(votes[-1]) is None
 
 
-def test_check_requeue_transaction(b, user_vk):
+def test_check_requeue_transaction(b, user_pk):
     from bigchaindb.models import Transaction
 
     e = election.Election()
 
     # create blocks with transactions
-    tx1 = Transaction.create([b.me], [user_vk])
+    tx1 = Transaction.create([b.me], [user_pk])
     test_block = b.create_block([tx1])
 
     e.requeue_transactions(test_block)
@@ -122,7 +122,7 @@ def test_start(mock_start):
     mock_start.assert_called_with()
 
 
-def test_full_pipeline(b, user_vk):
+def test_full_pipeline(b, user_pk):
     import random
     from bigchaindb.models import Transaction
 
@@ -131,7 +131,7 @@ def test_full_pipeline(b, user_vk):
     # write two blocks
     txs = []
     for i in range(100):
-        tx = Transaction.create([b.me], [user_vk], {'msg': random.random()})
+        tx = Transaction.create([b.me], [user_pk], {'msg': random.random()})
         tx = tx.sign([b.me_private])
         txs.append(tx)
 
@@ -140,7 +140,7 @@ def test_full_pipeline(b, user_vk):
 
     txs = []
     for i in range(100):
-        tx = Transaction.create([b.me], [user_vk], {'msg': random.random()})
+        tx = Transaction.create([b.me], [user_pk], {'msg': random.random()})
         tx = tx.sign([b.me_private])
         txs.append(tx)
 

--- a/tests/pipelines/test_stale_monitor.py
+++ b/tests/pipelines/test_stale_monitor.py
@@ -8,9 +8,9 @@ import time
 import os
 
 
-def test_get_stale(b, user_vk):
+def test_get_stale(b, user_pk):
     from bigchaindb.models import Transaction
-    tx = Transaction.create([b.me], [user_vk])
+    tx = Transaction.create([b.me], [user_pk])
     tx = tx.sign([b.me_private])
     b.write_transaction(tx, durability='hard')
 
@@ -24,10 +24,10 @@ def test_get_stale(b, user_vk):
         assert tx.to_dict() == _tx
 
 
-def test_reassign_transactions(b, user_vk):
+def test_reassign_transactions(b, user_pk):
     from bigchaindb.models import Transaction
     # test with single node
-    tx = Transaction.create([b.me], [user_vk])
+    tx = Transaction.create([b.me], [user_pk])
     tx = tx.sign([b.me_private])
     b.write_transaction(tx, durability='hard')
 
@@ -36,7 +36,7 @@ def test_reassign_transactions(b, user_vk):
     stm.reassign_transactions(tx.to_dict())
 
     # test with federation
-    tx = Transaction.create([b.me], [user_vk])
+    tx = Transaction.create([b.me], [user_pk])
     tx = tx.sign([b.me_private])
     b.write_transaction(tx, durability='hard')
 
@@ -51,7 +51,7 @@ def test_reassign_transactions(b, user_vk):
     assert reassigned_tx['assignee'] != tx['assignee']
 
     # test with node not in federation
-    tx = Transaction.create([b.me], [user_vk])
+    tx = Transaction.create([b.me], [user_pk])
     tx = tx.sign([b.me_private]).to_dict()
     tx.update({'assignee': 'lol'})
     tx.update({'assignment_timestamp': time.time()})
@@ -62,7 +62,7 @@ def test_reassign_transactions(b, user_vk):
     assert b.connection.run(r.table('backlog').get(tx['id']))['assignee'] != 'lol'
 
 
-def test_full_pipeline(monkeypatch, user_vk):
+def test_full_pipeline(monkeypatch, user_pk):
     from bigchaindb.models import Transaction
     CONFIG = {
         'database': {
@@ -85,7 +85,7 @@ def test_full_pipeline(monkeypatch, user_vk):
     monkeypatch.setattr('time.time', lambda: 1)
 
     for i in range(100):
-        tx = Transaction.create([b.me], [user_vk])
+        tx = Transaction.create([b.me], [user_pk])
         tx = tx.sign([b.me_private])
         original_txc.append(tx.to_dict())
 

--- a/tests/pipelines/test_vote.py
+++ b/tests/pipelines/test_vote.py
@@ -33,7 +33,7 @@ def test_vote_creation_valid(b):
     assert vote['vote']['is_block_valid'] is True
     assert vote['vote']['invalid_reason'] is None
     assert vote['node_pubkey'] == b.me
-    assert crypto.VerifyingKey(b.me).verify(serialize(vote['vote']).encode(),
+    assert crypto.PublicKey(b.me).verify(serialize(vote['vote']).encode(),
                                             vote['signature']) is True
 
 
@@ -52,7 +52,7 @@ def test_vote_creation_invalid(b):
     assert vote['vote']['is_block_valid'] is False
     assert vote['vote']['invalid_reason'] is None
     assert vote['node_pubkey'] == b.me
-    assert crypto.VerifyingKey(b.me).verify(serialize(vote['vote']).encode(),
+    assert crypto.PublicKey(b.me).verify(serialize(vote['vote']).encode(),
                                             vote['signature']) is True
 
 
@@ -177,7 +177,7 @@ def test_valid_block_voting_sequential(b, monkeypatch):
 
     serialized_vote = util.serialize(vote_doc['vote']).encode()
     assert vote_doc['node_pubkey'] == b.me
-    assert crypto.VerifyingKey(b.me).verify(serialized_vote,
+    assert crypto.PublicKey(b.me).verify(serialized_vote,
                                             vote_doc['signature']) is True
 
 
@@ -211,7 +211,7 @@ def test_valid_block_voting_multiprocessing(b, monkeypatch):
 
     serialized_vote = util.serialize(vote_doc['vote']).encode()
     assert vote_doc['node_pubkey'] == b.me
-    assert crypto.VerifyingKey(b.me).verify(serialized_vote,
+    assert crypto.PublicKey(b.me).verify(serialized_vote,
                                             vote_doc['signature']) is True
 
 
@@ -252,7 +252,7 @@ def test_valid_block_voting_with_create_transaction(b, monkeypatch):
 
     serialized_vote = util.serialize(vote_doc['vote']).encode()
     assert vote_doc['node_pubkey'] == b.me
-    assert crypto.VerifyingKey(b.me).verify(serialized_vote,
+    assert crypto.PublicKey(b.me).verify(serialized_vote,
                                             vote_doc['signature']) is True
 
 
@@ -306,7 +306,7 @@ def test_valid_block_voting_with_transfer_transactions(monkeypatch, b):
 
     serialized_vote = util.serialize(vote_doc['vote']).encode()
     assert vote_doc['node_pubkey'] == b.me
-    assert crypto.VerifyingKey(b.me).verify(serialized_vote,
+    assert crypto.PublicKey(b.me).verify(serialized_vote,
                                             vote_doc['signature']) is True
 
     vote2_rs = b.connection.run(r.table('votes').get_all([block2.id, b.me], index='block_and_voter'))
@@ -320,7 +320,7 @@ def test_valid_block_voting_with_transfer_transactions(monkeypatch, b):
 
     serialized_vote2 = util.serialize(vote2_doc['vote']).encode()
     assert vote2_doc['node_pubkey'] == b.me
-    assert crypto.VerifyingKey(b.me).verify(serialized_vote2,
+    assert crypto.PublicKey(b.me).verify(serialized_vote2,
                                             vote2_doc['signature']) is True
 
 
@@ -357,7 +357,7 @@ def test_unsigned_tx_in_block_voting(monkeypatch, b, user_vk):
 
     serialized_vote = util.serialize(vote_doc['vote']).encode()
     assert vote_doc['node_pubkey'] == b.me
-    assert crypto.VerifyingKey(b.me).verify(serialized_vote,
+    assert crypto.PublicKey(b.me).verify(serialized_vote,
                                             vote_doc['signature']) is True
 
 
@@ -396,7 +396,7 @@ def test_invalid_id_tx_in_block_voting(monkeypatch, b, user_vk):
 
     serialized_vote = util.serialize(vote_doc['vote']).encode()
     assert vote_doc['node_pubkey'] == b.me
-    assert crypto.VerifyingKey(b.me).verify(serialized_vote,
+    assert crypto.PublicKey(b.me).verify(serialized_vote,
                                             vote_doc['signature']) is True
 
 
@@ -435,7 +435,7 @@ def test_invalid_content_in_tx_in_block_voting(monkeypatch, b, user_vk):
 
     serialized_vote = util.serialize(vote_doc['vote']).encode()
     assert vote_doc['node_pubkey'] == b.me
-    assert crypto.VerifyingKey(b.me).verify(serialized_vote,
+    assert crypto.PublicKey(b.me).verify(serialized_vote,
                                             vote_doc['signature']) is True
 
 
@@ -470,7 +470,7 @@ def test_invalid_block_voting(monkeypatch, b, user_vk):
 
     serialized_vote = util.serialize(vote_doc['vote']).encode()
     assert vote_doc['node_pubkey'] == b.me
-    assert crypto.VerifyingKey(b.me).verify(serialized_vote,
+    assert crypto.PublicKey(b.me).verify(serialized_vote,
                                             vote_doc['signature']) is True
 
 

--- a/tests/pipelines/test_vote.py
+++ b/tests/pipelines/test_vote.py
@@ -324,7 +324,7 @@ def test_valid_block_voting_with_transfer_transactions(monkeypatch, b):
                                             vote2_doc['signature']) is True
 
 
-def test_unsigned_tx_in_block_voting(monkeypatch, b, user_vk):
+def test_unsigned_tx_in_block_voting(monkeypatch, b, user_pk):
     from bigchaindb.common import crypto, util
     from bigchaindb.models import Transaction
     from bigchaindb.pipelines import vote
@@ -361,7 +361,7 @@ def test_unsigned_tx_in_block_voting(monkeypatch, b, user_vk):
                                             vote_doc['signature']) is True
 
 
-def test_invalid_id_tx_in_block_voting(monkeypatch, b, user_vk):
+def test_invalid_id_tx_in_block_voting(monkeypatch, b, user_pk):
     from bigchaindb.common import crypto, util
     from bigchaindb.models import Transaction
     from bigchaindb.pipelines import vote
@@ -400,7 +400,7 @@ def test_invalid_id_tx_in_block_voting(monkeypatch, b, user_vk):
                                             vote_doc['signature']) is True
 
 
-def test_invalid_content_in_tx_in_block_voting(monkeypatch, b, user_vk):
+def test_invalid_content_in_tx_in_block_voting(monkeypatch, b, user_pk):
     from bigchaindb.common import crypto, util
     from bigchaindb.models import Transaction
     from bigchaindb.pipelines import vote
@@ -439,7 +439,7 @@ def test_invalid_content_in_tx_in_block_voting(monkeypatch, b, user_vk):
                                             vote_doc['signature']) is True
 
 
-def test_invalid_block_voting(monkeypatch, b, user_vk):
+def test_invalid_block_voting(monkeypatch, b, user_pk):
     from bigchaindb.common import crypto, util
     from bigchaindb.pipelines import vote
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -142,7 +142,7 @@ class TestBlockModel(object):
         assert Block(transactions) == Block(transactions)
 
     def test_sign_block(self, b):
-        from bigchaindb.common.crypto import SigningKey, VerifyingKey
+        from bigchaindb.common.crypto import PrivateKey, PublicKey
         from bigchaindb.common.util import gen_timestamp, serialize
         from bigchaindb.models import Block, Transaction
 
@@ -156,13 +156,13 @@ class TestBlockModel(object):
             'voters': voters,
         }
         expected_block_serialized = serialize(expected_block).encode()
-        expected = SigningKey(b.me_private).sign(expected_block_serialized)
+        expected = PrivateKey(b.me_private).sign(expected_block_serialized)
         block = Block(transactions, b.me, timestamp, voters)
         block = block.sign(b.me_private)
         assert block.signature == expected.decode()
 
-        verifying_key = VerifyingKey(b.me)
-        assert verifying_key.verify(expected_block_serialized, block.signature)
+        public_key = PublicKey(b.me)
+        assert public_key.verify(expected_block_serialized, block.signature)
 
     def test_validate_already_voted_on_block(self, b, monkeypatch):
         from unittest.mock import Mock

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -33,5 +33,5 @@ def app(request, node_config):
 # NOTE: In order to have a database setup as well as the `input` fixture,
 #       we have to proxy `db.conftest.input` here.
 # TODO: If possible replace this function with something nicer.
-def inputs(user_vk):
-    conftest.inputs(user_vk)
+def inputs(user_pk):
+    conftest.inputs(user_pk)

--- a/tests/web/test_basic_views.py
+++ b/tests/web/test_basic_views.py
@@ -8,8 +8,8 @@ TX_ENDPOINT = '/api/v1/transactions/'
 
 
 @pytest.mark.usefixtures('inputs')
-def test_get_transaction_endpoint(b, client, user_vk):
-    input_tx = b.get_owned_ids(user_vk).pop()
+def test_get_transaction_endpoint(b, client, user_pk):
+    input_tx = b.get_owned_ids(user_pk).pop()
     tx = b.get_transaction(input_tx.txid)
     res = client.get(TX_ENDPOINT + tx.id)
     assert tx.to_dict() == res.json
@@ -69,30 +69,30 @@ def test_post_create_transaction_with_invalid_signature(b, client):
 
 
 @pytest.mark.usefixtures('inputs')
-def test_post_transfer_transaction_endpoint(b, client, user_vk, user_sk):
-    sk, vk = crypto.generate_key_pair()
+def test_post_transfer_transaction_endpoint(b, client, user_pk, user_sk):
+    sk, pk = crypto.generate_key_pair()
     from bigchaindb.models import Transaction
 
     user_priv, user_pub = crypto.generate_key_pair()
 
-    input_valid = b.get_owned_ids(user_vk).pop()
+    input_valid = b.get_owned_ids(user_pk).pop()
     create_tx = b.get_transaction(input_valid.txid)
     transfer_tx = Transaction.transfer(create_tx.to_inputs(), [user_pub], create_tx.asset)
     transfer_tx = transfer_tx.sign([user_sk])
 
     res = client.post(TX_ENDPOINT, data=json.dumps(transfer_tx.to_dict()))
 
-    assert res.json['transaction']['fulfillments'][0]['owners_before'][0] == user_vk
+    assert res.json['transaction']['fulfillments'][0]['owners_before'][0] == user_pk
     assert res.json['transaction']['conditions'][0]['owners_after'][0] == user_pub
 
 
 @pytest.mark.usefixtures('inputs')
-def test_post_invalid_transfer_transaction_returns_400(b, client, user_vk, user_sk):
+def test_post_invalid_transfer_transaction_returns_400(b, client, user_pk, user_sk):
     from bigchaindb.models import Transaction
 
     user_priv, user_pub = crypto.generate_key_pair()
 
-    input_valid = b.get_owned_ids(user_vk).pop()
+    input_valid = b.get_owned_ids(user_pk).pop()
     create_tx = b.get_transaction(input_valid.txid)
     transfer_tx = Transaction.transfer(create_tx.to_inputs(), [user_pub], create_tx.asset)
 
@@ -101,8 +101,8 @@ def test_post_invalid_transfer_transaction_returns_400(b, client, user_vk, user_
 
 
 @pytest.mark.usefixtures('inputs')
-def test_get_transaction_status_endpoint(b, client, user_vk):
-    input_tx = b.get_owned_ids(user_vk).pop()
+def test_get_transaction_status_endpoint(b, client, user_pk):
+    input_tx = b.get_owned_ids(user_pk).pop()
     tx, status = b.get_transaction(input_tx.txid, include_status=True)
     res = client.get(TX_ENDPOINT + input_tx.txid + "/status")
     assert status == res.json['status']


### PR DESCRIPTION
resolves #746 

Replaces all occurrences of verifying key/signing key with public key/private key.
Replaces `VerifyingKey` with `PublicKey`
Replaces `SigningKey` with `PrivateKey`
Replaces the short name for public key `vk` with `pk`
Short name for private key `sk` remains the same. It seems to a common short name for private key in both the literature and NaCL code