### PR TITLE
Fixed bug in `bigchaindb load`

### DIFF
--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -1,6 +1,5 @@
 """Implementation of the `bigchaindb` command,
-which is one of the commands in the BigchainDB
-command-line interface.
+the command-line interface (CLI) for BigchainDB Server.
 """
 
 import os

--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -193,7 +193,7 @@ def _run_load(tx_left, stats):
     b = bigchaindb.Bigchain()
 
     while True:
-        tx = Transaction.create([b.me], [b.me])
+        tx = Transaction.create([b.me], [([b.me], 1)])
         tx = tx.sign([b.me_private])
         b.write_transaction(tx)
 


### PR DESCRIPTION
Resolves issue #823 

I also updated the top docstring in `commands/bigchain.py`: there is more than one "BigchainDB CLI" these days, so I clarified that that file has the implementation of the BigchainDB Server CLI.