### PR TITLE
Fix database timestamp indexes

### DIFF
--- a/bigchaindb/db/utils.py
+++ b/bigchaindb/db/utils.py
@@ -133,15 +133,10 @@ def create_bigchain_secondary_index(conn, dbname):
 
 def create_backlog_secondary_index(conn, dbname):
     logger.info('Create `backlog` secondary index.')
-    # to order transactions by timestamp
-    r.db(dbname).table('backlog')\
-        .index_create('transaction_timestamp',
-                      r.row['transaction']['timestamp'])\
-        .run(conn)
     # compound index to read transactions from the backlog per assignee
     r.db(dbname).table('backlog')\
         .index_create('assignee__transaction_timestamp',
-                      [r.row['assignee'], r.row['transaction']['timestamp']])\
+                      [r.row['assignee'], r.row['assignment_timestamp']])\
         .run(conn)
 
     # wait for rethinkdb to finish creating secondary indexes

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -33,7 +33,6 @@ def test_init_creates_db_tables_and_indexes():
         'block_timestamp').run(conn) is True
 
     assert r.db(dbname).table('backlog').index_list().contains(
-        'transaction_timestamp',
         'assignee__transaction_timestamp').run(conn) is True
 
 
@@ -108,8 +107,6 @@ def test_create_backlog_secondary_index():
     utils.create_table(conn, dbname, 'backlog')
     utils.create_backlog_secondary_index(conn, dbname)
 
-    assert r.db(dbname).table('backlog').index_list().contains(
-        'transaction_timestamp').run(conn) is True
     assert r.db(dbname).table('backlog').index_list().contains(
         'assignee__transaction_timestamp').run(conn) is True
 


### PR DESCRIPTION
2 issues found with timestamp indexes in DB, this PR fixes. The rationale on removing the transaction_timestamp index is that it's not used. The other fix is due to an index using the wrong timestamp.

* remove database index on transaction.timestamp
* fix database index on assignee__transaction_timestamp to use correct timestamp

See also: https://github.com/bigchaindb/bigchaindb/issues/808