### PR TITLE
Add a button to the docs linking to the bdb cli

### DIFF
--- a/docs/root/source/index.rst
+++ b/docs/root/source/index.rst
@@ -59,6 +59,9 @@ At a high level, one can communicate with a BigchainDB cluster (set of nodes) us
      <a class="button" href="http://docs.bigchaindb.com/projects/py-driver/en/latest/index.html">Python Driver Docs</a>
    </div>
    <div class="buttondiv">
+     <a class="button" href="https://docs.bigchaindb.com/projects/cli/en/latest/">Command Line Transaction Tool</a>
+   </div>
+   <div class="buttondiv">
      <a class="button" href="http://docs.bigchaindb.com/projects/server/en/latest/index.html">Server Docs</a>
    </div>
    <div class="buttondiv">

--- a/docs/server/source/drivers-clients/index.rst
+++ b/docs/server/source/drivers-clients/index.rst
@@ -5,7 +5,7 @@ Currently, the only language-native driver is written in the Python language.
 
 We also provide the Transaction CLI to be able to script the building of
 transactions. You may be able to wrap this tool inside the language of
-your choice, and then use the server api directly to post transactions.
+your choice, and then use the HTTP API directly to post transactions.
 
 
 .. toctree::

--- a/docs/server/source/drivers-clients/index.rst
+++ b/docs/server/source/drivers-clients/index.rst
@@ -6,5 +6,5 @@ Drivers & Clients
 
    http-client-server-api
    The Python Driver <https://docs.bigchaindb.com/projects/py-driver/en/latest/index.html>
+   Transaction CLI <https://docs.bigchaindb.com/projects/cli/en/latest/>
    example-apps
-   

--- a/docs/server/source/drivers-clients/index.rst
+++ b/docs/server/source/drivers-clients/index.rst
@@ -1,6 +1,13 @@
 Drivers & Clients
 =================
 
+Currently, the only language-native driver is written in the Python language.
+
+We also provide the Transaction CLI to be able to script the building of
+transactions. You may be able to wrap this tool inside the language of
+your choice, and then use the server api directly to post transactions.
+
+
 .. toctree::
    :maxdepth: 1
 


### PR DESCRIPTION
Screenie below. Any ideas where else to link these docs?

Links to https://docs.bigchaindb.com/projects/cli/en/latest/.

![screenshot from 2016-11-14 15-50-08](https://cloud.githubusercontent.com/assets/125019/20269103/21dd2f12-aa82-11e6-9b00-19d26bb86d4c.png)
