### PR TITLE
es[WIP/Feedback] Design BigchainDB HTTP API v0.9

### DIFF
--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -28,14 +28,14 @@ Content-Type: application/json
 """
 
 
-TPLS['get-tx-unfulfilled-request'] = """\
-GET /transactions?fulfilled=false&public_keys=%(public_keys_transfer_last)s HTTP/1.1
+TPLS['get-tx-unspent-request'] = """\
+GET /transactions?unspent=true&public_keys=%(public_keys_transfer_last)s HTTP/1.1
 Host: example.com
 
 """
 
 
-TPLS['get-tx-unfulfilled-response'] = """\
+TPLS['get-tx-unspent-response'] = """\
 HTTP/1.1 200 OK
 Content-Type: application/json
 

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -23,7 +23,6 @@ Host: example.com
 TPLS['get-tx-id-response'] = """\
 HTTP/1.1 200 OK
 Content-Type: application/json
-X-BigchainDB-Timestamp: 1482766245
 
 %(tx)s
 """

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -9,6 +9,38 @@ from bigchaindb.common.transaction import Transaction
 
 TPLS = {}
 
+
+TPLS['get-tx-id-request'] = """\
+GET /transactions/%(txid)s HTTP/1.1
+Host: example.com
+
+"""
+
+
+TPLS['get-tx-id-response'] = """\
+HTTP/1.1 200 OK
+Content-Type: application/json
+X-BigchainDB-Timestamp: 1482766245
+
+%(tx)s
+"""
+
+
+TPLS['get-tx-unfulfilled-request'] = """\
+GET /transactions?fulfilled=false&public_keys=%(public_keys)s HTTP/1.1
+Host: example.com
+
+"""
+
+
+TPLS['get-tx-unfulfilled-response'] = """\
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+[%(tx)s]
+"""
+
+
 TPLS['post-tx-request'] = """\
 POST /transactions/ HTTP/1.1
 Host: example.com
@@ -32,7 +64,6 @@ Host: example.com
 
 """
 
-
 TPLS['get-tx-status-response'] = """\
 HTTP/1.1 200 OK
 Content-Type: application/json
@@ -43,20 +74,6 @@ Content-Type: application/json
 """
 
 
-TPLS['get-tx-request'] = """\
-GET /transactions/%(txid)s HTTP/1.1
-Host: example.com
-
-"""
-
-
-TPLS['get-tx-response'] = """\
-HTTP/1.1 200 OK
-Content-Type: application/json
-X-BigchainDB-Timestamp: 1482766245
-
-%(tx)s
-"""
 
 
 def main():
@@ -75,7 +92,9 @@ def main():
 
     for name, tpl in TPLS.items():
         path = os.path.join(base_path, name + '.http')
-        code = tpl % {'tx': tx_json, 'txid': tx.id}
+        code = tpl % {'tx': tx_json,
+                      'txid': tx.id,
+                      'public_keys': tx.outputs[0].public_keys[0]}
         with open(path, 'w') as handle:
             handle.write(code)
 

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -177,7 +177,7 @@ def main():
     privkey = 'CfdqtD7sS7FgkMoGPXw55MVGGFwQLAoHYTcBhZDtF99Z'
     pubkey = '4K9sWUMFwTgaDGPfdynrbxWqWS6sWmKbZoTjxLtVUibD'
     asset = {'msg': 'Hello BigchainDB!'}
-    tx = Transaction.create([pubkey], [([pubkey], 1)], asset=asset)
+    tx = Transaction.create([pubkey], [([pubkey], 1)], asset=asset, metadata={'sequence': 0})
     tx = tx.sign([privkey])
     tx_json = json.dumps(tx.to_dict(), indent=2, sort_keys=True)
 
@@ -189,7 +189,7 @@ def main():
     input_ = Input(fulfillment=tx.outputs[cid].fulfillment,
                    fulfills=TransactionLink(txid=tx.id, output=cid),
                    owners_before=tx.outputs[cid].public_keys)
-    tx_transfer = Transaction.transfer([input_], [([pubkey_transfer], 1)], asset_id=tx.id)
+    tx_transfer = Transaction.transfer([input_], [([pubkey_transfer], 1)], asset_id=tx.id, metadata={'sequence': 1})
     tx_transfer = tx_transfer.sign([privkey])
     tx_transfer_json = json.dumps(tx_transfer.to_dict(), indent=2, sort_keys=True)
 
@@ -200,7 +200,7 @@ def main():
     input_ = Input(fulfillment=tx_transfer.outputs[cid].fulfillment,
                    fulfills=TransactionLink(txid=tx_transfer.id, output=cid),
                    owners_before=tx_transfer.outputs[cid].public_keys)
-    tx_transfer_last = Transaction.transfer([input_], [([pubkey_transfer_last], 1)], asset_id=tx.id)
+    tx_transfer_last = Transaction.transfer([input_], [([pubkey_transfer_last], 1)], asset_id=tx.id, metadata={'sequence': 2})
     tx_transfer_last = tx_transfer_last.sign([privkey_transfer])
     tx_transfer_last_json = json.dumps(tx_transfer_last.to_dict(), indent=2, sort_keys=True)
 

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -70,7 +70,6 @@ Content-Type: application/json
 TPLS['post-tx-response'] = """\
 HTTP/1.1 202 Accepted
 Content-Type: application/json
-Location: ../statuses?tx_id=%(txid)s
 
 {
   "status": "/statuses?tx_id=%(txid)s"

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -70,16 +70,16 @@ Content-Type: application/json
 TPLS['post-tx-response'] = """\
 HTTP/1.1 202 Accepted
 Content-Type: application/json
-Location: ../statuses/%(txid)s
+Location: ../statuses?tx_id=%(txid)s
 
 {
-  "status": "/statuses/%(txid)s"
+  "status": "/statuses?tx_id=%(txid)s"
 }
 """
 
 
 TPLS['get-statuses-tx-request'] = """\
-GET /statuses/%(txid)s HTTP/1.1
+GET /statuses?tx_id=%(txid)s HTTP/1.1
 Host: example.com
 
 """
@@ -90,10 +90,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-  "status": "invalid",
-  "_links" : {
-    "block": "/blocks/%(blockid)s"
-  }
+  "status": "invalid"
 }
 """
 
@@ -104,11 +101,7 @@ Content-Type: application/json
 Location: ../transactions/%(txid)s
 
 {
-  "status": "valid",
-  "_links" : {
-    "tx" : "/transactions/%(txid)s",
-    "block": "/blocks/%(blockid)s"
-  }
+  "status": "valid"
 }
 """
 

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -58,21 +58,6 @@ Content-Type: application/json
 %(tx_transfer_last)s]
 """
 
-TPLS['get-assets-request'] = """\
-GET /transactions?operation=CREATE&is_asset=true&public_keys=%(public_keys)s HTTP/1.1
-Host: example.com
-
-"""
-
-
-TPLS['get-assets-response'] = """\
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-[%(tx)s]
-"""
-
-
 TPLS['post-tx-request'] = """\
 POST /transactions/ HTTP/1.1
 Host: example.com

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -5,7 +5,9 @@ import os
 import os.path
 
 from bigchaindb.common.transaction import Transaction, Input, TransactionLink
+from bigchaindb.core import Bigchain
 from bigchaindb.models import Block
+
 
 
 TPLS = {}
@@ -80,6 +82,7 @@ Host: example.com
 
 """
 
+
 TPLS['get-statuses-tx-invalid-response'] = """\
 HTTP/1.1 200 OK
 Content-Type: application/json
@@ -107,6 +110,7 @@ Host: example.com
 
 """
 
+
 TPLS['get-block-response'] = """\
 HTTP/1.1 200 OK
 Content-Type: application/json
@@ -114,11 +118,13 @@ Content-Type: application/json
 %(block)s
 """
 
+
 TPLS['get-block-txid-request'] = """\
 GET /blocks?tx_id=%(txid)s HTTP/1.1
 Host: example.com
 
 """
+
 
 TPLS['get-block-txid-response'] = """\
 HTTP/1.1 200 OK
@@ -128,8 +134,25 @@ Content-Type: application/json
 """
 
 
+TPLS['get-vote-request'] = """\
+GET /votes?block_id=%(blockid)s HTTP/1.1
+Host: example.com
+
+"""
+
+
+TPLS['get-vote-response'] = """\
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+[%(vote)s]
+"""
+
+
 def main():
     """ Main function """
+
+    # tx create
     privkey = 'CfdqtD7sS7FgkMoGPXw55MVGGFwQLAoHYTcBhZDtF99Z'
     pubkey = '4K9sWUMFwTgaDGPfdynrbxWqWS6sWmKbZoTjxLtVUibD'
     asset = {'msg': 'Hello BigchainDB!'}
@@ -137,6 +160,7 @@ def main():
     tx = tx.sign([privkey])
     tx_json = json.dumps(tx.to_dict(), indent=2, sort_keys=True)
 
+    # tx transfer
     privkey_transfer = '3AeWpPdhEZzWLYfkfYHBfMFC2r1f8HEaGS9NtbbKssya'
     pubkey_transfer = '3yfQPHeWAa1MxTX9Zf9176QqcpcnWcanVZZbaHb8B3h9'
 
@@ -159,6 +183,7 @@ def main():
     tx_transfer_last = tx_transfer_last.sign([privkey_transfer])
     tx_transfer_last_json = json.dumps(tx_transfer_last.to_dict(), indent=2, sort_keys=True)
 
+    # block
     node = "ErEeVZt8AfLbMJub25tjNxbpzzTNp3mGidL3GxGdd9bt"
     signature = "53wxrEQDYk1dXzmvNSytbCfmNVnPqPkDQaTnAe8Jf43s6ssejPxezkCvUnGTnduNUmaLjhaan1iRLi3peu6s5DzA"
     block = Block(transactions=[tx], node_pubkey=node, voters=[node], signature=signature)
@@ -166,6 +191,12 @@ def main():
 
     base_path = os.path.join(os.path.dirname(__file__),
                              'source/drivers-clients/samples')
+
+    # vote
+    DUMMY_SHA3 = '0123456789abcdef' * 4
+    b = Bigchain(public_key=node)
+    vote = b.vote(block.id, DUMMY_SHA3, True)
+    vote_json = json.dumps(vote, indent=2, sort_keys=True)
 
     if not os.path.exists(base_path):
         os.makedirs(base_path)
@@ -182,7 +213,8 @@ def main():
                       'public_keys_transfer': tx_transfer.outputs[0].public_keys[0],
                       'public_keys_transfer_last': tx_transfer_last.outputs[0].public_keys[0],
                       'block': block_json,
-                      'blockid': block.id}
+                      'blockid': block.id,
+                      'vote': vote_json}
         with open(path, 'w') as handle:
             handle.write(code)
 

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -53,6 +53,7 @@ Host: example.com
 TPLS['get-tx-response'] = """\
 HTTP/1.1 200 OK
 Content-Type: application/json
+X-BigchainDB-Timestamp: 1482766245
 
 %(tx)s
 """

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -107,6 +107,36 @@ Content-Type: application/json
 """
 
 
+TPLS['get-statuses-block-request'] = """\
+GET /statuses?block_id=%(blockid)s HTTP/1.1
+Host: example.com
+
+"""
+
+
+TPLS['get-statuses-block-invalid-response'] = """\
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "status": "invalid"
+}
+"""
+
+
+TPLS['get-statuses-block-valid-response'] = """\
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "status": "valid",
+  "_links": {
+    "block": "/blocks/%(blockid)s"
+  }
+}
+"""
+
+
 TPLS['get-block-request'] = """\
 GET /blocks/%(blockid)s HTTP/1.1
 Host: example.com

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -66,29 +66,37 @@ Content-Type: application/json
 
 
 TPLS['post-tx-response'] = """\
-HTTP/1.1 201 Created
+HTTP/1.1 202 Accepted
 Content-Type: application/json
-
-%(tx)s
+Location: ../statuses/%(txid)s
 """
 
 
-TPLS['get-tx-status-request'] = """\
-GET /transactions/%(txid)s/status HTTP/1.1
+TPLS['get-statuses-tx-request'] = """\
+GET /statuses/%(txid)s HTTP/1.1
 Host: example.com
 
 """
 
-TPLS['get-tx-status-response'] = """\
+TPLS['get-statuses-tx-invalid-response'] = """\
 HTTP/1.1 200 OK
 Content-Type: application/json
+
+{
+  "status": "invalid"
+}
+"""
+
+
+TPLS['get-statuses-tx-valid-response'] = """\
+HTTP/1.1 303 See Other
+Content-Type: application/json
+Location: ../transactions/%(txid)s
 
 {
   "status": "valid"
 }
 """
-
-
 
 
 def main():

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -134,7 +134,7 @@ TPLS['get-block-txid-response'] = """\
 HTTP/1.1 200 OK
 Content-Type: application/json
 
-[%(block)s]
+%(block_status)s
 """
 
 
@@ -194,11 +194,21 @@ def main():
     block = Block(transactions=[tx], node_pubkey=node_public, voters=[node_public], signature=signature)
     block_json = json.dumps(block.to_dict(), indent=2, sort_keys=True)
 
+    block_transfer = Block(transactions=[tx_transfer], node_pubkey=node_public, voters=[node_public], signature=signature)
+    block_transfer_json = json.dumps(block.to_dict(), indent=2, sort_keys=True)
+
     # vote
     DUMMY_SHA3 = '0123456789abcdef' * 4
     b = Bigchain(public_key=node_public, private_key=node_private)
     vote = b.vote(block.id, DUMMY_SHA3, True)
     vote_json = json.dumps(vote, indent=2, sort_keys=True)
+
+    # block status
+    block_status = {
+        block_transfer.id: 'invalid',
+        block.id: 'valid'
+    }
+    block_status_json = json.dumps(block_status, indent=2, sort_keys=True)
 
     base_path = os.path.join(os.path.dirname(__file__),
                              'source/drivers-clients/samples')
@@ -218,6 +228,7 @@ def main():
                       'public_keys_transfer_last': tx_transfer_last.outputs[0].public_keys[0],
                       'block': block_json,
                       'blockid': block.id,
+                      'block_status': block_status_json,
                       'vote': vote_json}
         with open(path, 'w') as handle:
             handle.write(code)

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -205,14 +205,15 @@ def main():
     tx_transfer_last_json = json.dumps(tx_transfer_last.to_dict(), indent=2, sort_keys=True)
 
     # block
-    node = "ErEeVZt8AfLbMJub25tjNxbpzzTNp3mGidL3GxGdd9bt"
+    node_private = "5G2kE1zJAgTajkVSbPAQWo4c2izvtwqaNHYsaNpbbvxX"
+    node_public = "DngBurxfeNVKZWCEcDnLj1eMPAS7focUZTE5FndFGuHT"
     signature = "53wxrEQDYk1dXzmvNSytbCfmNVnPqPkDQaTnAe8Jf43s6ssejPxezkCvUnGTnduNUmaLjhaan1iRLi3peu6s5DzA"
-    block = Block(transactions=[tx], node_pubkey=node, voters=[node], signature=signature)
+    block = Block(transactions=[tx], node_pubkey=node_public, voters=[node_public], signature=signature)
     block_json = json.dumps(block.to_dict(), indent=2, sort_keys=True)
 
     # vote
     DUMMY_SHA3 = '0123456789abcdef' * 4
-    b = Bigchain(public_key=node)
+    b = Bigchain(public_key=node_public)
     vote = b.vote(block.id, DUMMY_SHA3, True)
     vote_json = json.dumps(vote, indent=2, sort_keys=True)
 

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -88,7 +88,10 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-  "status": "invalid"
+  "status": "invalid",
+  "_links" : {
+    "block": "/blocks/%(blockid)s"
+  }
 }
 """
 
@@ -99,7 +102,11 @@ Content-Type: application/json
 Location: ../transactions/%(txid)s
 
 {
-  "status": "valid"
+  "status": "valid",
+  "_links" : {
+    "tx" : "/transactions/%(txid)s",
+    "block": "/blocks/%(blockid)s"
+  }
 }
 """
 
@@ -189,15 +196,14 @@ def main():
     block = Block(transactions=[tx], node_pubkey=node, voters=[node], signature=signature)
     block_json = json.dumps(block.to_dict(), indent=2, sort_keys=True)
 
-    base_path = os.path.join(os.path.dirname(__file__),
-                             'source/drivers-clients/samples')
-
     # vote
     DUMMY_SHA3 = '0123456789abcdef' * 4
     b = Bigchain(public_key=node)
     vote = b.vote(block.id, DUMMY_SHA3, True)
     vote_json = json.dumps(vote, indent=2, sort_keys=True)
 
+    base_path = os.path.join(os.path.dirname(__file__),
+                             'source/drivers-clients/samples')
     if not os.path.exists(base_path):
         os.makedirs(base_path)
 

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -67,7 +67,7 @@ Content-Type: application/json
 
 
 TPLS['post-tx-response'] = """\
-HTTP/1.1 200 OK
+HTTP/1.1 202 Accepted
 Content-Type: application/json
 
 %(tx)s

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -59,6 +59,20 @@ Content-Type: application/json
 %(tx_transfer_last)s]
 """
 
+TPLS['get-assets-request'] = """\
+GET /transactions?operation=CREATE&is_asset=true&public_keys=%(public_keys)s HTTP/1.1
+Host: example.com
+
+"""
+
+
+TPLS['get-assets-response'] = """\
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+[%(tx)s]
+"""
+
 
 TPLS['post-tx-request'] = """\
 POST /transactions/ HTTP/1.1

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -134,7 +134,7 @@ TPLS['get-block-txid-response'] = """\
 HTTP/1.1 200 OK
 Content-Type: application/json
 
