### PR TITLE
Docs on the new ARM template for deploying on Azure

### DIFF
--- a/docs/server/source/cloud-deployment-starter-templates/index.rst
+++ b/docs/server/source/cloud-deployment-starter-templates/index.rst
@@ -12,4 +12,5 @@ If you find the cloud deployment starter templates for nodes helpful, then you m
 
    template-terraform-aws
    template-ansible
-   template-azure
+   new-azure-template
+   old-azure-template

--- a/docs/server/source/cloud-deployment-starter-templates/new-azure-template.md
+++ b/docs/server/source/cloud-deployment-starter-templates/new-azure-template.md
@@ -1,0 +1,57 @@
+# New Azure Template
+
+If you didn't read the introduction to the [cloud deployment starter templates](index.html), please do that now. The main point is that they're not for deploying a production node; they can be used as a starting point.
+
+One can deploy a BigchainDB node on Azure using the template in the `bigchaindb-on-ubuntu` directory of Microsoft's `azure-quickstart-templates` repository on GitHub:
+
+1. Go to [the `bigchaindb-on-ubuntu` directory in that repository](https://github.com/Azure/azure-quickstart-templates/tree/master/bigchaindb-on-ubuntu).
+
+2. Click the button labelled **Deploy to Azure**.
+
+3. If you're not already logged in to Microsoft Azure, then you'll be prompted to login. If you don't have an account, then you'll have to create one.
+
+4. One you are logged in to the Microsoft Azure Portal, you should be taken to a form titled **BigchainDB**. There are some notes to help with filling in that form at the bottom of this page.
+
+5. Deployment takes a few minutes. You can follow the notifications by clicking the bell icon at the top of the screen. When done, you should see a notification saying "Deployment to resource group '[your resource group name]' was successful." The install script (`init.sh`) installed RethinkDB, configured it using the default RethinkDB config file, and ran it. It also used `pip` to install [the latest `bigchaindb` from PyPI](https://pypi.python.org/pypi/BigchainDB).
+
+6. Find out the public IP address of the virtual machine in the Azure Portal. Example: `40.69.87.250`
+
+7. ssh in to the virtual machine at that IP address, e.g. `ssh adminusername@40.69.87.250` (where `adminusername` should be replaced by the Admin Username you entered into the form, and `40.69.87.250` should be replaced by the IP address you found in the last step).
+
+8. You should be prompted for a password. Enter the Admin Password you entered into the form.
+
+9. Configure BigchainDB using the default BigchainDB settings: `bigchaindb -y configure`
+
+10. Run BigchainDB: `bigchaindb start`
+
+BigchainDB should now be running on the Azure VM.
+
+Remember to shut everything down when you're done (via the Azure Portal), because it generally costs money to run stuff on Azure.
+
+
+## Notes on the Blockchain Template Form Fields
+
+### BASICS
+
+**Resource group** - You can use an existing resource group (if you have one) or create a new one named whatever you like, but avoid using fancy characters in the name because Azure might have problems if you do.
+
+**Location** is the Microsoft Azure data center where you want the BigchainDB node to run. Pick one close to where you are located.
+
+### SETTINGS
+
+You can use whatever **Admin\_username** and **Admin\_password** you like (provided you don't get too fancy). It will complain if your password is too simple. You'll need these later to `ssh` into the virtual machine.
+
+**Dns\_label\_prefix** - Once your virtual machine is deployed, it will have a public IP address and a DNS name (hostname) something like `DNSprefix.northeurope.cloudapp.azure.com`. The `DNSprefix` will be whatever you enter into this field.
+
+**Virtual\_machine\_size** - This should be one of Azure's standard virtual machine sizes, such as `Standard_D1_v2`. There's a [list of virtual machine sizes in the Azure docs](https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-windows-sizes?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json).
+
+
+**\_artifacts Location** - Leave this alone.
+
+**\_artifacts Location Sas Token** - Leave this alone (blank).
+
+### TERMS AND CONDITIONS
+
+Read the terms and conditions. If you agree to them, then check the checkbox.
+
+Finally, click the button labelled **Purchase**. (Generally speaking, it costs money to run stuff on Azure.)

--- a/docs/server/source/cloud-deployment-starter-templates/new-azure-template.md
+++ b/docs/server/source/cloud-deployment-starter-templates/new-azure-template.md
@@ -10,21 +10,21 @@ One can deploy a BigchainDB node on Azure using the template in the `bigchaindb-
 
 3. If you're not already logged in to Microsoft Azure, then you'll be prompted to login. If you don't have an account, then you'll have to create one.
 
-4. One you are logged in to the Microsoft Azure Portal, you should be taken to a form titled **BigchainDB**. There are some notes to help with filling in that form at the bottom of this page.
+4. Once you are logged in to the Microsoft Azure Portal, you should be taken to a form titled **BigchainDB**. Some notes to help with filling in that form are available [below](new-azure-template.html#notes-on-the-blockchain-template-form-fields).
 
-5. Deployment takes a few minutes. You can follow the notifications by clicking the bell icon at the top of the screen. When done, you should see a notification saying "Deployment to resource group '[your resource group name]' was successful." The install script (`init.sh`) installed RethinkDB, configured it using the default RethinkDB config file, and ran it. It also used `pip` to install [the latest `bigchaindb` from PyPI](https://pypi.python.org/pypi/BigchainDB).
+5. Deployment takes a few minutes. You can follow the notifications by clicking the bell icon at the top of the screen. When done, you should see a notification saying "Deployment to resource group '[your resource group name]' was successful." The install script (`init.sh`) installed RethinkDB and ran it with default configs. It also used `pip` to install [the latest **bigchaindb** from PyPI](https://pypi.python.org/pypi/BigchainDB).
 
 6. Find out the public IP address of the virtual machine in the Azure Portal. Example: `40.69.87.250`
 
-7. ssh in to the virtual machine at that IP address, e.g. `ssh adminusername@40.69.87.250` (where `adminusername` should be replaced by the Admin Username you entered into the form, and `40.69.87.250` should be replaced by the IP address you found in the last step).
+7. ssh in to the virtual machine at that IP address, i.e. do `ssh <Admin_username>@<machine-ip>` where `<Admin_username>` is the admin username you entered into the form and `<machine-ip>` is the virtual machine IP address determined in the last step. Example: `ssh bcdbadmin@40.69.87.250`
 
-8. You should be prompted for a password. Enter the Admin Password you entered into the form.
+8. You should be prompted for a password. Give the `<Admin_password>` you entered into the form.
 
-9. Configure BigchainDB using the default BigchainDB settings: `bigchaindb -y configure`
+9. Configure BigchainDB Server using the default BigchainDB settings: `bigchaindb -y configure`
 
-10. Run BigchainDB: `bigchaindb start`
+10. Run BigchainDB Server: `bigchaindb start`
 
-BigchainDB should now be running on the Azure VM.
+BigchainDB Server should now be running on the Azure VM.
 
 Remember to shut everything down when you're done (via the Azure Portal), because it generally costs money to run stuff on Azure.
 
@@ -41,10 +41,9 @@ Remember to shut everything down when you're done (via the Azure Portal), becaus
 
 You can use whatever **Admin\_username** and **Admin\_password** you like (provided you don't get too fancy). It will complain if your password is too simple. You'll need these later to `ssh` into the virtual machine.
 
-**Dns\_label\_prefix** - Once your virtual machine is deployed, it will have a public IP address and a DNS name (hostname) something like `DNSprefix.northeurope.cloudapp.azure.com`. The `DNSprefix` will be whatever you enter into this field.
+**Dns\_label\_prefix** - Once your virtual machine is deployed, it will have a public IP address and a DNS name (hostname) something like `<DNSprefix>.northeurope.cloudapp.azure.com`. The `<DNSprefix>` will be whatever you enter into this field.
 
 **Virtual\_machine\_size** - This should be one of Azure's standard virtual machine sizes, such as `Standard_D1_v2`. There's a [list of virtual machine sizes in the Azure docs](https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-windows-sizes?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json).
-
 
 **\_artifacts Location** - Leave this alone.
 

--- a/docs/server/source/cloud-deployment-starter-templates/old-azure-template.md
+++ b/docs/server/source/cloud-deployment-starter-templates/old-azure-template.md
@@ -1,16 +1,20 @@
-# Template: Node Deployment on Azure
+# Old Azure Template
+
+**Note: As its name suggests, this is an old template for deploying a node on Azure. It will probably be removed eventually. We advise you use the [New Azure Template](new-azure-template.html) instead.**
+
+<hr>
 
 If you didn't read the introduction to the [cloud deployment starter templates](index.html), please do that now. The main point is that they're not for deploying a production node; they can be used as a starting point.
 
-One can deploy a BigchainDB node on Azure using the template in [Microsoft's azure-quickstart-templates repository on GitHub](https://github.com/Azure/azure-quickstart-templates):
+One can deploy a BigchainDB node on Azure using the template in the `blockchain` directory of Microsoft's `azure-quickstart-templates` repository on GitHub:
 
-1. Go to [the /blockchain subdirectory in that repository](https://github.com/Azure/azure-quickstart-templates/tree/master/blockchain).
+1. Go to [the `blockchain` directory in that repository](https://github.com/Azure/azure-quickstart-templates/tree/master/blockchain).
 
 2. Click the button labelled **Deploy to Azure**.
 
 3. If you're not already logged in to Microsoft Azure, then you'll be prompted to login. If you don't have an account, then you'll have to create one.
 
-4. One you are logged in to the Microsoft Azure Portal, you should be taken to a form titled **Blockchain Template**. Below there are some notes to help with filling in that form.
+4. One you are logged in to the Microsoft Azure Portal, you should be taken to a form titled **Blockchain Template**. There are some notes to help with filling in that form at the bottom of this page.
 
 5. Deployment takes a few minutes. You can follow the notifications by clicking the bell icon at the top of the screen. When done, you should see a notification saying "Deployment to resource group '[your resource group name]' was successful." The install script (`bigchaindb.sh`) installed RethinkDB, configured it using the default RethinkDB config file, and ran it. It also used pip to install [the latest `bigchaindb` from PyPI](https://pypi.python.org/pypi/BigchainDB).
 


### PR DESCRIPTION
We now have two ARM templates on the Azure Quickstart Templates repo so I added a new page to the docs to help users with the new one. (The old one is still there, for now.)

In the process of testing it, I discovered some issues with the new ARM template (and accompanying bash script). I fixed those issues and pushed the fixes to the Azure Quickstart Templates repo: see https://github.com/Azure/azure-quickstart-templates/pull/2785 

That PR (2785) should be merged before we merge this PR.