### PR TITLE
Updated example AWS deployment config file to use Ubuntu 16.04 LTS

### DIFF
--- a/deploy-cluster-aws/example_deploy_conf.py
+++ b/deploy-cluster-aws/example_deploy_conf.py
@@ -43,9 +43,9 @@ USE_KEYPAIRS_FILE=False
 # Canonical (the company behind Ubuntu) generates many AMIs
 # and you can search for one that meets your needs at:
 # https://cloud-images.ubuntu.com/locator/ec2/
-# Example:
-# (eu-central-1 Ubuntu 14.04 LTS amd64 hvm:ebs-ssd 20161020)
-IMAGE_ID="ami-9c09f0f3"
+# Example: ami-8504fdea is what you get if you search for:
+# eu-central-1 16.04 LTS amd64 hvm:ebs-ssd
+IMAGE_ID="ami-8504fdea"
 
 # INSTANCE_TYPE is the type of AWS instance to launch
 # i.e. How many CPUs do you want? How much storage? etc.

--- a/deploy-cluster-aws/fabfile.py
+++ b/deploy-cluster-aws/fabfile.py
@@ -156,7 +156,12 @@ def prep_rethinkdb_storage(USING_EBS):
 @parallel
 def install_rethinkdb():
     """Install RethinkDB"""
-    sudo("echo 'deb http://download.rethinkdb.com/apt trusty main' | sudo tee /etc/apt/sources.list.d/rethinkdb.list")
+    # Old way:
+    # sudo("echo 'deb http://download.rethinkdb.com/apt trusty main' | sudo tee /etc/apt/sources.list.d/rethinkdb.list")
+    # New way: (from https://www.rethinkdb.com/docs/install/ubuntu/ )
+    sudo('source /etc/lsb-release && '
+         'echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | '
+         'sudo tee /etc/apt/sources.list.d/rethinkdb.list')
     sudo("wget -qO- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -")
     sudo("apt-get update")
     sudo("apt-get -y install rethinkdb")

--- a/docs/server/source/clusters-feds/aws-testing-cluster.md
+++ b/docs/server/source/clusters-feds/aws-testing-cluster.md
@@ -126,7 +126,7 @@ BRANCH="master"
 WHAT_TO_DEPLOY="servers"
 SSH_KEY_NAME="not-set-yet"
 USE_KEYPAIRS_FILE=False
-IMAGE_ID="ami-9c09f0f3"
+IMAGE_ID="ami-8504fdea"
 INSTANCE_TYPE="t2.medium"
 SECURITY_GROUP="bigchaindb"
 USING_EBS=True
@@ -136,6 +136,8 @@ BIND_HTTP_TO_LOCALHOST=True
 ```
 
 Make a copy of that file and call it whatever you like (e.g. `cp example_deploy_conf.py my_deploy_conf.py`). You can leave most of the settings at their default values, but you must change the value of `SSH_KEY_NAME` to the name of your private SSH key. You can do that with a text editor. Set `SSH_KEY_NAME` to the name you used for `<key-name>` when you generated an RSA key pair for SSH (in basic AWS setup).
+
+You'll also want to change the `IMAGE_ID` to one that's up-to-date and available in your AWS region. If you don't remember your AWS region, then look in your `$HOME/.aws/config` file. You can find an up-to-date Ubuntu image ID for your region at [https://cloud-images.ubuntu.com/locator/ec2/](https://cloud-images.ubuntu.com/locator/ec2/). An example search string is "eu-central-1 16.04 LTS amd64 hvm:ebs-ssd". You should replace "eu-central-1" with your region name.
 
 If you want your nodes to have a predictable set of pre-generated keypairs, then you should 1) set `USE_KEYPAIRS_FILE=True` in the AWS deployment configuration file, and 2) provide a `keypairs.py` file containing enough keypairs for all of your nodes. You can generate a `keypairs.py` file using the `write_keypairs_file.py` script. For example:
 ```text


### PR DESCRIPTION
* Updated the example AWS deployment config file to use an Ubuntu 16.04 AMI. Updated the documentation accordingly.
* Also added a paragraph to those docs about how to get an up-to-date Ubuntu AMI image ID for your AWS region
* In `fabfile.py`, updated the first command to install RethinkDB, based on [the instructions on the RethinkDB website](https://www.rethinkdb.com/docs/install/ubuntu/) (also updated). The old command was failing with Ubuntu 16.04

I tested it and it works.

This PR resolves #773 