-%(block_status)s
+%(block_list)s
 """
 
 
@@ -204,11 +204,11 @@ def main():
     vote_json = json.dumps(vote, indent=2, sort_keys=True)
 
     # block status
-    block_status = {
-        block_transfer.id: 'invalid',
-        block.id: 'valid'
-    }
-    block_status_json = json.dumps(block_status, indent=2, sort_keys=True)
+    block_list = [
+        block_transfer.id,
+        block.id
+    ]
+    block_list_json = json.dumps(block_list, indent=2, sort_keys=True)
 
     base_path = os.path.join(os.path.dirname(__file__),
                              'source/drivers-clients/samples')
@@ -228,7 +228,7 @@ def main():
                       'public_keys_transfer_last': tx_transfer_last.outputs[0].public_keys[0],
                       'block': block_json,
                       'blockid': block.id,
-                      'block_status': block_status_json,
+                      'block_list': block_list_json,
                       'vote': vote_json}
         with open(path, 'w') as handle:
             handle.write(code)

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -213,7 +213,7 @@ def main():
 
     # vote
     DUMMY_SHA3 = '0123456789abcdef' * 4
-    b = Bigchain(public_key=node_public)
+    b = Bigchain(public_key=node_public, private_key=node_private)
     vote = b.vote(block.id, DUMMY_SHA3, True)
     vote_json = json.dumps(vote, indent=2, sort_keys=True)
 

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -5,6 +5,8 @@ import os
 import os.path
 
 from bigchaindb.common.transaction import Transaction, Input, TransactionLink
+from bigchaindb.models import Block
+
 
 TPLS = {}
 
@@ -99,6 +101,20 @@ Location: ../transactions/%(txid)s
 """
 
 
+TPLS['get-block-request'] = """\
+GET /blocks/%(blockid)s HTTP/1.1
+Host: example.com
+
+"""
+
+TPLS['get-block-response'] = """\
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+%(block)s
+"""
+
+
 def main():
     """ Main function """
     privkey = 'CfdqtD7sS7FgkMoGPXw55MVGGFwQLAoHYTcBhZDtF99Z'
@@ -130,6 +146,11 @@ def main():
     tx_transfer_last = tx_transfer_last.sign([privkey_transfer])
     tx_transfer_last_json = json.dumps(tx_transfer_last.to_dict(), indent=2, sort_keys=True)
 
+    node = "ErEeVZt8AfLbMJub25tjNxbpzzTNp3mGidL3GxGdd9bt"
+    signature = "53wxrEQDYk1dXzmvNSytbCfmNVnPqPkDQaTnAe8Jf43s6ssejPxezkCvUnGTnduNUmaLjhaan1iRLi3peu6s5DzA"
+    block = Block(transactions=[tx], node_pubkey=node, voters=[node], signature=signature)
+    block_json = json.dumps(block.to_dict(), indent=2, sort_keys=True)
+
     base_path = os.path.join(os.path.dirname(__file__),
                              'source/drivers-clients/samples')
 
@@ -146,7 +167,9 @@ def main():
                       'tx_transfer_last_id': tx_transfer_last.id,
                       'public_keys': tx.outputs[0].public_keys[0],
                       'public_keys_transfer': tx_transfer.outputs[0].public_keys[0],
-                      'public_keys_transfer_last': tx_transfer_last.outputs[0].public_keys[0]}
+                      'public_keys_transfer_last': tx_transfer_last.outputs[0].public_keys[0],
+                      'block': block_json,
+                      'blockid': block.id}
         with open(path, 'w') as handle:
             handle.write(code)
 
@@ -158,3 +181,5 @@ def setup(*_):
 
 if __name__ == '__main__':
     main()
+
+

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -96,12 +96,14 @@ Content-Type: application/json
 
 
 TPLS['get-statuses-tx-valid-response'] = """\
-HTTP/1.1 303 See Other
+HTTP/1.1 200 OK
 Content-Type: application/json
-Location: ../transactions/%(txid)s
 
 {
-  "status": "valid"
+  "status": "valid",
+  "_links": {
+    "tx": "/transactions/%(txid)s"
+  }
 }
 """
 

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -114,6 +114,19 @@ Content-Type: application/json
 %(block)s
 """
 
+TPLS['get-block-txid-request'] = """\
+GET /blocks?tx_id=%(txid)s HTTP/1.1
+Host: example.com
+
+"""
+
+TPLS['get-block-txid-response'] = """\
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+[%(block)s]
+"""
+
 
 def main():
     """ Main function """

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -71,6 +71,10 @@ TPLS['post-tx-response'] = """\
 HTTP/1.1 202 Accepted
 Content-Type: application/json
 Location: ../statuses/%(txid)s
