### PR TITLE
Fix equality check for AssetLinks

### DIFF
--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -541,7 +541,7 @@ class AssetLink(Asset):
 
     def __eq__(self, other):
         return isinstance(other, AssetLink) and \
-                self.to_dict() == self.to_dict()
+                self.to_dict() == other.to_dict()
 
     @classmethod
     def from_dict(cls, link):

--- a/tests/common/test_transaction.py
+++ b/tests/common/test_transaction.py
@@ -516,6 +516,16 @@ def test_cast_asset_link_to_boolean():
     assert bool(AssetLink(False)) is True
 
 
+def test_eq_asset_link():
+    from bigchaindb.common.transaction import AssetLink
+
+    asset_id_1 = 'asset_1'
+    asset_id_2 = 'asset_2'
+
+    assert AssetLink(asset_id_1) == AssetLink(asset_id_1)
+    assert AssetLink(asset_id_1) != AssetLink(asset_id_2)
+
+
 def test_add_fulfillment_to_tx(user_ffill):
     from bigchaindb.common.transaction import Transaction, Asset
 


### PR DESCRIPTION
Small fix for equality checks with AssetLinks that was missed in https://github.com/bigchaindb/bigchaindb/pull/794.