+
+{
+  "status": "/statuses/%(txid)s"
+}
 """
 
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -128,15 +128,13 @@ Transactions
    queried correctly. Some of them include retrieving a list of transactions
    that include:
 
-   * `Unfulfilled conditions <#get--transactions?fields=id,conditions&fulfilled=false&owners_after=owners_after>`_
-   * `A specific asset <#get--transactions?fields=id,asset,operation&operation=CREATE|TRANSFER&asset_id=asset_id>`_
-   * `Specific metadata <#get--transactions?fields=id,metadata&metadata_id=metadata_id>`_
+   * `Unfulfilled conditions <#get--transactions?fulfilled=false&owners_after=owners_after>`_
+   * `A specific asset <#get--transactions?operation=CREATE|TRANSFER&asset_id=asset_id>`_
+   * `Specific metadata <#get--transactions?&metadata_id=metadata_id>`_
 
    In this section, we've listed those particular requests, as they will likely
    to be very handy when implementing your application on top of BigchainDB.
    A generalization of those parameters can follows:
-
-   :query string fields: Comma separated list, allowed values are: ``asset``, ``conditions``, ``fulfillments``, ``id``, ``metadata``, ``operation``, ``owners_after``, ``version``.
 
    :query boolean fulfilled: A flag to indicate if transaction's with fulfilled conditions should be returned.
 
@@ -151,7 +149,7 @@ Transactions
    :statuscode 404: BigchainDB does not expose this endpoint.
 
 
-.. http:get:: /transactions?fields=id,conditions&fulfilled=false&owners_after={owners_after}
+.. http:get:: /transactions?fulfilled=false&owners_after={owners_after}
 
    Get a list of transactions with unfulfilled conditions.
 
@@ -162,8 +160,6 @@ Transactions
    This endpoint returns conditions only if the transaction they're in are
    included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
 
-   :query string fields: A comma separated string to expand properties on the transaction object to be returned.
-
    :query boolean fulfilled: A flag to indicate if transaction's with fulfilled conditions should be returned.
 
    :query string owners_after: Public key able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
@@ -172,7 +168,7 @@ Transactions
 
    .. sourcecode:: http
 
-      GET /transactions?fields=id,conditions&fulfilled=false&owners_after=1AAAbbb...ccc HTTP/1.1
+      GET /transactions?fulfilled=false&owners_after=1AAAbbb...ccc HTTP/1.1
       Host: example.com
 
    **Example response**:
@@ -203,7 +199,29 @@ Transactions
               ]
             }
           ],
+          "operation": "CREATE",
+          "asset": {
+            "divisible": false,
+            "updatable": false,
+            "data": null,
+            "id": "aebeab22-e672-4d3b-a187-bde5fda6533d",
+            "refillable": false
+          },
+          "metadata": null,
+          "timestamp": "1477578978",
+          "fulfillments": [
+            {
+              "fid": 0,
+              "input": null,
+              "fulfillment": "cf:4:GG-pi3CeIlySZhQoJVBh9O23PzrOuhnYI7OHqIbHjkn2VnQaEWvecO1x82Qr2Va_JjFywLKIOEV1Ob9Ofkeln2K89ny2mB-s7RLNvYAVzWNiQnp18_nQEUsvwACEXTYJ",
+              "owners_before": [
+                "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
+              ]
+            }
+          ]
+        },
         "id": "2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e",
+        "version": 1
       }]
 
    :resheader Content-Type: ``application/json``
@@ -211,14 +229,12 @@ Transactions
    :statuscode 200: A list of transaction's containing unfulfilled conditions was found and returned.
    :statuscode 400: The request wasn't understood by the server, e.g. the ``owners_after`` querystring was not included in the request.
 
-.. http:get:: /transactions?fields=id,asset,operation&operation={GENESIS|CREATE|TRANSFER}&asset_id={asset_id}
+.. http:get:: /transactions?operation={GENESIS|CREATE|TRANSFER}&asset_id={asset_id}
 
    Get a list of transactions that use an asset with the ID ``asset_id``.
 
    This endpoint returns assets only if the transaction they're in are
    included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
-
-   :query string fields: A comma separated string to expand properties on the transaction object to be returned.
 
    :query string operation: One of the three supported operations of a transaction: ``GENESIS``, ``CREATE``, ``TRANSFER``.
 
@@ -228,7 +244,7 @@ Transactions
 
    .. sourcecode:: http
 
-      GET /transactions?fields=id,asset,operation&operation=CREATE&asset_id=1AAAbbb...ccc HTTP/1.1
+      GET /transactions?operation=CREATE&asset_id=1AAAbbb...ccc HTTP/1.1
       Host: example.com
 
    **Example response**:
@@ -240,6 +256,26 @@ Transactions
 
       [{
         "transaction": {
+          "conditions": [
+            {
+              "cid": 0,
+              "condition": {
+                "uri": "cc:4:20:GG-pi3CeIlySZhQoJVBh9O23PzrOuhnYI7OHqIbHjkk:96",
+                "details": {
+                  "signature": null,
+                  "type": "fulfillment",
+                  "type_id": 4,
+                  "bitmask": 32,
+                  "public_key": "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
+                }
+              },
+              "amount": 1,
+              "owners_after": [
+                "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
+              ]
+            }
+          ],
+          "operation": "CREATE",
           "asset": {
             "divisible": false,
             "updatable": false,
@@ -247,8 +283,21 @@ Transactions
             "id": "1AAAbbb...ccc",
             "refillable": false
           },
-        "operation": "CREATE",
+          "metadata": null,
+          "timestamp": "1477578978",
+          "fulfillments": [
+            {
+              "fid": 0,
+              "input": null,
+              "fulfillment": "cf:4:GG-pi3CeIlySZhQoJVBh9O23PzrOuhnYI7OHqIbHjkn2VnQaEWvecO1x82Qr2Va_JjFywLKIOEV1Ob9Ofkeln2K89ny2mB-s7RLNvYAVzWNiQnp18_nQEUsvwACEXTYJ",
+              "owners_before": [
+                "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
+              ]
+            }
+          ]
+        },
         "id": "2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e",
+        "version": 1
       }]
 
    :resheader Content-Type: ``application/json``
@@ -256,14 +305,12 @@ Transactions
    :statuscode 200: A list of transaction's containing an asset with ID ``asset_id`` was found and returned.
    :statuscode 400: The request wasn't understood by the server, e.g. the ``asset_id`` querystring was not included in the request.
 
-.. http:get:: /transactions?fields=id,metadata&metadata_id={metadata_id}
+.. http:get:: /transactions?metadata_id={metadata_id}
 
    Get a list of transactions that use metadata with the ID ``metadata_id``.
 
    This endpoint returns assets only if the transaction they're in are
    included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
-
-   :query string fields: A comma separated string to expand properties on the transaction object to be returned.
 
    :query string metadata_id: metadata ID.
 
@@ -271,7 +318,7 @@ Transactions
 
    .. sourcecode:: http
 
-      GET /transactions?fields=id,metadata&metadata_id=1AAAbbb...ccc HTTP/1.1
+      GET /transactions?metadata_id=1AAAbbb...ccc HTTP/1.1
       Host: example.com
 
    **Example response**:
@@ -283,12 +330,53 @@ Transactions
 
       [{
         "transaction": {
-        "metadata": {
-          "id": "1AAAbbb...ccc",
-          "data": {
-            "hello": "world"
+          "conditions": [
+            {
+              "cid": 0,
+              "condition": {
+                "uri": "cc:4:20:GG-pi3CeIlySZhQoJVBh9O23PzrOuhnYI7OHqIbHjkk:96",
+                "details": {
+                  "signature": null,
+                  "type": "fulfillment",
+                  "type_id": 4,
+                  "bitmask": 32,
+                  "public_key": "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
+                }
+              },
+              "amount": 1,
+              "owners_after": [
+                "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
+              ]
+            }
+          ],
+          "operation": "CREATE",
+          "asset": {
+            "divisible": false,
+            "updatable": false,
+            "data": null,
+            "id": "aebeab22-e672-4d3b-a187-bde5fda6533d",
+            "refillable": false
           },
+          "metadata": {
+            "id": "1AAAbbb...ccc",
+            "data": {
+              "hello": "world"
+            },
+          },
+          "timestamp": "1477578978",
+          "fulfillments": [
+            {
+              "fid": 0,
+              "input": null,
+              "fulfillment": "cf:4:GG-pi3CeIlySZhQoJVBh9O23PzrOuhnYI7OHqIbHjkn2VnQaEWvecO1x82Qr2Va_JjFywLKIOEV1Ob9Ofkeln2K89ny2mB-s7RLNvYAVzWNiQnp18_nQEUsvwACEXTYJ",
+              "owners_before": [
+                "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
+              ]
+            }
+          ]
+        },
         "id": "2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e",
+        "version": 1
       }]
 
    :resheader Content-Type: ``application/json``

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -26,6 +26,7 @@ with something like the following in the body:
     {
       "_links": {
         "docs": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/"
+        "api_v1": "http://example.com:9984/api/v1/"
       },
       "keyring": [
         "6qHyZew94NMmUTYyHnkZsB8cxJYuRNEiEpXHe1ih9QX3",
@@ -50,12 +51,10 @@ that allows you to discover the BigchainDB API endpoints:
 
     {
       "_links": {
-        "blocks": "https://example.com:9984/api/v1/blocks",
         "docs": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html",
         "self": "https://example.com:9984/api/v1",
         "statuses": "https://example.com:9984/api/v1/statuses",
         "transactions": "https://example.com:9984/api/v1/transactions",
-        "votes": "https://example.com:9984/api/v1/votes"
       },
       "version" : "0.9.0"
     }

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -382,7 +382,48 @@ Blocks
 
 .. http:get:: /blocks/{block_id}
 
-   Descriptions: TODO
+   Get the block with the ID ``block_id``.
+
+   A block is only returned if it was labeled ``VALID`` or ``UNDECIDED`` and
+   exists in the table ``bigchain``.
+
+   :param block_id: block ID
+   :type block_id: hex string
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+      GET /blocks/6152fbc7e0f7686512ed6b92c01e8c73ea1e3f51a7b037ac5cc8c860215e7202 HTTP/1.1
+      Host: example.com
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "block":{
+          "node_pubkey":"ErEeVZt8AfLbMJub25tjNxbpzzTNp3mGidL3GxGdd9bt",
+            "timestamp":"1479389911",
+            "transactions":[
+              '<transaction1>',
+              '<transaction2>'
+            ],
+            "voters":[
+              "ErEeVZt8AfLbMJub25tjNxbpzzTNp3mGidL3GxGdd9bt"
+            ]
+        },
+        "id":"6152fbc7e0f7686512ed6b92c01e8c73ea1e3f51a7b037ac5cc8c860215e7202",
+        "signature":"53wxrEQDYk1dXzmvNSytbCfmNVnPqPkDQaTnAe8Jf43s6ssejPxezkCvUnGTnduNUmaLjhaan1iRLi3peu6s5DzA"
+      }
+
+   :resheader Content-Type: ``application/json``
+
+   :statuscode 200: A block with that ID was found. Its status is either ``VALID`` or ``UNDECIDED``.
+   :statuscode 404: A block with that ID was not found.
 
 .. http:get:: /blocks?tx_id={tx_id}
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -12,8 +12,8 @@ and you're not sure what the API Root URL is,
 then see the last section of this page for help.
 
 
-API Root URL
-------------
+BigchainDB Root URL
+-------------------
 
 If you send an HTTP GET request to the API Root URL
 e.g. ``http://localhost:9984`` 
@@ -31,7 +31,28 @@ with something like the following in the body:
       ],
       "public_key": "AiygKSRhZWTxxYT4AfgKoTG4TZAoPsWoEt6C6bLq4jJR",
       "software": "BigchainDB",
-      "version": "0.6.0"
+      "version": "0.9.0"
+    }
+
+
+API Root URL
+-------------------
+
+If you send an HTTP GET request to the API Root URL
+e.g. ``http://localhost:9984/api/v1/``
+or ``http://apihosting4u.net:9984/api/v1/``,
+then you should get an HTTP response
+that allows you to discover the BigchainDB endpoints:
+
+.. code-block:: json
+
+    {
+      "_links": {
+        "self": { "href": "/" },
+        "transactions": { "href": "/transactions" },
+        "statuses": { "href": "/statuses" },
+        "blocks": { "href": "/blocks" },
+        "votes": { "href": "/votes" }
     }
 
 Transactions

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -247,8 +247,11 @@ Transactions
    .. literalinclude:: samples/post-tx-response.http
       :language: http
 
-   :statuscode 202: The pushed transaction was accepted, but the processing has not been completed.
-   :statuscode 400: The transaction was invalid and not created.
+   :resheader Content-Type: ``application/json``
+   :resheader Location: As the transaction will be persisted asynchronously, an endpoint to monitor its status is provided in this header.
+
+   :statuscode 202: The pushed transaction was accepted in the ``BACKLOG``, but the processing has not been completed.
+   :statuscode 400: The transaction was malformed and not accepted in the ``BACKLOG``.
 
 
 Statuses

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -636,14 +636,8 @@ Blocks
 Votes
 --------------------------------
 
-.. http:get:: /votes/{vote_id}
-
-   Descriptions: TODO
-
 .. http:get:: /votes?block_id={block_id}
 
    Descriptions: TODO
 
 .. http:get:: /votes?block_id={block_id}&voter={voter}
-
-   Descriptions: TODO

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -257,12 +257,13 @@ Transactions
 Statuses
 --------------------------------
 
-.. http:get:: /statuses/{tx_id|block_id}
+.. http:get:: /statuses?tx_id={tx_id}|block_id={block_id}
 
    Get the status of an asynchronously written resource by their id.
 
    Supports the retrieval of a status for a transaction using ``tx_id`` or the
-   retrieval of a status for a block using ``block_id``.
+   retrieval of a status for a block using ``block_id``. Only use exactly one of both
+   queries, as they are required but mutually exclusive.
 
    The possible status values are ``backlog``, ``undecided``, ``valid`` or
    ``invalid``.
@@ -312,7 +313,7 @@ Blocks
        that was labeled ``UNDECIDED`` or ``INVALID`` is requested by
        ``block_id``, this endpoint will return a ``404 Not Found`` status code
        to warn the user. To check a block's status independently, use the
-       `Statuses endpoint <#get--statuses-tx_id|block_id>`_. The ``INVALID`` status
+       `Statuses endpoint <#get--statuses?tx_id=tx_id|block_id=block_id>`_. The ``INVALID`` status
        can be handy to figure out why the block was rejected.
 
    :param block_id: block ID

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -198,6 +198,8 @@ Transactions
        ``/transactions?operation=CREATE&asset_id={asset_id}``, there will in
        any case only be one transaction returned (in a list though, since
        ``/transactions`` is a list-returning endpoint).
+       Leaving out the ``asset_id`` query and calling
+       ``/transactions?operation=CREATE`` returns the list of assets.
 
    :query string operation: One of the two supported operations of a transaction: ``CREATE``, ``TRANSFER``.
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -184,8 +184,11 @@ Transactions
 .. http:get:: /transactions?operation={CREATE|TRANSFER}&asset_id={asset_id}
 
    Get a list of transactions that use an asset with the ID ``asset_id``.
+   Every ``TRANSFER`` transaction that originates from a ``CREATE`` transaction
+   with ``asset_id`` will be included. This allows users to query the entire history or
+   provenance of an asset.
 
-   This endpoint returns assets only if the transaction they're in are
+   This endpoint returns transactions only if they are
    included in the ``BACKLOG`` or in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
 
    .. note::

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -223,14 +223,9 @@ Transactions
    :statuscode 200: A list of transaction's containing unfulfilled conditions was found and returned.
    :statuscode 400: The request wasn't understood by the server, e.g. the ``owners_after`` querystring was not included in the request.
 
-.. http:get:: /transactions?fields=id,asset,operation&operation={CREATE|TRANSFER}&asset_id={asset_id}
+.. http:get:: /transactions?fields=id,asset,operation&operation={GENESIS|CREATE|TRANSFER}&asset_id={asset_id}
 
    Get a list of transactions that use an asset with the ID ``asset_id``.
-
-   This endpoint will return a ``HTTP 400 Bad Request`` if the querystring
-   ``asset_id`` happens to not be defined in the request.
-
-   ``operation`` can either be ``GENESIS``, ``CREATE`` or ``TRANSFER``.
 
    This endpoint returns assets only if the transaction they're in are
    included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
@@ -238,7 +233,7 @@ Transactions
    :query fields: A comma separated string to expand properties on the transaction object to be returned.
    :type fields: string
 
-   :query operation: One of the three supported operations of a transaction.
+   :query operation: One of the three supported operations of a transaction (``GENESIS``, ``CREATE``, ``TRANSFER``).
    :type operation: string
 
    :query asset_id: asset ID.
@@ -279,9 +274,6 @@ Transactions
 .. http:get:: /transactions?fields=id,metadata&metadata_id={metadata_id}
 
    Get a list of transactions that use metadata with the ID ``metadata_id``.
-
-   This endpoint will return a ``HTTP 400 Bad Request`` if the querystring
-   ``metadata_id`` happens to not be defined in the request.
 
    This endpoint returns assets only if the transaction they're in are
    included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
@@ -353,6 +345,7 @@ Statuses
 .. http:get:: /statuses/{tx_id | block_id}
 
    Get the status of an asynchronously written resource by their id.
+
    Supports the retrieval of a status for a transaction using ``tx_id`` or the
    retrieval of a status for a block using ``block_id``.
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -638,6 +638,48 @@ Votes
 
 .. http:get:: /votes?block_id={block_id}
 
-   Descriptions: TODO
+   Retrieve a list of votes for a certain block with ID ``block_id``.
+   To check for the validity of a vote, a user of this endpoint needs to
+   perform the `following steps: <https://github.com/bigchaindb/bigchaindb/blob/8ebd93ed3273e983f5770b1617292aadf9f1462b/bigchaindb/util.py#L119>`_
+
+   1. Check if the vote's ``node_pubkey`` is allowed to vote.
+   2. Verify the vote's signature against the vote's body (``vote.vote``) and
+   ``node_pubkey``.
+
+   :query string block_id: The block ID to filter the votes.
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+      GET /votes?block_id=6152f...e7202 HTTP/1.1
+      Host: example.com
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      [{
+        "node_pubkey": "ErEeVZt8AfLbMJub25tjNxbpzzTNp3mGidL3GxGdd9bt" ,
+        "signature": "53wxrEQDYk1dXzmvNSytbCfmNVnPqPkDQaTnAe8Jf43s6ssejPxezkCvUnGTnduNUmaLjhaan1iRLi3peu6s5DzA",
+        "vote": {
+          "invalid_reason": null ,
+          "is_block_valid": true ,
+          "previous_block": "6152fbc7e0f7686512ed6b92c01e8c73ea1e3f51a7b037ac5cc8c860215e7202" ,
+          "timestamp": "1480082692" ,
+          "voting_for_block": "6152f...e7202"
+        }
+      }]
+
+   :resheader Content-Type: ``application/json``
+
+   :statuscode 200: A list of votes voting for a block with ID ``block_id`` was found and returned.
+   :statuscode 400: The request wasn't understood by the server, e.g. just requesting ``/votes``, without defining ``block_id``.
+
 
 .. http:get:: /votes?block_id={block_id}&voter={voter}
+
+   Description: TODO

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -165,9 +165,6 @@ Transactions
    ``owners_after`` happen to be fulfilled already, this endpoint will return
    an empty list.
 
-   This endpoint will return a ``HTTP 400 Bad Request`` if the querystring
-   ``owners_after`` happens to not be defined in the request.
-
    This endpoint returns conditions only if the transaction they're in are
    included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
 
@@ -401,10 +398,22 @@ Blocks
 
    Descriptions: TODO
 
+.. http:get:: /blocks?tx_id={tx_id}
+
+   Descriptions: TODO
+
 
 Votes
 --------------------------------
 
+.. http:get:: /votes/{vote_id}
+
+   Descriptions: TODO
+
 .. http:get:: /votes?block_id={block_id}
+
+   Descriptions: TODO
+
+.. http:get:: /votes?block_id={block_id}&voter={voter}
 
    Descriptions: TODO

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -112,6 +112,8 @@ Transactions
         "version": 1
       }
 
+   :resheader Content-Type: ``application/json``
+
    :statuscode 200: A transaction with that ID was found.
    :statuscode 404: A transaction with that ID was not found.
 
@@ -216,6 +218,8 @@ Transactions
         "id": "2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e",
       }]
 
+   :resheader Content-Type: ``application/json``
+
    :statuscode 200: A list of transaction's containing unfulfilled conditions was found and returned.
    :statuscode 400: The request wasn't understood by the server, e.g. the ``owners_after`` querystring was not included in the request.
 
@@ -267,6 +271,8 @@ Transactions
         "id": "2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e",
       }]
 
+   :resheader Content-Type: ``application/json``
+
    :statuscode 200: A list of transaction's containing an asset with ID ``asset_id`` was found and returned.
    :statuscode 400: The request wasn't understood by the server, e.g. the ``asset_id`` querystring was not included in the request.
 
@@ -309,6 +315,8 @@ Transactions
           },
         "id": "2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e",
       }]
+
+   :resheader Content-Type: ``application/json``
 
    :statuscode 200: A list of transaction's containing metadata with ID ``metadata_id`` was found and returned.
    :statuscode 400: The request wasn't understood by the server, e.g. the ``metadata_id`` querystring was not included in the request.
@@ -370,6 +378,9 @@ Statuses
 
    .. literalinclude:: samples/get-tx-status-response.http
       :language: http
+
+   :resheader Content-Type: ``application/json``
+   :resheader Location: Once the transaction has been persisted, this header will link to the actual resource.
 
    :statuscode 200: A transaction or block with that ID was found. The status is either ``backlog``, ``invalid``.
    :statuscode 303: A transaction or block with that ID was found and persisted to the chain. A location header to the resource is provided.

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -25,34 +25,40 @@ with something like the following in the body:
 .. code-block:: json
 
     {
+      "_links": {
+        "docs": { "href": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/" }
+      }
       "keyring": [
         "6qHyZew94NMmUTYyHnkZsB8cxJYuRNEiEpXHe1ih9QX3",
         "AdDuyrTyjrDt935YnFu4VBCVDhHtY2Y6rcy7x2TFeiRi"
       ],
       "public_key": "AiygKSRhZWTxxYT4AfgKoTG4TZAoPsWoEt6C6bLq4jJR",
       "software": "BigchainDB",
-      "version": "0.9.0"
+      "version": "0.9.0",
     }
 
 
-API Root URL
+API Root Endpoint
 -------------------
 
-If you send an HTTP GET request to the API Root URL
-e.g. ``http://localhost:9984/api/v1/``
-or ``http://apihosting4u.net:9984/api/v1/``,
+If you send an HTTP GET request to the API Root Endpoint
+e.g. ``http://localhost:9984/api/v0.9/``
+or ``http://apihosting4u.net:9984/api/v0.9/``,
 then you should get an HTTP response
-that allows you to discover the BigchainDB endpoints:
+that allows you to discover the BigchainDB API endpoints:
 
 .. code-block:: json
 
     {
       "_links": {
-        "self": { "href": "/" },
-        "transactions": { "href": "/transactions" },
-        "statuses": { "href": "/statuses" },
         "blocks": { "href": "/blocks" },
+        "docs": { "href": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html" },
+        "self": { "href": "/" },
+        "statuses": { "href": "/statuses" },
+        "transactions": { "href": "/transactions" },
         "votes": { "href": "/votes" }
+      },
+      "version" : "0.9.0"
     }
 
 Transactions
@@ -455,3 +461,40 @@ Votes
 .. http:get:: /votes?block_id={block_id}&voter={voter}
 
    Description: TODO
+
+
+Determining the API Root URL
+----------------------------
+
+When you start BigchainDB Server using ``bigchaindb start``,
+an HTTP API is exposed at some address. The default is:
+
+`http://localhost:9984/api/v0.9/ <http://localhost:9984/api/v0.9/>`_
+
+It's bound to ``localhost``,
+so you can access it from the same machine,
+but it won't be directly accessible from the outside world.
+(The outside world could connect via a SOCKS proxy or whatnot.)
+
+The documentation about BigchainDB Server :any:`Configuration Settings`
+has a section about how to set ``server.bind`` so as to make
+the HTTP API publicly accessible.
+
+If the API endpoint is publicly accessible,
+then the public API Root URL is determined as follows:
+
+- The public IP address (like 12.34.56.78)
+  is the public IP address of the machine exposing
+  the HTTP API to the public internet (e.g. either the machine hosting
+  Gunicorn or the machine running the reverse proxy such as Nginx).
+  It's determined by AWS, Azure, Rackspace, or whoever is hosting the machine.
+
+- The DNS hostname (like apihosting4u.net) is determined by DNS records,
+  such as an "A Record" associating apihosting4u.net with 12.34.56.78
+
+- The port (like 9984) is determined by the ``server.bind`` setting
+  if Gunicorn is exposed directly to the public Internet.
+  If a reverse proxy (like Nginx) is exposed directly to the public Internet
+  instead, then it could expose the HTTP API on whatever port it wants to.
+  (It should expose the HTTP API on port 9984, but it's not bound to do
+  that by anything other than convention.)

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -470,15 +470,22 @@ Statuses
 Blocks
 --------------------------------
 
-.. http:get:: /blocks/{block_id}
+.. http:get:: /blocks/{block_id}?status={VALID|UNDECIDED|INVALID}
 
    Get the block with the ID ``block_id``.
 
-   A block is only returned if it was labeled ``VALID`` or ``UNDECIDED`` and
-   exists in the table ``bigchain``.
+   .. note::
+       As ``status``'s default value is set to ``VALID``, only ``VALID`` blocks
+       will be returned by this endpoint. In case ``status=VALID``, but a block
+       that was labeled ``UNDECIDED`` or ``INVALID`` is requested by
+       ``block_id``, this endpoint will return a ``404 Not Found`` status code
+       to warn the user. To check a block's status independently, use the
+       `Statuses endpoint <#get--statuses-tx_id|block_id>`_.
 
    :param block_id: block ID
    :type block_id: hex string
+
+   :query string status: Per default set to ``VALID``. One of ``VALID``, ``UNDECIDED`` or ``INVALID``.
 
    **Example request**:
 
@@ -512,8 +519,9 @@ Blocks
 
    :resheader Content-Type: ``application/json``
 
-   :statuscode 200: A block with that ID was found. Its status is either ``VALID`` or ``UNDECIDED``.
-   :statuscode 404: A block with that ID was not found.
+   :statuscode 200: A block with that ID was found.
+   :statuscode 400: The request wasn't understood by the server, e.g. just requesting ``/blocks`` without the ``block_id``.
+   :statuscode 404: A block with that ID and a certain ``status`` was not found.
 
 .. http:get:: /blocks
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -54,12 +54,12 @@ Transactions
 
    **Example request**:
 
-   .. literalinclude:: samples/get-tx-request.http
+   .. literalinclude:: samples/get-tx-id-request.http
       :language: http
 
    **Example response**:
 
-   .. literalinclude:: samples/get-tx-response.http
+   .. literalinclude:: samples/get-tx-id-response.http
       :language: http
 
    :resheader X-BigchainDB-Timestamp: A unix timestamp describing when a transaction was included into a valid block. The timestamp provided is taken from the block the transaction was included in.
@@ -79,7 +79,7 @@ Transactions
    queried correctly. Some of them include retrieving a list of transactions
    that include:
 
-   * `Unfulfilled conditions <#get--transactions?fulfilled=false&owners_after=owners_after>`_
+   * `Unfulfilled conditions <#get--transactions?fulfilled=false&public_keys=public_keys>`_
    * `A specific asset <#get--transactions?operation=CREATE|TRANSFER&asset_id=asset_id>`_
    * `Specific metadata <#get--transactions?&metadata_id=metadata_id>`_
 
@@ -89,7 +89,7 @@ Transactions
 
    :query boolean fulfilled: A flag to indicate if transaction's with fulfilled conditions should be returned.
 
-   :query string owners_after: Public key able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
+   :query string public_keys: Public key able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
 
    :query string operation: One of the three supported operations of a transaction: ``GENESIS``, ``CREATE``, ``TRANSFER``.
 
@@ -100,12 +100,12 @@ Transactions
    :statuscode 404: BigchainDB does not expose this endpoint.
 
 
-.. http:get:: /transactions?fulfilled=false&owners_after={owners_after}
+.. http:get:: /transactions?fulfilled=false&public_keys={public_keys}
 
    Get a list of transactions with unfulfilled conditions.
 
    If the querystring ``fulfilled`` is set to ``false`` and all conditions for
-   ``owners_after`` happen to be fulfilled already, this endpoint will return
+   ``public_keys`` happen to be fulfilled already, this endpoint will return
    an empty list.
 
    This endpoint returns conditions only if the transaction they're in are
@@ -113,67 +113,19 @@ Transactions
 
    :query boolean fulfilled: A flag to indicate if transaction's with fulfilled conditions should be returned.
 
-   :query string owners_after: Public key able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
+   :query string public_keys: Public key able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
 
    **Example request**:
 
-   .. sourcecode:: http
 
-      GET /transactions?fulfilled=false&owners_after=1AAAbbb...ccc HTTP/1.1
-      Host: example.com
+   .. literalinclude:: samples/get-tx-unfulfilled-request.http
+      :language: http
+
 
    **Example response**:
 
-   .. sourcecode:: http
-
-      HTTP/1.1 200 OK
-      Content-Type: application/json
-
-      [{
-        "transaction": {
-          "conditions": [
-            {
-              "cid": 0,
-              "condition": {
-                "uri": "cc:4:20:GG-pi3CeIlySZhQoJVBh9O23PzrOuhnYI7OHqIbHjkk:96",
-                "details": {
-                  "signature": null,
-                  "type": "fulfillment",
-                  "type_id": 4,
-                  "bitmask": 32,
-                  "public_key": "1AAAbbb...ccc"
-                }
-              },
-              "amount": 1,
-              "owners_after": [
-                "1AAAbbb...ccc"
-              ]
-            }
-          ],
-          "operation": "CREATE",
-          "asset": {
-            "divisible": false,
-            "updatable": false,
-            "data": null,
-            "id": "aebeab22-e672-4d3b-a187-bde5fda6533d",
-            "refillable": false
-          },
-          "metadata": null,
-          "timestamp": "1477578978",
-          "fulfillments": [
-            {
-              "fid": 0,
-              "input": null,
-              "fulfillment": "cf:4:GG-pi3CeIlySZhQoJVBh9O23PzrOuhnYI7OHqIbHjkn2VnQaEWvecO1x82Qr2Va_JjFywLKIOEV1Ob9Ofkeln2K89ny2mB-s7RLNvYAVzWNiQnp18_nQEUsvwACEXTYJ",
-              "owners_before": [
-                "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
-              ]
-            }
-          ]
-        },
-        "id": "2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e",
-        "version": 1
-      }]
+   .. literalinclude:: samples/get-tx-unfulfilled-response.http
+      :language: http
 
    :resheader Content-Type: ``application/json``
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -450,21 +450,6 @@ Statuses
    :statuscode 303: A transaction or block with that ID was found and persisted to the chain. A location header to the resource is provided.
    :statuscode 404: A transaction or block with that ID was not found.
 
-
-Assets
---------------------------------
-
-.. http:get:: /assets/{asset_id}
-
-   Descriptions: TODO
-
-
-Metadata
---------------------------------
-
-.. http:get:: /metadata/{metadata_id}
-
-
 Blocks
 --------------------------------
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -37,6 +37,7 @@ that allows you to discover the BigchainDB API endpoints:
 .. literalinclude:: samples/api-index-response.http
     :language: http
 
+
 Transactions
 -------------------
 
@@ -152,7 +153,7 @@ Transaction Outputs
 
 The ``/api/v1/outputs`` endpoint returns transactions outputs filtered by a
 given public key, and optionally filtered to only include outputs that have
-not already been spent. 
+not already been spent.
 
 
 .. http:get:: /api/v1/outputs?public_key={public_key}
@@ -162,20 +163,20 @@ not already been spent.
    ownership.
 
    Returns a list of links to transaction outputs.
-   
+
    :param public_key: Base58 encoded public key associated with output ownership. This parameter is mandatory and without it the endpoint will return a ``400`` response code.
    :param unspent: Boolean value ("true" or "false") indicating if the result set should be limited to outputs that are available to spend.
-   
- 
+
+
    **Example request**:
- 
+
    .. sourcecode:: http
- 
+
      GET /api/v1/outputs?public_key=1AAAbbb...ccc HTTP/1.1
      Host: example.com
 
    **Example response**:
-   
+
    .. sourcecode:: http
 
      HTTP/1.1 200 OK
@@ -185,10 +186,9 @@ not already been spent.
        "../transactions/2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e/outputs/0",
        "../transactions/2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e/outputs/1"
      ]
- 
+
    :statuscode 200: A list of outputs were found and returned in the body of the response.
    :statuscode 400: The request wasn't understood by the server, e.g. the ``public_key`` querystring was not included in the request.
-
 
 
 Statuses
@@ -282,7 +282,6 @@ The `votes endpoint <#votes>`_ contains all the voting information for a specifi
 ``block_id`` for a given ``tx_id``, one can now simply inspect the votes that happened at a specific time on that block.
 
 
-
 Blocks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -364,8 +363,6 @@ Blocks
 
    :statuscode 200: A list of blocks containing a transaction with ID ``tx_id`` was found and returned.
    :statuscode 400: The request wasn't understood by the server, e.g. just requesting ``/blocks``, without defining ``tx_id``.
-
-
 
 
 Votes

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -224,12 +224,17 @@ Statuses
 
    **Example request**:
 
-   .. literalinclude:: samples/get-tx-status-request.http
+   .. literalinclude:: samples/get-statuses-tx-request.http
       :language: http
 
    **Example response**:
 
-   .. literalinclude:: samples/get-tx-status-response.http
+   .. literalinclude:: samples/get-statuses-tx-invalid-response.http
+      :language: http
+
+   **Example response**:
+
+   .. literalinclude:: samples/get-statuses-tx-valid-response.http
       :language: http
 
    :resheader Content-Type: ``application/json``

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -513,8 +513,8 @@ Blocks
           "node_pubkey":"ErEeVZt8AfLbMJub25tjNxbpzzTNp3mGidL3GxGdd9bt",
             "timestamp":"1479389911",
             "transactions":[
-              '<transaction1>',
-              '<transaction2>'
+              "<transaction1>",
+              "<transaction2>"
             ],
             "voters":[
               "ErEeVZt8AfLbMJub25tjNxbpzzTNp3mGidL3GxGdd9bt"
@@ -643,8 +643,8 @@ Votes
    perform the `following steps: <https://github.com/bigchaindb/bigchaindb/blob/8ebd93ed3273e983f5770b1617292aadf9f1462b/bigchaindb/util.py#L119>`_
 
    1. Check if the vote's ``node_pubkey`` is allowed to vote.
-   2. Verify the vote's signature against the vote's body (``vote.vote``) and
-   ``node_pubkey``.
+   2. Verify the vote's signature against the vote's body (``vote.vote``) and ``node_pubkey``.
+
 
    :query string block_id: The block ID to filter the votes.
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -226,7 +226,8 @@ Transactions
 
 .. http:post:: /transactions
 
-   Push a new transaction.
+   Push a new transaction. The endpoint will return a ``statuses`` endpoint to track
+   the status of the transaction.
 
    .. note::
        The posted transaction should be valid `transaction

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -520,9 +520,107 @@ Blocks
    :statuscode 200: A block with that ID was found. Its status is either ``VALID`` or ``UNDECIDED``.
    :statuscode 404: A block with that ID was not found.
 
-.. http:get:: /blocks?tx_id={tx_id}
+.. http:get:: /blocks
 
-   Descriptions: TODO
+   The current ``/blocks`` endpoint returns a ``404 Not Found`` HTTP status
+   code. Eventually, this functionality will get implemented.
+   We believe a PUSH rather than a PULL pattern is more appropriate, as the
+   items returned in the collection would change by the second.
+
+   :statuscode 404: BigchainDB does not expose this endpoint.
+
+
+.. http:get:: /blocks?tx_id={tx_id}&status={VALID|UNDECIDED|INVALID}
+
+   Retrieve a list of blocks that contain a transaction with the ID ``tx_id``.
+
+   Any blocks, be they ``VALID``, ``UNDECIDED`` or ``INVALID`` will be
+   returned. To filter blocks by their status, use the optional ``status``
+   querystring.
+
+   .. note::
+       In case no block was found, an empty list and an HTTP status code
+       ``200 OK`` is returned, as the request was still successful.
+
+   :query string tx_id: transaction ID
+   :query string status: Filter blocks by their status. One of ``VALID``, ``UNDECIDED`` or ``INVALID``.
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+      GET /blocks?tx_id=2d431...0b4b0e HTTP/1.1
+      Host: example.com
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "block":{
+          "node_pubkey":"ErEeVZt8AfLbMJub25tjNxbpzzTNp3mGidL3GxGdd9bt",
+            "timestamp":"1479389911",
+            "transactions":[
+              {
+                "transaction": {
+                  "conditions": [
+                    {
+                      "cid": 0,
+                      "condition": {
+                        "uri": "cc:4:20:GG-pi3CeIlySZhQoJVBh9O23PzrOuhnYI7OHqIbHjkk:96",
+                        "details": {
+                          "signature": null,
+                          "type": "fulfillment",
+                          "type_id": 4,
+                          "bitmask": 32,
+                          "public_key": "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
+                        }
+                      },
+                      "amount": 1,
+                      "owners_after": [
+                        "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
+                      ]
+                    }
+                  ],
+                  "operation": "CREATE",
+                  "asset": {
+                    "divisible": false,
+                    "updatable": false,
+                    "data": null,
+                    "id": "aebeab22-e672-4d3b-a187-bde5fda6533d",
+                    "refillable": false
+                  },
+                  "metadata": null,
+                  "timestamp": "1477578978",
+                  "fulfillments": [
+                    {
+                      "fid": 0,
+                      "input": null,
+                      "fulfillment": "cf:4:GG-pi3CeIlySZhQoJVBh9O23PzrOuhnYI7OHqIbHjkn2VnQaEWvecO1x82Qr2Va_JjFywLKIOEV1Ob9Ofkeln2K89ny2mB-s7RLNvYAVzWNiQnp18_nQEUsvwACEXTYJ",
+                      "owners_before": [
+                        "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
+                      ]
+                    }
+                  ]
+                },
+                "id": "2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e",
+                "version": 1
+              }],
+            "voters":[
+              "ErEeVZt8AfLbMJub25tjNxbpzzTNp3mGidL3GxGdd9bt"
+            ]
+        },
+        "id":"6152fbc7e0f7686512ed6b92c01e8c73ea1e3f51a7b037ac5cc8c860215e7202",
+        "signature":"53wxrEQDYk1dXzmvNSytbCfmNVnPqPkDQaTnAe8Jf43s6ssejPxezkCvUnGTnduNUmaLjhaan1iRLi3peu6s5DzA"
+      }
+
+   :resheader Content-Type: ``application/json``
+
+   :statuscode 200: A list of blocks containing a transaction with ID ``tx_id`` was found and returned.
+   :statuscode 400: The request wasn't understood by the server, e.g. just requesting ``/blocks``, without defining ``tx_id``.
 
 
 Votes

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -303,12 +303,13 @@ Blocks
    Get the block with the ID ``block_id``.
 
    .. note::
-       As ``status``'s default value is set to ``VALID``, only ``VALID`` blocks
+       As ``status``'s default value is set to ``VALID``, hence only ``VALID`` blocks
        will be returned by this endpoint. In case ``status=VALID``, but a block
        that was labeled ``UNDECIDED`` or ``INVALID`` is requested by
        ``block_id``, this endpoint will return a ``404 Not Found`` status code
        to warn the user. To check a block's status independently, use the
-       `Statuses endpoint <#get--statuses-tx_id|block_id>`_.
+       `Statuses endpoint <#get--statuses-tx_id|block_id>`_. The ``INVALID`` status
+       can be handy to figure out why the block was rejected.
 
    :param block_id: block ID
    :type block_id: hex string

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -266,33 +266,14 @@ Blocks
 
    **Example request**:
 
-   .. sourcecode:: http
-
-      GET /blocks/6152fbc7e0f7686512ed6b92c01e8c73ea1e3f51a7b037ac5cc8c860215e7202 HTTP/1.1
-      Host: example.com
+   .. literalinclude:: samples/get-block-request.http
+      :language: http
 
    **Example response**:
 
-   .. sourcecode:: http
+   .. literalinclude:: samples/get-block-response.http
+      :language: http
 
-      HTTP/1.1 200 OK
-      Content-Type: application/json
-
-      {
-        "block":{
-          "node_pubkey":"ErEeVZt8AfLbMJub25tjNxbpzzTNp3mGidL3GxGdd9bt",
-            "timestamp":"1479389911",
-            "transactions":[
-              "<transaction1>",
-              "<transaction2>"
-            ],
-            "voters":[
-              "ErEeVZt8AfLbMJub25tjNxbpzzTNp3mGidL3GxGdd9bt"
-            ]
-        },
-        "id":"6152fbc7e0f7686512ed6b92c01e8c73ea1e3f51a7b037ac5cc8c860215e7202",
-        "signature":"53wxrEQDYk1dXzmvNSytbCfmNVnPqPkDQaTnAe8Jf43s6ssejPxezkCvUnGTnduNUmaLjhaan1iRLi3peu6s5DzA"
-      }
 
    :resheader Content-Type: ``application/json``
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -26,7 +26,7 @@ with something like the following in the body:
     {
       "_links": {
         "docs": { "href": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/" }
-      }
+      },
       "keyring": [
         "6qHyZew94NMmUTYyHnkZsB8cxJYuRNEiEpXHe1ih9QX3",
         "AdDuyrTyjrDt935YnFu4VBCVDhHtY2Y6rcy7x2TFeiRi"
@@ -365,39 +365,18 @@ Votes
 
    **Example request**:
 
-   .. sourcecode:: http
-
-      GET /votes?block_id=6152f...e7202 HTTP/1.1
-      Host: example.com
+   .. literalinclude:: samples/get-vote-request.http
+      :language: http
 
    **Example response**:
 
-   .. sourcecode:: http
-
-      HTTP/1.1 200 OK
-      Content-Type: application/json
-
-      [{
-        "node_pubkey": "ErEeVZt8AfLbMJub25tjNxbpzzTNp3mGidL3GxGdd9bt" ,
-        "signature": "53wxrEQDYk1dXzmvNSytbCfmNVnPqPkDQaTnAe8Jf43s6ssejPxezkCvUnGTnduNUmaLjhaan1iRLi3peu6s5DzA",
-        "vote": {
-          "invalid_reason": null ,
-          "is_block_valid": true ,
-          "previous_block": "6152fbc7e0f7686512ed6b92c01e8c73ea1e3f51a7b037ac5cc8c860215e7202" ,
-          "timestamp": "1480082692" ,
-          "voting_for_block": "6152f...e7202"
-        }
-      }]
+   .. literalinclude:: samples/get-vote-response.http
+      :language: http
 
    :resheader Content-Type: ``application/json``
 
    :statuscode 200: A list of votes voting for a block with ID ``block_id`` was found and returned.
    :statuscode 400: The request wasn't understood by the server, e.g. just requesting ``/votes``, without defining ``block_id``.
-
-
-.. http:get:: /votes?block_id={block_id}&voter={voter}
-
-   Description: TODO
 
 
 Determining the API Root URL

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -316,57 +316,14 @@ The `votes endpoint <#votes>`_ contains all the voting information for a specifi
 Blocks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. http:get:: /blocks
+.. http:get:: /blocks/{block_id}
 
-   The unfiltered ``/blocks`` endpoint without any query parameters
-   returns a list of available block usages and relevant endpoints.
-   We believe a PUSH rather than a PULL pattern is more appropriate, as the
-   items returned in the collection would change by the second.
-
-
-   **Example request**:
-
-   .. sourcecode:: http
-
-      GET /blocks HTTP/1.1
-      Host: example.com
-
-   **Example response**:
-
-   .. sourcecode:: http
-
-      HTTP/1.1 200 OK
-      Content-Type: application/json
-
-      {
-        "_links": {
-          "blocks": "https://example.com:9984/api/v1/blocks?tx_id={tx_id}&status={VALID|UNDECIDED|INVALID}",
-          "docs": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html",
-          "item": "https://example.com:9984/api/v1/blocks/{block_id}?status={VALID|UNDECIDED|INVALID}",
-          "self": "https://example.com:9984/api/v1/blocks"
-        },
-        "version" : "0.9.0"
-      }
-
-   :statuscode 200: BigchainDB blocks root endpoint.
-
-.. http:get:: /blocks/{block_id}?status={VALID|UNDECIDED|INVALID}
-
-   Get the block with the ID ``block_id``.
-
-   .. note::
-       As ``status``'s default value is set to ``VALID``, hence only ``VALID`` blocks
-       will be returned by this endpoint. In case ``status=VALID``, but a block
-       that was labeled ``UNDECIDED`` or ``INVALID`` is requested by
-       ``block_id``, this endpoint will return a ``404 Not Found`` status code
-       to warn the user. To check a block's status independently, use the
-       `Statuses endpoint <#get--statuses?tx_id=tx_id|block_id=block_id>`_. The ``INVALID`` status
-       can be handy to figure out why the block was rejected.
+   Get the block with the ID ``block_id``. Any blocks, be they ``VALID``, ``UNDECIDED`` or ``INVALID`` will be
+   returned. To check a block's status independently, use the `Statuses endpoint <#get--statuses?tx_id=tx_id|block_id=block_id>`_.
+   To check the votes on a block, have a look at the `votes endpoint <#votes>`_.
 
    :param block_id: block ID
    :type block_id: hex string
-
-   :query string status: Per default set to ``VALID``. One of ``VALID``, ``UNDECIDED`` or ``INVALID``.
 
    **Example request**:
 
@@ -383,20 +340,44 @@ Blocks
 
    :statuscode 200: A block with that ID was found.
    :statuscode 400: The request wasn't understood by the server, e.g. just requesting ``/blocks`` without the ``block_id``.
-   :statuscode 404: A block with that ID and a certain ``status`` was not found.
+   :statuscode 404: A block with that ID was not found.
 
-.. http:get:: /blocks?tx_id={tx_id}
+
+.. http:get:: /blocks
+
+   The unfiltered ``/blocks`` endpoint without any query parameters returns a `400` status code.
+   The list endpoint should be filtered with a ``tx_id`` query parameter,
+   see the ``/blocks?tx_id={tx_id}&status=UNDECIDED|VALID|INVALID``
+   `endpoint <#get--blocks?tx_id=tx_id&status=UNDECIDED|VALID|INVALID>`_.
+
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+      GET /blocks HTTP/1.1
+      Host: example.com
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 400 OK
+
+   :statuscode 400: The request wasn't understood by the server, e.g. just requesting ``/blocks`` without the ``block_id``.
+
+.. http:get:: /blocks?tx_id={tx_id}&status={UNDECIDED|VALID|INVALID}
 
    Retrieve a list of ``block_id`` with their corresponding status that contain a transaction with the ID ``tx_id``.
 
-   Any blocks, be they ``VALID``, ``UNDECIDED`` or ``INVALID`` will be
-   returned.
+   Any blocks, be they ``UNDECIDED``, ``VALID`` or ``INVALID`` will be
+   returned if no status filter is provided.
 
    .. note::
        In case no block was found, an empty list and an HTTP status code
        ``200 OK`` is returned, as the request was still successful.
 
-   :query string tx_id: transaction ID
+   :query string tx_id: transaction ID *(required)*
    :query string status: Filter blocks by their status. One of ``VALID``, ``UNDECIDED`` or ``INVALID``.
 
    **Example request**:
@@ -413,6 +394,8 @@ Blocks
 
    :statuscode 200: A list of blocks containing a transaction with ID ``tx_id`` was found and returned.
    :statuscode 400: The request wasn't understood by the server, e.g. just requesting ``/blocks``, without defining ``tx_id``.
+
+
 
 
 Votes

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -242,24 +242,31 @@ Transactions
 Statuses
 --------------------------------
 
-.. http:get:: /statuses?tx_id={tx_id}|block_id={block_id}
+.. http:get:: /statuses
 
-   Get the status of an asynchronously written resource by their id.
+   Get the status of an asynchronously written transaction or block by their id.
 
-   Supports the retrieval of a status for a transaction using ``tx_id`` or the
-   retrieval of a status for a block using ``block_id``. Only use exactly one of both
-   queries, as they are required but mutually exclusive. A URL to the resource is also
-   provided under ``_links``.
-
-   The possible status values are ``undecided``, ``valid`` or
-   ``invalid`` for both blocks and transactions. An additional state ``backlog`` is provided
+   The possible status values are ``undecided``, ``valid`` or ``invalid`` for
+   both blocks and transactions. An additional state ``backlog`` is provided
    for transactions.
 
-   :param tx_id: transaction ID
-   :type tx_id: hex string
+   A link to the resource is also provided in the returned payload under
+   ``_links``.
 
-   :param block_id: block ID
-   :type block_id: hex string
+   :query string tx_id: transaction ID
+   :query string block_id: block ID
+
+   .. note::
+
+        Exactly one of the ``tx_id`` or ``block_id`` query parameters must be
+        used together with this endpoint (see below for getting `transaction
+        statuses <#get--statuses?tx_id=tx_id>`_ and `block statuses
+        <#get--statuses?block_id=block_id>`_).
+
+
+.. http:get:: /statuses?tx_id={tx_id}
+
+    Get the status of a transaction.
 
    **Example request**:
 
@@ -279,8 +286,35 @@ Statuses
    :resheader Content-Type: ``application/json``
    :resheader Location: Once the transaction has been persisted, this header will link to the actual resource.
 
-   :statuscode 200: A transaction or block with that ID was found.
-   :statuscode 404: A transaction or block with that ID was not found.
+   :statuscode 200: A transaction with that ID was found.
+   :statuscode 404: A transaction with that ID was not found.
+
+
+.. http:get:: /statuses?block_id={block_id}
+
+    Get the status of a block.
+
+   **Example request**:
+
+   .. literalinclude:: samples/get-statuses-block-request.http
+      :language: http
+
+   **Example response**:
+
+   .. literalinclude:: samples/get-statuses-block-invalid-response.http
+      :language: http
+
+   **Example response**:
+
+   .. literalinclude:: samples/get-statuses-block-valid-response.http
+      :language: http
+
+   :resheader Content-Type: ``application/json``
+   :resheader Location: Once the block has been persisted, this header will link to the actual resource.
+
+   :statuscode 200: A block with that ID was found.
+   :statuscode 404: A block with that ID was not found.
+
 
 Advanced Usage
 --------------------------------
@@ -303,7 +337,7 @@ Blocks
 .. http:get:: /blocks/{block_id}
 
    Get the block with the ID ``block_id``. Any blocks, be they ``VALID``, ``UNDECIDED`` or ``INVALID`` will be
-   returned. To check a block's status independently, use the `Statuses endpoint <#get--statuses?tx_id=tx_id|block_id=block_id>`_.
+   returned. To check a block's status independently, use the `Statuses endpoint <#status>`_.
    To check the votes on a block, have a look at the `votes endpoint <#votes>`_.
 
    :param block_id: block ID

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -298,8 +298,57 @@ Statuses
    :statuscode 200: A transaction or block with that ID was found.
    :statuscode 404: A transaction or block with that ID was not found.
 
-Blocks
+Advanced Usage
 --------------------------------
+
+The following endpoints are more advanced and meant for debugging and transparency purposes.
+
+More precisely, the `blocks endpoint <#blocks>`_ allows you to retrieve a block by ``block_id`` as well the list of blocks that
+a certain transaction with ``tx_id`` occured in (a transaction can occur in multiple ``invalid`` blocks until it
+either gets rejected or validated by the system). This endpoint gives the ability to drill down on the lifecycle of a
+transaction
+
+The `votes endpoint <#votes>`_ contains all the voting information for a specific block. So after retrieving the
+``block_id`` for a given ``tx_id``, one can now simply inspect the votes that happened at a specific time on that block.
+
+
+
+Blocks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. http:get:: /blocks
+
+   The unfiltered ``/blocks`` endpoint without any query parameters
+   returns a list of available block usages and relevant endpoints.
+   We believe a PUSH rather than a PULL pattern is more appropriate, as the
+   items returned in the collection would change by the second.
+
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+      GET /blocks HTTP/1.1
+      Host: example.com
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "_links": {
+          "blocks": "https://example.com:9984/api/v1/blocks?tx_id={tx_id}&status={VALID|UNDECIDED|INVALID}",
+          "docs": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html",
+          "item": "https://example.com:9984/api/v1/blocks/{block_id}?status={VALID|UNDECIDED|INVALID}",
+          "self": "https://example.com:9984/api/v1/blocks"
+        },
+        "version" : "0.9.0"
+      }
+
+   :statuscode 200: BigchainDB blocks root endpoint.
 
 .. http:get:: /blocks/{block_id}?status={VALID|UNDECIDED|INVALID}
 
@@ -336,48 +385,12 @@ Blocks
    :statuscode 400: The request wasn't understood by the server, e.g. just requesting ``/blocks`` without the ``block_id``.
    :statuscode 404: A block with that ID and a certain ``status`` was not found.
 
-.. http:get:: /blocks
+.. http:get:: /blocks?tx_id={tx_id}
 
-   The unfiltered ``/blocks`` endpoint without any query parameters
-   returns a list of available block usages and relevant endpoints.
-   We believe a PUSH rather than a PULL pattern is more appropriate, as the
-   items returned in the collection would change by the second.
-
-
-   **Example request**:
-
-   .. sourcecode:: http
-
-      GET /blocks HTTP/1.1
-      Host: example.com
-
-   **Example response**:
-
-   .. sourcecode:: http
-
-      HTTP/1.1 200 OK
-      Content-Type: application/json
-
-      {
-        "_links": {
-          "blocks": "https://example.com:9984/api/v1/blocks?tx_id={tx_id}&status={VALID|UNDECIDED|INVALID}",
-          "docs": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html",
-          "item": "https://example.com:9984/api/v1/blocks/{block_id}?status={VALID|UNDECIDED|INVALID}",
-          "self": "https://example.com:9984/api/v1/blocks"
-        },
-        "version" : "0.9.0"
-      }
-
-   :statuscode 200: BigchainDB blocks root endpoint.
-
-
-.. http:get:: /blocks?tx_id={tx_id}&status={VALID|UNDECIDED|INVALID}
-
-   Retrieve a list of blocks that contain a transaction with the ID ``tx_id``.
+   Retrieve a list of ``block_id`` with their corresponding status that contain a transaction with the ID ``tx_id``.
 
    Any blocks, be they ``VALID``, ``UNDECIDED`` or ``INVALID`` will be
-   returned. To filter blocks by their status, use the optional ``status``
-   querystring.
+   returned.
 
    .. note::
        In case no block was found, an empty list and an HTTP status code
@@ -403,7 +416,7 @@ Blocks
 
 
 Votes
---------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. http:get:: /votes?block_id={block_id}
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -115,7 +115,7 @@ Transactions
           "docs": { "href": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html" },
           "item": { "href": "https://example.com:9984/api/v0.9/transactions/{tx_id}" },
           "self": { "href": "https://example.com:9984/api/v0.9/transactions" },
-          "unfulfilled": { "href": "https://example.com:9984/api/v0.9/transactions?fulfilled=false&public_keys={public_keys}" }
+          "unspent": { "href": "https://example.com:9984/api/v0.9/transactions?unspent=true&public_keys={public_keys}" }
         },
         "version" : "0.9.0"
       }
@@ -126,7 +126,7 @@ Transactions
    queried correctly. Some of them include retrieving a list of transactions
    that include:
 
-   * `Unfulfilled outputs <#get--transactions?fulfilled=false&public_keys=public_keys>`_
+   * `Unspent outputs <#get--transactions?unspent=true&public_keys=public_keys>`_
    * `Transactions related to a specific asset <#get--transactions?operation=GENESIS|CREATE|TRANSFER&asset_id=asset_id>`_
 
    In this section, we've listed those particular requests, as they will likely
@@ -139,7 +139,7 @@ Transactions
 
    A generalization of those parameters follows:
 
-   :query boolean fulfilled: A flag to indicate if transactions with fulfilled conditions should be returned.
+   :query boolean unspent: A flag to indicate whether only transactions with unspent outputs should be returned.
 
    :query string public_keys: Public key able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
 
@@ -148,36 +148,37 @@ Transactions
    :query string asset_id: asset ID.
 
 
-.. http:get:: /transactions?fulfilled=false&public_keys={public_keys}
+.. http:get:: /transactions?unspent=true&public_keys={public_keys}
 
-   Get a list of transactions with unfulfilled conditions.
+   Get a list of transactions with unspent outputs.
 
-   If the querystring ``fulfilled`` is set to ``false`` and all conditions for
-   ``public_keys`` happen to be fulfilled already, this endpoint will return
-   an empty list.
+   If the querystring ``unspent`` is set to ``false`` and all outputs for
+   ``public_keys`` happen to be spent already, this endpoint will return
+   an empty list. Transactions with multiple outputs that have not all been spent
+   will be included in the response.
 
-   This endpoint returns conditions only if the transaction they're in are
+   This endpoint returns transactions only if they are
    included in the ``BACKLOG`` or in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
 
-   :query boolean fulfilled: A flag to indicate if transactions with fulfilled conditions should be returned.
+   :query boolean unspent: A flag to indicate if transactions with unspent outputs should be returned.
 
    :query string public_keys: Public key able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
 
    **Example request**:
 
 
-   .. literalinclude:: samples/get-tx-unfulfilled-request.http
+   .. literalinclude:: samples/get-tx-unspent-request.http
       :language: http
 
 
    **Example response**:
 
-   .. literalinclude:: samples/get-tx-unfulfilled-response.http
+   .. literalinclude:: samples/get-tx-unspent-response.http
       :language: http
 
    :resheader Content-Type: ``application/json``
 
-   :statuscode 200: A list of transactions containing unfulfilled conditions was found and returned.
+   :statuscode 200: A list of transactions containing unspent outputs was found and returned.
    :statuscode 400: The request wasn't understood by the server, e.g. the ``public_keys`` querystring was not included in the request.
 
 .. http:get:: /transactions?operation={GENESIS|CREATE|TRANSFER}&asset_id={asset_id}

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -236,6 +236,17 @@ Transactions
    This endpoint returns assets only if the transaction they're in are
    included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
 
+   .. note::
+       The BigchainDB API currently doesn't expose an
+       ``/assets/{asset_id}`` endpoint, as there wouldn't be any way for a
+       client to verify that what was received is consistent with what was
+       persisted in the database.
+       However, BigchainDB's consensus ensures that any ``asset_id`` is
+       a unique key identifying an asset, meaning that when calling
+       ``/transactions?operation=CREATE&asset_id={asset_id}``, there will in
+       any case only be one transaction returned (in a list though, since
+       ``/transactions`` is a list-returning endpoint).
+
    :query string operation: One of the three supported operations of a transaction: ``GENESIS``, ``CREATE``, ``TRANSFER``.
 
    :query string asset_id: asset ID.
@@ -311,6 +322,17 @@ Transactions
 
    This endpoint returns assets only if the transaction they're in are
    included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
+
+   .. note::
+       The BigchainDB API currently doesn't expose an
+       ``/metadata/{metadata_id}`` endpoint, as there wouldn't be any way for a
+       client to verify that what was received is consistent with what was
+       persisted in the database.
+       However, BigchainDB's consensus ensures that any ``metadata_id`` is
+       a unique key identifying metadata, meaning that when calling
+       ``/transactions?metadata_id={metadata_id}``, there will in any case only
+       be one transaction returned (in a list though, since ``/transactions``
+       is a list-returning endpoint).
 
    :query string metadata_id: metadata ID.
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -169,13 +169,13 @@ Transactions
    This endpoint returns conditions only if the transaction they're in are
    included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
 
-   :param fields: A comma separated string to expand properties on the transaction object to be returned.
+   :query fields: A comma separated string to expand properties on the transaction object to be returned.
    :type fields: string
 
-   :param fulfilled: A flag to indicate if transaction's with fulfilled conditions should be returned.
+   :query fulfilled: A flag to indicate if transaction's with fulfilled conditions should be returned.
    :type fulfilled: boolean
 
-   :param owners_after: Public keys able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
+   :query owners_after: Public keys able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
    :type owners_after: base58 encoded string
 
    **Example request**:
@@ -231,13 +231,13 @@ Transactions
    This endpoint returns assets only if the transaction they're in are
    included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
 
-   :param fields: A comma separated string to expand properties on the transaction object to be returned.
+   :query fields: A comma separated string to expand properties on the transaction object to be returned.
    :type fields: string
 
-   :param operation: One of the three supported operations of a transaction.
+   :query operation: One of the three supported operations of a transaction.
    :type operation: string
 
-   :param asset_id: asset ID.
+   :query asset_id: asset ID.
    :type asset_id: uuidv4
 
    **Example request**:
@@ -280,10 +280,10 @@ Transactions
    This endpoint returns assets only if the transaction they're in are
    included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
 
-   :param fields: A comma separated string to expand properties on the transaction object to be returned.
+   :query fields: A comma separated string to expand properties on the transaction object to be returned.
    :type fields: string
 
-   :param metadata_id: metadata ID.
+   :query metadata_id: metadata ID.
    :type metadata_id: uuidv4
 
    **Example request**:

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -362,7 +362,7 @@ Blocks
 
    .. sourcecode:: http
 
-      HTTP/1.1 400 OK
+      HTTP/1.1 400 Bad Request
 
    :statuscode 400: The request wasn't understood by the server, e.g. just requesting ``/blocks`` without the ``block_id``.
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -435,7 +435,7 @@ Transactions
 Statuses
 --------------------------------
 
-.. http:get:: /statuses/{tx_id | block_id}
+.. http:get:: /statuses/{tx_id|block_id}
 
    Get the status of an asynchronously written resource by their id.
 
@@ -445,9 +445,9 @@ Statuses
    The possible status values are ``backlog``, ``undecided``, ``valid`` or
    ``invalid``.
 
-   If a transaction or block is persisted to the chain and it's status is set to
-   ``valid`` or ``undecided``, a ``303 See Other`` status code is returned, as
-   well as an URL to the resource in the location header.
+   If a transaction or block is persisted to the chain and it's status is set
+   to ``valid`` or ``undecided``, a ``303 See Other`` status code is returned,
+   as well as an URL to the resource in the location header.
 
    :param tx_id: transaction ID
    :type tx_id: hex string

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -25,7 +25,7 @@ with something like the following in the body:
 
     {
       "_links": {
-        "docs": { "href": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/" }
+        "docs": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/"
       },
       "keyring": [
         "6qHyZew94NMmUTYyHnkZsB8cxJYuRNEiEpXHe1ih9QX3",
@@ -50,12 +50,12 @@ that allows you to discover the BigchainDB API endpoints:
 
     {
       "_links": {
-        "blocks": { "href": "https://example.com:9984/api/v1/blocks" },
-        "docs": { "href": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html" },
-        "self": { "href": "https://example.com:9984/api/v1" },
-        "statuses": { "href": "https://example.com:9984/api/v1/statuses" },
-        "transactions": { "href": "https://example.com:9984/api/v1/transactions" },
-        "votes": { "href": "https://example.com:9984/api/v1/votes" }
+        "blocks": "https://example.com:9984/api/v1/blocks",
+        "docs": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html",
+        "self": "https://example.com:9984/api/v1",
+        "statuses": "https://example.com:9984/api/v1/statuses",
+        "transactions": "https://example.com:9984/api/v1/transactions",
+        "votes": "https://example.com:9984/api/v1/votes"
       },
       "version" : "0.9.0"
     }
@@ -111,11 +111,11 @@ Transactions
 
       {
         "_links": {
-          "assets": { "href": "https://example.com:9984/api/v1/transactions?operation={CREATE|TRANSFER}&asset_id={asset_id}" },
-          "docs": { "href": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html" },
-          "item": { "href": "https://example.com:9984/api/v1/transactions/{tx_id}" },
-          "self": { "href": "https://example.com:9984/api/v1/transactions" },
-          "unspent": { "href": "https://example.com:9984/api/v1/transactions?unspent=true&public_keys={public_keys}" }
+          "assets": "https://example.com:9984/api/v1/transactions?operation={CREATE|TRANSFER}&asset_id={asset_id}",
+          "docs": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html",
+          "item": "https://example.com:9984/api/v1/transactions/{tx_id}",
+          "self": "https://example.com:9984/api/v1/transactions",
+          "unspent": "https://example.com:9984/api/v1/transactions?unspent=true&public_keys={public_keys}"
         },
         "version" : "0.9.0"
       }
@@ -362,10 +362,10 @@ Blocks
 
       {
         "_links": {
-          "blocks": { "href": "https://example.com:9984/api/v1/blocks?tx_id={tx_id}&status={VALID|UNDECIDED|INVALID}" },
-          "docs": { "href": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html" },
-          "item": { "href": "https://example.com:9984/api/v1/blocks/{block_id}?status={VALID|UNDECIDED|INVALID}" },
-          "self": { "href": "https://example.com:9984/api/v1/blocks" }
+          "blocks": "https://example.com:9984/api/v1/blocks?tx_id={tx_id}&status={VALID|UNDECIDED|INVALID}",
+          "docs": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html",
+          "item": "https://example.com:9984/api/v1/blocks/{block_id}?status={VALID|UNDECIDED|INVALID}",
+          "self": "https://example.com:9984/api/v1/blocks"
         },
         "version" : "0.9.0"
       }

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -70,11 +70,6 @@ Transactions
    This endpoint returns only a transaction from the ``BACKLOG`` or a ``VALID`` or ``UNDECIDED``
    block on ``bigchain``, if exists.
 
-   A transaction itself doesn't include a ``timestamp`` property. Only the
-   block a transaction was included in has a unix ``timestamp`` property. It is
-   returned by this endpoint in a HTTP custom entity header called
-   ``X-BigchainDB-Timestamp``.
-
    :param tx_id: transaction ID
    :type tx_id: hex string
 
@@ -88,7 +83,6 @@ Transactions
    .. literalinclude:: samples/get-tx-id-response.http
       :language: http
 
-   :resheader X-BigchainDB-Timestamp: A unix timestamp describing when a transaction was included into a valid block. The timestamp provided is taken from the block the transaction was included in.
    :resheader Content-Type: ``application/json``
 
    :statuscode 200: A transaction with that ID was found.

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -54,64 +54,13 @@ Transactions
 
    **Example request**:
 
-   .. sourcecode:: http
-
-      GET /transactions/2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e HTTP/1.1
-      Host: example.com
+   .. literalinclude:: samples/get-tx-request.http
+      :language: http
 
    **Example response**:
 
-   .. sourcecode:: http
-
-      HTTP/1.1 200 OK
-      Content-Type: application/json
-      X-BigchainDB-Timestamp: 1234567890
-
-      {
-        "transaction": {
-          "conditions": [
-            {
-              "cid": 0,
-              "condition": {
-                "uri": "cc:4:20:GG-pi3CeIlySZhQoJVBh9O23PzrOuhnYI7OHqIbHjkk:96",
-                "details": {
-                  "signature": null,
-                  "type": "fulfillment",
-                  "type_id": 4,
-                  "bitmask": 32,
-                  "public_key": "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
-                }
-              },
-              "amount": 1,
-              "owners_after": [
-                "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
-              ]
-            }
-          ],
-          "operation": "CREATE",
-          "asset": {
-            "divisible": false,
-            "updatable": false,
-            "data": null,
-            "id": "aebeab22-e672-4d3b-a187-bde5fda6533d",
-            "refillable": false
-          },
-          "metadata": null,
-          "timestamp": "1477578978",
-          "fulfillments": [
-            {
-              "fid": 0,
-              "input": null,
-              "fulfillment": "cf:4:GG-pi3CeIlySZhQoJVBh9O23PzrOuhnYI7OHqIbHjkn2VnQaEWvecO1x82Qr2Va_JjFywLKIOEV1Ob9Ofkeln2K89ny2mB-s7RLNvYAVzWNiQnp18_nQEUsvwACEXTYJ",
-              "owners_before": [
-                "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
-              ]
-            }
-          ]
-        },
-        "id": "2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e",
-        "version": 1
-      }
+   .. literalinclude:: samples/get-tx-response.http
+      :language: http
 
    :resheader X-BigchainDB-Timestamp: A unix timestamp describing when a transaction was included into a valid block. The timestamp provided is taken from the block the transaction was included in.
    :resheader Content-Type: ``application/json``

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -34,7 +34,7 @@ with something like the following in the body:
       ],
       "public_key": "AiygKSRhZWTxxYT4AfgKoTG4TZAoPsWoEt6C6bLq4jJR",
       "software": "BigchainDB",
-      "version": "0.9.0",
+      "version": "0.9.0"
     }
 
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -333,7 +333,7 @@ Blocks
 
    The unfiltered ``/blocks`` endpoint without any query parameters returns a `400` status code.
    The list endpoint should be filtered with a ``tx_id`` query parameter,
-   see the ``/blocks?tx_id={tx_id}&status=UNDECIDED|VALID|INVALID``
+   see the ``/blocks?tx_id={tx_id}&status={UNDECIDED|VALID|INVALID}``
    `endpoint <#get--blocks?tx_id=tx_id&status=UNDECIDED|VALID|INVALID>`_.
 
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -334,75 +334,13 @@ Blocks
 
    **Example request**:
 
-   .. sourcecode:: http
-
-      GET /blocks?tx_id=2d431...0b4b0e HTTP/1.1
-      Host: example.com
+   .. literalinclude:: samples/get-block-txid-request.http
+      :language: http
 
    **Example response**:
 
-   .. sourcecode:: http
-
-      HTTP/1.1 200 OK
-      Content-Type: application/json
-
-      {
-        "block":{
-          "node_pubkey":"ErEeVZt8AfLbMJub25tjNxbpzzTNp3mGidL3GxGdd9bt",
-            "timestamp":"1479389911",
-            "transactions":[
-              {
-                "transaction": {
-                  "conditions": [
-                    {
-                      "cid": 0,
-                      "condition": {
-                        "uri": "cc:4:20:GG-pi3CeIlySZhQoJVBh9O23PzrOuhnYI7OHqIbHjkk:96",
-                        "details": {
-                          "signature": null,
-                          "type": "fulfillment",
-                          "type_id": 4,
-                          "bitmask": 32,
-                          "public_key": "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
-                        }
-                      },
-                      "amount": 1,
-                      "owners_after": [
-                        "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
-                      ]
-                    }
-                  ],
-                  "operation": "CREATE",
-                  "asset": {
-                    "divisible": false,
-                    "updatable": false,
-                    "data": null,
-                    "id": "aebeab22-e672-4d3b-a187-bde5fda6533d",
-                    "refillable": false
-                  },
-                  "metadata": null,
-                  "timestamp": "1477578978",
-                  "fulfillments": [
-                    {
-                      "fid": 0,
-                      "input": null,
-                      "fulfillment": "cf:4:GG-pi3CeIlySZhQoJVBh9O23PzrOuhnYI7OHqIbHjkn2VnQaEWvecO1x82Qr2Va_JjFywLKIOEV1Ob9Ofkeln2K89ny2mB-s7RLNvYAVzWNiQnp18_nQEUsvwACEXTYJ",
-                      "owners_before": [
-                        "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
-                      ]
-                    }
-                  ]
-                },
-                "id": "2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e",
-                "version": 1
-              }],
-            "voters":[
-              "ErEeVZt8AfLbMJub25tjNxbpzzTNp3mGidL3GxGdd9bt"
-            ]
-        },
-        "id":"6152fbc7e0f7686512ed6b92c01e8c73ea1e3f51a7b037ac5cc8c860215e7202",
-        "signature":"53wxrEQDYk1dXzmvNSytbCfmNVnPqPkDQaTnAe8Jf43s6ssejPxezkCvUnGTnduNUmaLjhaan1iRLi3peu6s5DzA"
-      }
+   .. literalinclude:: samples/get-block-txid-response.http
+      :language: http
 
    :resheader Content-Type: ``application/json``
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -44,6 +44,11 @@ Transactions
    This endpoint returns only a transaction from a ``VALID`` or ``UNDECIDED``
    block on ``bigchain``, if exists.
 
+   A transaction itself doesn't include a ``timestamp`` property. Only the
+   block a transaction was included in has a unix ``timestamp`` property. It is
+   returned by this endpoint in a HTTP custom entity header called
+   ``X-BigchainDB-Timestamp``.
+
    :param tx_id: transaction ID
    :type tx_id: hex string
 
@@ -60,6 +65,7 @@ Transactions
 
       HTTP/1.1 200 OK
       Content-Type: application/json
+      X-BigchainDB-Timestamp: 1234567890
 
       {
         "transaction": {
@@ -107,6 +113,7 @@ Transactions
         "version": 1
       }
 
+   :resheader X-BigchainDB-Timestamp: A unix timestamp describing when a transaction was included into a valid block. The timestamp provided is taken from the block the transaction was included in.
    :resheader Content-Type: ``application/json``
 
    :statuscode 200: A transaction with that ID was found.

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -111,8 +111,7 @@ Transactions
 
       {
         "_links": {
-          "asset_history": { "href": "https://example.com:9984/api/v0.9/transactions?operation={GENESIS|CREATE|TRANSFER}&asset_id={asset_id}" },
-          "asset_list": { "href": "https://example.com:9984/api/v0.9/transactions?operation=CREATE&is_asset=true&public_keys={public_keys}" },
+          "assets": { "href": "https://example.com:9984/api/v0.9/transactions?operation={GENESIS|CREATE|TRANSFER}&asset_id={asset_id}" },
           "docs": { "href": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html" },
           "item": { "href": "https://example.com:9984/api/v0.9/transactions/{tx_id}" },
           "self": { "href": "https://example.com:9984/api/v0.9/transactions" },
@@ -129,7 +128,6 @@ Transactions
 
    * `Unfulfilled outputs <#get--transactions?fulfilled=false&public_keys=public_keys>`_
    * `Transactions related to a specific asset <#get--transactions?operation=GENESIS|CREATE|TRANSFER&asset_id=asset_id>`_
-   * `Listing of assets <#get--transactions?operation=CREATE&is_asset=true&public_keys=public_keys>`_
 
    In this section, we've listed those particular requests, as they will likely
    to be very handy when implementing your application on top of BigchainDB.
@@ -142,8 +140,6 @@ Transactions
    A generalization of those parameters follows:
 
    :query boolean fulfilled: A flag to indicate if transactions with fulfilled conditions should be returned.
-
-   :query boolean is_asset: A flag to indicate if the ``asset`` field of the transaction is ``null`` or not.
 
    :query string public_keys: Public key able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
 
@@ -221,37 +217,6 @@ Transactions
    :statuscode 200: A list of transactions containing an asset with ID ``asset_id`` was found and returned.
    :statuscode 400: The request wasn't understood by the server, e.g. the ``asset_id`` querystring was not included in the request.
 
-.. http:get:: /transactions?operation=CREATE&is_asset=true&public_keys={public_keys}
-
-   Get a list of ``CREATE`` transactions that have the asset field defined.
-   This can serve as a recipe for retrieving your list of assets.
-   Currently, filtering on specific fields in the ``asset`` or ``metadata`` is assumed to be done clientside.
-
-   This endpoint returns assets only if the transaction they're in are
-   included in the ``BACKLOG`` or in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
-
-   :query string operation: One of the three supported operations of a transaction: ``GENESIS``, ``CREATE``, ``TRANSFER``.
-
-   :query boolean is_asset: A flag to indicate if the ``asset`` field of the transaction is ``null`` or not.
-
-   :query string public_keys: Public key able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
-
-
-   **Example request**:
-
-   .. literalinclude:: samples/get-assets-request.http
-      :language: http
-
-   **Example response**:
-
-   .. literalinclude:: samples/get-assets-response.http
-      :language: http
-
-
-   :resheader Content-Type: ``application/json``
-
-   :statuscode 200: A list of transactions containing an asset and ``public_keys`` found and returned.
-   :statuscode 400: The request wasn't understood by the server, e.g. the ``is_asset`` querystring was not included in the request.
 
 .. http:post:: /transactions
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -7,11 +7,6 @@ The HTTP Client-Server API
    there is no ability to do complex queries using the HTTP API. We plan to add
    more querying capabilities in the future.
 
-This page assumes you already know an API Root URL
-for a BigchainDB node or reverse proxy.
-It should be something like ``http://apihosting4u.net:9984``
-or ``http://12.34.56.78:9984``.
-
 If you set up a BigchainDB node or reverse proxy yourself,
 and you're not sure what the API Root URL is,
 then see the last section of this page for help.

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -67,7 +67,7 @@ Transactions
 
    Get the transaction with the ID ``tx_id``.
 
-   This endpoint returns only a transaction from a ``VALID`` or ``UNDECIDED``
+   This endpoint returns only a transaction from the ``BACKLOG`` or a ``VALID`` or ``UNDECIDED``
    block on ``bigchain``, if exists.
 
    A transaction itself doesn't include a ``timestamp`` property. Only the
@@ -142,7 +142,7 @@ Transactions
    an empty list.
 
    This endpoint returns conditions only if the transaction they're in are
-   included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
+   included in the ``BACKLOG`` or in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
 
    :query boolean fulfilled: A flag to indicate if transactions with fulfilled conditions should be returned.
 
@@ -170,7 +170,7 @@ Transactions
    Get a list of transactions that use an asset with the ID ``asset_id``.
 
    This endpoint returns assets only if the transaction they're in are
-   included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
+   included in the ``BACKLOG`` or in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
 
    .. note::
        The BigchainDB API currently doesn't expose an
@@ -209,7 +209,7 @@ Transactions
    Currently, filtering on specific fields in the ``asset`` or ``metadata`` is assumed to be done clientside.
 
    This endpoint returns assets only if the transaction they're in are
-   included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
+   included in the ``BACKLOG`` or in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
 
    :query string operation: One of the three supported operations of a transaction: ``GENESIS``, ``CREATE``, ``TRANSFER``.
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -25,7 +25,7 @@ with something like the following in the body:
 
     {
       "_links": {
-        "docs": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/"
+        "docs": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/",
         "api_v1": "http://example.com:9984/api/v1/"
       },
       "keyring": [

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -111,7 +111,7 @@ Transactions
 
       {
         "_links": {
-          "assets": { "href": "https://example.com:9984/api/v0.9/transactions?operation={GENESIS|CREATE|TRANSFER}&asset_id={asset_id}" },
+          "assets": { "href": "https://example.com:9984/api/v0.9/transactions?operation={CREATE|TRANSFER}&asset_id={asset_id}" },
           "docs": { "href": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html" },
           "item": { "href": "https://example.com:9984/api/v0.9/transactions/{tx_id}" },
           "self": { "href": "https://example.com:9984/api/v0.9/transactions" },
@@ -127,7 +127,7 @@ Transactions
    that include:
 
    * `Unspent outputs <#get--transactions?unspent=true&public_keys=public_keys>`_
-   * `Transactions related to a specific asset <#get--transactions?operation=GENESIS|CREATE|TRANSFER&asset_id=asset_id>`_
+   * `Transactions related to a specific asset <#get--transactions?operation=CREATE|TRANSFER&asset_id=asset_id>`_
 
    In this section, we've listed those particular requests, as they will likely
    to be very handy when implementing your application on top of BigchainDB.
@@ -143,7 +143,7 @@ Transactions
 
    :query string public_keys: Public key able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
 
-   :query string operation: One of the three supported operations of a transaction: ``GENESIS``, ``CREATE``, ``TRANSFER``.
+   :query string operation: One of the two supported operations of a transaction: ``CREATE``, ``TRANSFER``.
 
    :query string asset_id: asset ID.
 
@@ -181,7 +181,7 @@ Transactions
    :statuscode 200: A list of transactions containing unspent outputs was found and returned.
    :statuscode 400: The request wasn't understood by the server, e.g. the ``public_keys`` querystring was not included in the request.
 
-.. http:get:: /transactions?operation={GENESIS|CREATE|TRANSFER}&asset_id={asset_id}
+.. http:get:: /transactions?operation={CREATE|TRANSFER}&asset_id={asset_id}
 
    Get a list of transactions that use an asset with the ID ``asset_id``.
 
@@ -199,7 +199,7 @@ Transactions
        any case only be one transaction returned (in a list though, since
        ``/transactions`` is a list-returning endpoint).
 
-   :query string operation: One of the three supported operations of a transaction: ``GENESIS``, ``CREATE``, ``TRANSFER``.
+   :query string operation: One of the two supported operations of a transaction: ``CREATE``, ``TRANSFER``.
 
    :query string asset_id: asset ID.
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -268,8 +268,8 @@ Statuses
    ``invalid``.
 
    If a transaction or block is persisted to the chain and it's status is set
-   to ``valid`` or ``undecided``, a ``303 See Other`` status code is returned,
-   as well as an URL to the resource in the location header.
+   to ``valid`` or ``undecided``, a ``200`` status code is returned,
+   as well as an URL to the resource.
 
    :param tx_id: transaction ID
    :type tx_id: hex string
@@ -295,8 +295,7 @@ Statuses
    :resheader Content-Type: ``application/json``
    :resheader Location: Once the transaction has been persisted, this header will link to the actual resource.
 
-   :statuscode 200: A transaction or block with that ID was found. The status is either ``backlog``, ``invalid``.
-   :statuscode 303: A transaction or block with that ID was found and persisted to the chain. A location header to the resource is provided.
+   :statuscode 200: A transaction or block with that ID was found.
    :statuscode 404: A transaction or block with that ID was not found.
 
 Blocks

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -90,9 +90,7 @@ Transactions
 .. http:get:: /transactions
 
    The unfiltered ``/transactions`` endpoint without any query parameters
-   returns a list of available transaction usages and relevant endpoints.
-   We believe a PUSH rather than a PULL pattern is more appropriate, as the
-   items returned in the collection would change by the second.
+   returns a status code `400`. For valid filters, see the sections below.
 
    **Example request**:
 
@@ -105,21 +103,9 @@ Transactions
 
    .. sourcecode:: http
 
-      HTTP/1.1 200 OK
-      Content-Type: application/json
+      HTTP/1.1 400 Bad Request
 
-      {
-        "_links": {
-          "assets": "https://example.com:9984/api/v1/transactions?operation={CREATE|TRANSFER}&asset_id={asset_id}",
-          "docs": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html",
-          "item": "https://example.com:9984/api/v1/transactions/{tx_id}",
-          "self": "https://example.com:9984/api/v1/transactions",
-          "unspent": "https://example.com:9984/api/v1/transactions?unspent=true&public_keys={public_keys}"
-        },
-        "version" : "0.9.0"
-      }
-
-   :statuscode 200: BigchainDB transactions root endpoint.
+   :statuscode 400: The request wasn't understood by the server, a mandatory querystring was not included in the request.
 
    There are however filtered requests that might come of use, given the endpoint is
    queried correctly. Some of them include retrieving a list of transactions

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -106,7 +106,8 @@ Transactions
    that include:
 
    * `Unfulfilled outputs <#get--transactions?fulfilled=false&public_keys=public_keys>`_
-   * `Transactions related to a specific asset <#get--transactions?operation=CREATE|TRANSFER&asset_id=asset_id>`_
+   * `Transactions related to a specific asset <#get--transactions?operation=GENESIS|CREATE|TRANSFER&asset_id=asset_id>`_
+   * `Listing of assets <#get--transactions?operation=CREATE&is_asset=true&public_keys=public_keys>`_
 
    In this section, we've listed those particular requests, as they will likely
    to be very handy when implementing your application on top of BigchainDB.
@@ -120,11 +121,14 @@ Transactions
 
    :query boolean fulfilled: A flag to indicate if transactions with fulfilled conditions should be returned.
 
+   :query boolean is_asset: A flag to indicate if the ``asset`` field of the transaction is ``null`` or not.
+
    :query string public_keys: Public key able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
 
    :query string operation: One of the three supported operations of a transaction: ``GENESIS``, ``CREATE``, ``TRANSFER``.
 
    :query string asset_id: asset ID.
+
 
    :statuscode 404: BigchainDB does not expose this endpoint.
 
@@ -198,6 +202,37 @@ Transactions
    :statuscode 200: A list of transactions containing an asset with ID ``asset_id`` was found and returned.
    :statuscode 400: The request wasn't understood by the server, e.g. the ``asset_id`` querystring was not included in the request.
 
+.. http:get:: /transactions?operation=CREATE&is_asset=true&public_keys={public_keys}
+
+   Get a list of ``CREATE`` transactions that have the asset field defined.
+   This can serve as a recipe for retrieving your list of assets.
+   Currently, filtering on specific fields in the ``asset`` or ``metadata`` is assumed to be done clientside.
+
+   This endpoint returns assets only if the transaction they're in are
+   included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
+
+   :query string operation: One of the three supported operations of a transaction: ``GENESIS``, ``CREATE``, ``TRANSFER``.
+
+   :query boolean is_asset: A flag to indicate if the ``asset`` field of the transaction is ``null`` or not.
+
+   :query string public_keys: Public key able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
+
+
+   **Example request**:
+
+   .. literalinclude:: samples/get-assets-request.http
+      :language: http
+
+   **Example response**:
+
+   .. literalinclude:: samples/get-assets-response.http
+      :language: http
+
+
+   :resheader Content-Type: ``application/json``
+
+   :statuscode 200: A list of transactions containing an asset and ``public_keys`` found and returned.
+   :statuscode 400: The request wasn't understood by the server, e.g. the ``is_asset`` querystring was not included in the request.
 
 .. http:post:: /transactions
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -41,8 +41,8 @@ API Root Endpoint
 -------------------
 
 If you send an HTTP GET request to the API Root Endpoint
-e.g. ``http://localhost:9984/api/v0.9/``
-or ``https://example.com:9984/api/v0.9/``,
+e.g. ``http://localhost:9984/api/v1/``
+or ``https://example.com:9984/api/v1/``,
 then you should get an HTTP response
 that allows you to discover the BigchainDB API endpoints:
 
@@ -50,12 +50,12 @@ that allows you to discover the BigchainDB API endpoints:
 
     {
       "_links": {
-        "blocks": { "href": "https://example.com:9984/api/v0.9/blocks" },
+        "blocks": { "href": "https://example.com:9984/api/v1/blocks" },
         "docs": { "href": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html" },
-        "self": { "href": "https://example.com:9984/api/v0.9" },
-        "statuses": { "href": "https://example.com:9984/api/v0.9/statuses" },
-        "transactions": { "href": "https://example.com:9984/api/v0.9/transactions" },
-        "votes": { "href": "https://example.com:9984/api/v0.9/votes" }
+        "self": { "href": "https://example.com:9984/api/v1" },
+        "statuses": { "href": "https://example.com:9984/api/v1/statuses" },
+        "transactions": { "href": "https://example.com:9984/api/v1/transactions" },
+        "votes": { "href": "https://example.com:9984/api/v1/votes" }
       },
       "version" : "0.9.0"
     }
@@ -111,11 +111,11 @@ Transactions
 
       {
         "_links": {
-          "assets": { "href": "https://example.com:9984/api/v0.9/transactions?operation={CREATE|TRANSFER}&asset_id={asset_id}" },
+          "assets": { "href": "https://example.com:9984/api/v1/transactions?operation={CREATE|TRANSFER}&asset_id={asset_id}" },
           "docs": { "href": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html" },
-          "item": { "href": "https://example.com:9984/api/v0.9/transactions/{tx_id}" },
-          "self": { "href": "https://example.com:9984/api/v0.9/transactions" },
-          "unspent": { "href": "https://example.com:9984/api/v0.9/transactions?unspent=true&public_keys={public_keys}" }
+          "item": { "href": "https://example.com:9984/api/v1/transactions/{tx_id}" },
+          "self": { "href": "https://example.com:9984/api/v1/transactions" },
+          "unspent": { "href": "https://example.com:9984/api/v1/transactions?unspent=true&public_keys={public_keys}" }
         },
         "version" : "0.9.0"
       }
@@ -362,10 +362,10 @@ Blocks
 
       {
         "_links": {
-          "blocks": { "href": "https://example.com:9984/api/v0.9/blocks?tx_id={tx_id}&status={VALID|UNDECIDED|INVALID}" },
+          "blocks": { "href": "https://example.com:9984/api/v1/blocks?tx_id={tx_id}&status={VALID|UNDECIDED|INVALID}" },
           "docs": { "href": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html" },
-          "item": { "href": "https://example.com:9984/api/v0.9/blocks/{block_id}?status={VALID|UNDECIDED|INVALID}" },
-          "self": { "href": "https://example.com:9984/api/v0.9/blocks" }
+          "item": { "href": "https://example.com:9984/api/v1/blocks/{block_id}?status={VALID|UNDECIDED|INVALID}" },
+          "self": { "href": "https://example.com:9984/api/v1/blocks" }
         },
         "version" : "0.9.0"
       }
@@ -441,7 +441,7 @@ Determining the API Root URL
 When you start BigchainDB Server using ``bigchaindb start``,
 an HTTP API is exposed at some address. The default is:
 
-`http://localhost:9984/api/v0.9/ <http://localhost:9984/api/v0.9/>`_
+`http://localhost:9984/api/v1/ <http://localhost:9984/api/v1/>`_
 
 It's bound to ``localhost``,
 so you can access it from the same machine,

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -74,7 +74,7 @@ Transactions
    queried correctly. Some of them include retrieving a list of transactions
    that include:
 
-   * `Transactions related to a specific asset <#get--transactions?operation=CREATE|TRANSFER&asset_id=asset_id>`_
+   * `Transactions related to a specific asset <#get--transactions?asset_id=asset_id&operation=CREATE|TRANSFER>`_
 
    In this section, we've listed those particular requests, as they will likely
    to be very handy when implementing your application on top of BigchainDB.
@@ -85,11 +85,11 @@ Transactions
 
    A generalization of those parameters follows:
 
-   :query string operation: One of the two supported operations of a transaction: ``CREATE``, ``TRANSFER``.
-
    :query string asset_id: The ID of the asset.
 
-.. http:get:: /api/v1/transactions?operation={CREATE|TRANSFER}&asset_id={asset_id}
+   :query string operation: (Optional) One of the two supported operations of a transaction: ``CREATE``, ``TRANSFER``.
+
+.. http:get:: /api/v1/transactions?asset_id={asset_id}&operation={CREATE|TRANSFER}
 
    Get a list of transactions that use an asset with the ID ``asset_id``.
    Every ``TRANSFER`` transaction that originates from a ``CREATE`` transaction
@@ -98,7 +98,7 @@ Transactions
 
    This endpoint returns transactions only if they are decided ``VALID`` by the server.
 
-   :query string operation: One of the two supported operations of a transaction: ``CREATE``, ``TRANSFER``.
+   :query string operation: (Optional) One of the two supported operations of a transaction: ``CREATE``, ``TRANSFER``.
 
    :query string asset_id: asset ID.
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -130,7 +130,7 @@ Transactions
    :resheader Content-Type: ``application/json``
 
    :statuscode 200: A list of transaction's containing unfulfilled conditions was found and returned.
-   :statuscode 400: The request wasn't understood by the server, e.g. the ``owners_after`` querystring was not included in the request.
+   :statuscode 400: The request wasn't understood by the server, e.g. the ``public_keys`` querystring was not included in the request.
 
 .. http:get:: /transactions?operation={GENESIS|CREATE|TRANSFER}&asset_id={asset_id}
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -156,63 +156,13 @@ Transactions
 
    **Example request**:
 
-   .. sourcecode:: http
-
-      GET /transactions?operation=CREATE&asset_id=1AAAbbb...ccc HTTP/1.1
-      Host: example.com
+   .. literalinclude:: samples/get-tx-by-asset-request.http
+      :language: http
 
    **Example response**:
 
-   .. sourcecode:: http
-
-      HTTP/1.1 200 OK
-      Content-Type: application/json
-
-      [{
-        "transaction": {
-          "conditions": [
-            {
-              "cid": 0,
-              "condition": {
-                "uri": "cc:4:20:GG-pi3CeIlySZhQoJVBh9O23PzrOuhnYI7OHqIbHjkk:96",
-                "details": {
-                  "signature": null,
-                  "type": "fulfillment",
-                  "type_id": 4,
-                  "bitmask": 32,
-                  "public_key": "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
-                }
-              },
-              "amount": 1,
-              "owners_after": [
-                "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
-              ]
-            }
-          ],
-          "operation": "CREATE",
-          "asset": {
-            "divisible": false,
-            "updatable": false,
-            "data": null,
-            "id": "1AAAbbb...ccc",
-            "refillable": false
-          },
-          "metadata": null,
-          "timestamp": "1477578978",
-          "fulfillments": [
-            {
-              "fid": 0,
-              "input": null,
-              "fulfillment": "cf:4:GG-pi3CeIlySZhQoJVBh9O23PzrOuhnYI7OHqIbHjkn2VnQaEWvecO1x82Qr2Va_JjFywLKIOEV1Ob9Ofkeln2K89ny2mB-s7RLNvYAVzWNiQnp18_nQEUsvwACEXTYJ",
-              "owners_before": [
-                "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
-              ]
-            }
-          ]
-        },
-        "id": "2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e",
-        "version": 1
-      }]
+   .. literalinclude:: samples/get-tx-by-asset-response.http
+      :language: http
 
    :resheader Content-Type: ``application/json``
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -128,7 +128,7 @@ Transactions
    queried correctly. Some of them include retrieving a list of transactions
    that include:
 
-   * `Unfulfilled conditions <#get--transactions?fields=id,conditions&fulfilled=false&owner_afters=owners_after>`_
+   * `Unfulfilled conditions <#get--transactions?fields=id,conditions&fulfilled=false&owners_after=owners_after>`_
    * `A specific asset <#get--transactions?fields=id,asset,operation&operation=CREATE|TRANSFER&asset_id=asset_id>`_
    * `Specific metadata <#get--transactions?fields=id,metadata&metadata_id=metadata_id>`_
 
@@ -136,28 +136,22 @@ Transactions
    to be very handy when implementing your application on top of BigchainDB.
    A generalization of those parameters can follows:
 
-   :query fields: A comma separated string to expand properties on the transaction object to be returned.
-   :type fields: string
+   :query string fields: Comma separated list, allowed values are: ``asset``, ``conditions``, ``fulfillments``, ``id``, ``metadata``, ``operation``, ``owners_after``, ``version``.
 
-   :query fulfilled: A flag to indicate if transaction's with fulfilled conditions should be returned.
-   :type fulfilled: boolean
+   :query boolean fulfilled: A flag to indicate if transaction's with fulfilled conditions should be returned.
 
-   :query owners_after: Public keys able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
-   :type owners_after: base58 encoded string
+   :query string owners_after: Public key able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
 
-   :query operation: One of the three supported operations of a transaction.
-   :type operation: string
+   :query string operation: One of the three supported operations of a transaction: ``GENESIS``, ``CREATE``, ``TRANSFER``.
 
-   :query asset_id: asset ID.
-   :type asset_id: uuidv4
+   :query string asset_id: asset ID.
 
-   :query metadata_id: metadata ID.
-   :type metadata_id: uuidv4
+   :query string metadata_id: metadata ID.
 
    :statuscode 404: BigchainDB does not expose this endpoint.
 
 
-.. http:get:: /transactions?fields=id,conditions&fulfilled=false&owner_afters={owners_after}
+.. http:get:: /transactions?fields=id,conditions&fulfilled=false&owners_after={owners_after}
 
    Get a list of transactions with unfulfilled conditions.
 
@@ -168,14 +162,11 @@ Transactions
    This endpoint returns conditions only if the transaction they're in are
    included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
 
-   :query fields: A comma separated string to expand properties on the transaction object to be returned.
-   :type fields: string
+   :query string fields: A comma separated string to expand properties on the transaction object to be returned.
 
-   :query fulfilled: A flag to indicate if transaction's with fulfilled conditions should be returned.
-   :type fulfilled: boolean
+   :query boolean fulfilled: A flag to indicate if transaction's with fulfilled conditions should be returned.
 
-   :query owners_after: Public keys able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
-   :type owners_after: base58 encoded string
+   :query string owners_after: Public key able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
 
    **Example request**:
 
@@ -227,14 +218,11 @@ Transactions
    This endpoint returns assets only if the transaction they're in are
    included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
 
-   :query fields: A comma separated string to expand properties on the transaction object to be returned.
-   :type fields: string
+   :query string fields: A comma separated string to expand properties on the transaction object to be returned.
 
-   :query operation: One of the three supported operations of a transaction (``GENESIS``, ``CREATE``, ``TRANSFER``).
-   :type operation: string
+   :query string operation: One of the three supported operations of a transaction: ``GENESIS``, ``CREATE``, ``TRANSFER``.
 
-   :query asset_id: asset ID.
-   :type asset_id: uuidv4
+   :query string asset_id: asset ID.
 
    **Example request**:
 
@@ -275,11 +263,9 @@ Transactions
    This endpoint returns assets only if the transaction they're in are
    included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
 
-   :query fields: A comma separated string to expand properties on the transaction object to be returned.
-   :type fields: string
+   :query string fields: A comma separated string to expand properties on the transaction object to be returned.
 
-   :query metadata_id: metadata ID.
-   :type metadata_id: uuidv4
+   :query string metadata_id: metadata ID.
 
    **Example request**:
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -248,14 +248,12 @@ Statuses
 
    Supports the retrieval of a status for a transaction using ``tx_id`` or the
    retrieval of a status for a block using ``block_id``. Only use exactly one of both
-   queries, as they are required but mutually exclusive.
+   queries, as they are required but mutually exclusive. A URL to the resource is also
+   provided under ``_links``.
 
-   The possible status values are ``backlog``, ``undecided``, ``valid`` or
-   ``invalid``.
-
-   If a transaction or block is persisted to the chain and it's status is set
-   to ``valid`` or ``undecided``, a ``200`` status code is returned,
-   as well as an URL to the resource.
+   The possible status values are ``undecided``, ``valid`` or
+   ``invalid`` for both blocks and transactions. An additional state ``backlog`` is provided
+   for transactions.
 
    :param tx_id: transaction ID
    :type tx_id: hex string

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -1,11 +1,10 @@
 The HTTP Client-Server API
 ==========================
 
-.. note::
-
-   The HTTP client-server API is currently quite rudimentary. For example,
-   there is no ability to do complex queries using the HTTP API. We plan to add
-   more querying capabilities in the future.
+This page assumes you already know an API Root URL
+for a BigchainDB node or reverse proxy.
+It should be something like ``http://apihosting4u.net:9984``
+or ``http://12.34.56.78:9984``.
 
 If you set up a BigchainDB node or reverse proxy yourself,
 and you're not sure what the API Root URL is,
@@ -119,7 +118,7 @@ Transactions
 
    A generalization of those parameters follows:
 
-   :query boolean fulfilled: A flag to indicate if transaction's with fulfilled conditions should be returned.
+   :query boolean fulfilled: A flag to indicate if transactions with fulfilled conditions should be returned.
 
    :query string public_keys: Public key able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
 
@@ -141,7 +140,7 @@ Transactions
    This endpoint returns conditions only if the transaction they're in are
    included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
 
-   :query boolean fulfilled: A flag to indicate if transaction's with fulfilled conditions should be returned.
+   :query boolean fulfilled: A flag to indicate if transactions with fulfilled conditions should be returned.
 
    :query string public_keys: Public key able to validly spend an output of a transaction, assuming the user also has the corresponding private key.
 
@@ -159,7 +158,7 @@ Transactions
 
    :resheader Content-Type: ``application/json``
 
-   :statuscode 200: A list of transaction's containing unfulfilled conditions was found and returned.
+   :statuscode 200: A list of transactions containing unfulfilled conditions was found and returned.
    :statuscode 400: The request wasn't understood by the server, e.g. the ``public_keys`` querystring was not included in the request.
 
 .. http:get:: /transactions?operation={GENESIS|CREATE|TRANSFER}&asset_id={asset_id}
@@ -196,7 +195,7 @@ Transactions
 
    :resheader Content-Type: ``application/json``
 
-   :statuscode 200: A list of transaction's containing an asset with ID ``asset_id`` was found and returned.
+   :statuscode 200: A list of transactions containing an asset with ID ``asset_id`` was found and returned.
    :statuscode 400: The request wasn't understood by the server, e.g. the ``asset_id`` querystring was not included in the request.
 
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -3,8 +3,8 @@ The HTTP Client-Server API
 
 This page assumes you already know an API Root URL
 for a BigchainDB node or reverse proxy.
-It should be something like ``http://apihosting4u.net:9984``
-or ``http://12.34.56.78:9984``.
+It should be something like ``https://example.com:9984``
+or ``https://12.34.56.78:9984``.
 
 If you set up a BigchainDB node or reverse proxy yourself,
 and you're not sure what the API Root URL is,
@@ -14,11 +14,11 @@ then see the last section of this page for help.
 BigchainDB Root URL
 -------------------
 
-If you send an HTTP GET request to the API Root URL
-e.g. ``http://localhost:9984`` 
-or ``http://apihosting4u.net:9984``
-(with no ``/api/v1/`` on the end), 
-then you should get an HTTP response 
+If you send an HTTP GET request to the BigchainDB Root URL
+e.g. ``http://localhost:9984``
+or ``https://example.com:9984``
+(with no ``/api/v1/`` on the end),
+then you should get an HTTP response
 with something like the following in the body:
 
 .. code-block:: json
@@ -42,7 +42,7 @@ API Root Endpoint
 
 If you send an HTTP GET request to the API Root Endpoint
 e.g. ``http://localhost:9984/api/v0.9/``
-or ``http://apihosting4u.net:9984/api/v0.9/``,
+or ``https://example.com:9984/api/v0.9/``,
 then you should get an HTTP response
 that allows you to discover the BigchainDB API endpoints:
 
@@ -50,12 +50,12 @@ that allows you to discover the BigchainDB API endpoints:
 
     {
       "_links": {
-        "blocks": { "href": "/blocks" },
+        "blocks": { "href": "https://example.com:9984/api/v0.9/blocks" },
         "docs": { "href": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html" },
-        "self": { "href": "/" },
-        "statuses": { "href": "/statuses" },
-        "transactions": { "href": "/transactions" },
-        "votes": { "href": "/votes" }
+        "self": { "href": "https://example.com:9984/api/v0.9" },
+        "statuses": { "href": "https://example.com:9984/api/v0.9/statuses" },
+        "transactions": { "href": "https://example.com:9984/api/v0.9/transactions" },
+        "votes": { "href": "https://example.com:9984/api/v0.9/votes" }
       },
       "version" : "0.9.0"
     }
@@ -96,12 +96,40 @@ Transactions
 
 .. http:get:: /transactions
 
-   The current ``/transactions`` endpoint returns a ``404 Not Found`` HTTP
-   status code. Eventually, this functionality will get implemented.
+   The unfiltered ``/transactions`` endpoint without any query parameters
+   returns a list of available transaction usages and relevant endpoints.
    We believe a PUSH rather than a PULL pattern is more appropriate, as the
    items returned in the collection would change by the second.
 
-   There are however requests that might come of use, given the endpoint is
+   **Example request**:
+
+   .. sourcecode:: http
+
+      GET /transactions HTTP/1.1
+      Host: example.com
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "_links": {
+          "asset_history": { "href": "https://example.com:9984/api/v0.9/transactions?operation={GENESIS|CREATE|TRANSFER}&asset_id={asset_id}" },
+          "asset_list": { "href": "https://example.com:9984/api/v0.9/transactions?operation=CREATE&is_asset=true&public_keys={public_keys}" },
+          "docs": { "href": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html" },
+          "item": { "href": "https://example.com:9984/api/v0.9/transactions/{tx_id}" },
+          "self": { "href": "https://example.com:9984/api/v0.9/transactions" },
+          "unfulfilled": { "href": "https://example.com:9984/api/v0.9/transactions?fulfilled=false&public_keys={public_keys}" }
+        },
+        "version" : "0.9.0"
+      }
+
+   :statuscode 200: BigchainDB transactions root endpoint.
+
+   There are however filtered requests that might come of use, given the endpoint is
    queried correctly. Some of them include retrieving a list of transactions
    that include:
 
@@ -128,9 +156,6 @@ Transactions
    :query string operation: One of the three supported operations of a transaction: ``GENESIS``, ``CREATE``, ``TRANSFER``.
 
    :query string asset_id: asset ID.
-
-
-   :statuscode 404: BigchainDB does not expose this endpoint.
 
 
 .. http:get:: /transactions?fulfilled=false&public_keys={public_keys}
@@ -344,12 +369,37 @@ Blocks
 
 .. http:get:: /blocks
 
-   The current ``/blocks`` endpoint returns a ``404 Not Found`` HTTP status
-   code. Eventually, this functionality will get implemented.
+   The unfiltered ``/blocks`` endpoint without any query parameters
+   returns a list of available block usages and relevant endpoints.
    We believe a PUSH rather than a PULL pattern is more appropriate, as the
    items returned in the collection would change by the second.
 
-   :statuscode 404: BigchainDB does not expose this endpoint.
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+      GET /blocks HTTP/1.1
+      Host: example.com
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "_links": {
+          "blocks": { "href": "https://example.com:9984/api/v0.9/blocks?tx_id={tx_id}&status={VALID|UNDECIDED|INVALID}" },
+          "docs": { "href": "https://docs.bigchaindb.com/projects/server/en/v0.9.0/drivers-clients/http-client-server-api.html" },
+          "item": { "href": "https://example.com:9984/api/v0.9/blocks/{block_id}?status={VALID|UNDECIDED|INVALID}" },
+          "self": { "href": "https://example.com:9984/api/v0.9/blocks" }
+        },
+        "version" : "0.9.0"
+      }
+
+   :statuscode 200: BigchainDB blocks root endpoint.
 
 
 .. http:get:: /blocks?tx_id={tx_id}&status={VALID|UNDECIDED|INVALID}
@@ -440,8 +490,8 @@ then the public API Root URL is determined as follows:
   Gunicorn or the machine running the reverse proxy such as Nginx).
   It's determined by AWS, Azure, Rackspace, or whoever is hosting the machine.
 
-- The DNS hostname (like apihosting4u.net) is determined by DNS records,
-  such as an "A Record" associating apihosting4u.net with 12.34.56.78
+- The DNS hostname (like example.com) is determined by DNS records,
+  such as an "A Record" associating example.com with 12.34.56.78
 
 - The port (like 9984) is determined by the ``server.bind`` setting
   if Gunicorn is exposed directly to the public Internet.

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -45,8 +45,8 @@ Transactions
 
    Get the transaction with the ID ``tx_id``.
 
-   This endpoint returns only a transaction from the ``BACKLOG`` or a ``VALID`` or ``UNDECIDED``
-   block on ``bigchain``, if exists.
+   This endpoint returns a transaction only if a ``VALID`` block on
+   ``bigchain`` exists.
 
    :param tx_id: transaction ID
    :type tx_id: hex string
@@ -144,7 +144,7 @@ Transactions
 
    :resheader Content-Type: ``application/json``
 
-   :statuscode 200: The pushed transaction was accepted in the ``BACKLOG``, but the processing has not been completed.
+   :statuscode 202: The pushed transaction was accepted in the ``BACKLOG``, but the processing has not been completed.
    :statuscode 400: The transaction was malformed and not accepted in the ``BACKLOG``.
 
 
@@ -198,10 +198,6 @@ Statuses
 
    Get the status of an asynchronously written transaction or block by their id.
 
-   The possible status values are ``undecided``, ``valid`` or ``invalid`` for
-   both blocks and transactions. An additional state ``backlog`` is provided
-   for transactions.
-
    A link to the resource is also provided in the returned payload under
    ``_links``.
 
@@ -220,14 +216,13 @@ Statuses
 
     Get the status of a transaction.
 
+    The possible status values are ``undecided``, ``valid`` or ``backlog``.
+    If a transaction in neither of those states is found, a ``404 Not Found``
+    HTTP status code is returned. `We're currently looking into ways to unambigously let the user know about a transaction's status that was included in an invalid block. <https://github.com/bigchaindb/bigchaindb/issues/1039>`_
+
    **Example request**:
 
    .. literalinclude:: samples/get-statuses-tx-request.http
-      :language: http
-
-   **Example response**:
-
-   .. literalinclude:: samples/get-statuses-tx-invalid-response.http
       :language: http
 
    **Example response**:
@@ -245,6 +240,8 @@ Statuses
 .. http:get:: /api/v1/statuses?block_id={block_id}
 
     Get the status of a block.
+
+    The possible status values are ``undecided``, ``valid`` or ``invalid``.
 
    **Example request**:
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -79,13 +79,18 @@ Transactions
    queried correctly. Some of them include retrieving a list of transactions
    that include:
 
-   * `Unfulfilled conditions <#get--transactions?fulfilled=false&public_keys=public_keys>`_
-   * `A specific asset <#get--transactions?operation=CREATE|TRANSFER&asset_id=asset_id>`_
-   * `Specific metadata <#get--transactions?&metadata_id=metadata_id>`_
+   * `Unfulfilled outputs <#get--transactions?fulfilled=false&public_keys=public_keys>`_
+   * `Transactions related to a specific asset <#get--transactions?operation=CREATE|TRANSFER&asset_id=asset_id>`_
 
    In this section, we've listed those particular requests, as they will likely
    to be very handy when implementing your application on top of BigchainDB.
-   A generalization of those parameters can follows:
+
+   .. note::
+      Looking up transactions with a specific ``metadata`` field is currently not supported.
+      This functionality requires something like custom indexing per client or read-only followers,
+      which is not yet on the roadmap.
+
+   A generalization of those parameters follows:
 
    :query boolean fulfilled: A flag to indicate if transaction's with fulfilled conditions should be returned.
 
@@ -94,8 +99,6 @@ Transactions
    :query string operation: One of the three supported operations of a transaction: ``GENESIS``, ``CREATE``, ``TRANSFER``.
 
    :query string asset_id: asset ID.
-
-   :query string metadata_id: metadata ID.
 
    :statuscode 404: BigchainDB does not expose this endpoint.
 
@@ -169,95 +172,6 @@ Transactions
    :statuscode 200: A list of transaction's containing an asset with ID ``asset_id`` was found and returned.
    :statuscode 400: The request wasn't understood by the server, e.g. the ``asset_id`` querystring was not included in the request.
 
-.. http:get:: /transactions?metadata_id={metadata_id}
-
-   Get a list of transactions that use metadata with the ID ``metadata_id``.
-
-   This endpoint returns assets only if the transaction they're in are
-   included in a ``VALID`` or ``UNDECIDED`` block on ``bigchain``.
-
-   .. note::
-       The BigchainDB API currently doesn't expose an
-       ``/metadata/{metadata_id}`` endpoint, as there wouldn't be any way for a
-       client to verify that what was received is consistent with what was
-       persisted in the database.
-       However, BigchainDB's consensus ensures that any ``metadata_id`` is
-       a unique key identifying metadata, meaning that when calling
-       ``/transactions?metadata_id={metadata_id}``, there will in any case only
-       be one transaction returned (in a list though, since ``/transactions``
-       is a list-returning endpoint).
-
-   :query string metadata_id: metadata ID.
-
-   **Example request**:
-
-   .. sourcecode:: http
-
-      GET /transactions?metadata_id=1AAAbbb...ccc HTTP/1.1
-      Host: example.com
-
-   **Example response**:
-
-   .. sourcecode:: http
-
-      HTTP/1.1 200 OK
-      Content-Type: application/json
-
-      [{
-        "transaction": {
-          "conditions": [
-            {
-              "cid": 0,
-              "condition": {
-                "uri": "cc:4:20:GG-pi3CeIlySZhQoJVBh9O23PzrOuhnYI7OHqIbHjkk:96",
-                "details": {
-                  "signature": null,
-                  "type": "fulfillment",
-                  "type_id": 4,
-                  "bitmask": 32,
-                  "public_key": "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
-                }
-              },
-              "amount": 1,
-              "owners_after": [
-                "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
-              ]
-            }
-          ],
-          "operation": "CREATE",
-          "asset": {
-            "divisible": false,
-            "updatable": false,
-            "data": null,
-            "id": "aebeab22-e672-4d3b-a187-bde5fda6533d",
-            "refillable": false
-          },
-          "metadata": {
-            "id": "1AAAbbb...ccc",
-            "data": {
-              "hello": "world"
-            },
-          },
-          "timestamp": "1477578978",
-          "fulfillments": [
-            {
-              "fid": 0,
-              "input": null,
-              "fulfillment": "cf:4:GG-pi3CeIlySZhQoJVBh9O23PzrOuhnYI7OHqIbHjkn2VnQaEWvecO1x82Qr2Va_JjFywLKIOEV1Ob9Ofkeln2K89ny2mB-s7RLNvYAVzWNiQnp18_nQEUsvwACEXTYJ",
-              "owners_before": [
-                "2ePYHfV3yS3xTxF9EE3Xjo8zPwq2RmLPFAJGQqQKc3j6"
-              ]
-            }
-          ]
-        },
-        "id": "2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e",
-        "version": 1
-      }]
-
-   :resheader Content-Type: ``application/json``
-
-   :statuscode 200: A list of transaction's containing metadata with ID ``metadata_id`` was found and returned.
-   :statuscode 400: The request wasn't understood by the server, e.g. the ``metadata_id`` querystring was not included in the request.
 
 .. http:post:: /transactions
 


### PR DESCRIPTION
This morning @diminator and @sbellem had a discussion about the BigchainDB HTTP API.
From the discussion, the conclusion was drawn that in order to properly design the API, we should - instead of iteratively - a single document outlining the individual calls using HTTP as this methodology:

- provides a better overview of actual endpoints to be implemented; and
- allows us to plan and split tasks more efficiently.

Hence, for the rest of the day I hacked together a first draft of what the BigchainDB HTTP API could look like.

## How to review

When your reviewing, see this rather as a proposal. It's here to be discussed with everyone. Things can and will change.
A few things upfront though:

- All paths, responses, status codes, headers were assigned according to widely-accepted specifications and heuristics. Suggestions like: "I prefer X to be like schema Y" is therefore only acceptable as feedback if founded on a credible source (specification > blog posts  and so on - obviously!)
- Reasoning for changes is provided in the message section of the commits. Read them.
- The diff of the `.rst` file will very likely not give you a good overview of the changes. Pull the changes from this branch and render them in sphinx for reviewing/reading.

When merging this PR, we should have an HTTP API everyone is happy with :tada:.

## Higher-level decisions taken in this proposal

#### All endpoint names use the plural of the resource name

#### Countering "endpoint madness"

A very simple rule:
> Any entity that is retrievable with a unique key has its own top-level endpoint.

This only makes sense as REST mainly implements pathing after the following scheme:

- `/resource`: List endpoint
- `/resource?manipulator=X`: Filtered/manipulated list endpoint
- `/resource/id`: Single endpoint
- `/resource/id?manipulator=X` Filtered/manipulated single endpoint

Concretely, this means the following resources will have a top-level endpoint:

- blocks
- votes
- transactions
- statuses
- assets
- metadata

Keep in mind: Best practices advise strongly for a flat path hierarchy.

##### "But, Fulfillments and Conditions should have their own top-level endpoints!"

Theoretically they could. In fact, we could pretend that a condition's or fulfillment's unique key of retrieval is their URI. This would enable the following endpoints:

- `GET /conditions`
- `GET /conditions/uri`
- `GET /fulfillments`
- `GET /fulfillments/uri`

However, there has yet to be a use case found, where a HTTP API user would benefit from this. Hence in this proposal I thought about it, but didn't include it in the design.


#### ~Retrieval of specific fields in a resource~

~I followed [this very popular guide](http://www.vinaysahni.com/best-practices-for-a-pragmatic-restful-api):~

> ~Limiting which fields are returned by the API~
> ~The API consumer doesn't always need the full representation of a resource. The ability select and chose returned fields goes a long way in letting the API consumer minimize network traffic and speed up their own usage of the API.~
> ~Use a fields query parameter that takes a comma separated list of fields to include. For example, the following request would retrieve just enough information to display a sorted listing of open tickets:~
> ~GET /tickets?fields=id,subject,customer_name,updated_at~

## Changes made to the current HTTP API

#### `201 Created` for `POST /transactions` becomes `202 Accepted`

https://www.ietf.org/rfc/rfc2616.txt `10.2.2 201 Created` reads:

> The origin server MUST create the resource before returning the 201 status code.

Since a transaction is not created before the `POST` request returns, we cannot use status code 201 to respond to the request. However (same document) `10.2.3 202 Accepted` reads:

> The request has been accepted for processing, but the processing has not been completed.
> The entity returned with this response SHOULD include an indication of the request's current status and either a pointer to a status monitor or some estimate of when the user can expect the request to be fulfilled.

Using the HTTP `Location` header, we redirect the client to the status endpoint to ask for the status of the creation.

Once the resource has been created, we use HTTP code `303 See Other`, to notify the client about the updated resource and, using the  `Location` header, link back to the actual transaction `/transactions/txid`.

#### `/transaction/{txid}/status` becomes `/statuses`

1. [The plural of status is `statuses`](http://english.stackexchange.com/questions/877/what-is-the-plural-form-of-status)
2. `/transaction/{txid}/status` is not a RESTful path
3. Statuses do not only occur on transactions. In fact, a status is derived from a block, a transaction just inherits it from the block.

Therefore, an endpoint `/status` was introduced that allows to query any entity that is retrievable by a unique ID (block, transaction, asset, metadata, votes(not sure)).


## Things to be done

- [x] Get feedback
- [x] [Find solution to the `/unspents` endpoint-problem](https://github.com/bigchaindb/bigchaindb/pull/830#issuecomment-261502197)
- [x] Block retrieval by ID
- [x] Block retrieval by transaction
- [x] Asset retrieval by ID
- [x] Asset list retrieval
- [x] Asset history retrieval
- [x] ~Metadata retrieval by ID~
- [x] Include related context in statuses response (type, related resources)
- [x] ~Votes retrieval by ID **(use case missing)**~
- [x] Votes retrieval by Block ID
- [x] Outline how to retrieve the timestamp of the block containing the transaction
- [ ] Outline how to retrieve the timestamps of the votes for a certain block
- [x] Consider resolvement of #835 (remove `?fields` query strings)
- [x] Consider changes made in #856 (remove `metadata.id`)
- [x] ~Consider implementing `get_spent` functionality~
- [x] Consider timestamp removal made in #817
- [x] Consider resolving #906
- [x] Consider changes made in #925 (Inputs and Outputs)
- [x] Consider changes made in #945 (remove `owners_before`)
- [x] Consider changes made in #963 (rename `owners_after`)

## Things to better be discussed later

- Sorting (timestamps are influx right now)
- Pagination (easy to add later on)
- How this proposal relates to a [Interledger Common Web API](https://github.com/mDuo13/rfcs/blob/7a6a4b0723c347759c0366836c48c546efc9f268/0012-common-ledger-api/0012-common-ledger-api.md#common-ledger-api) (this is the BigchainDB™ API, lets separate concerns for now)
- Retrieval of full blocks vs hyperlinked versions [see comment](https://github.com/bigchaindb/bigchaindb/pull/830#issuecomment-269996902)
- Websockets: see issue #862 
- Client-defined queries and indices [see comment](https://github.com/bigchaindb/bigchaindb/pull/830#issuecomment-268258036)