### PR TITLE
Removed hardcoded backlog_reassign_delay.

### DIFF
--- a/bigchaindb/__init__.py
+++ b/bigchaindb/__init__.py
@@ -30,7 +30,7 @@ config = {
         'rate': 0.01,
     },
     'api_endpoint': os.environ.get('BIGCHAINDB_API_ENDPOINT') or 'http://localhost:9984/api/v1',
-    'backlog_reassign_delay': 30
+    'backlog_reassign_delay': 120
 }
 
 # We need to maintain a backup copy of the original config dict in case

--- a/bigchaindb/pipelines/stale.py
+++ b/bigchaindb/pipelines/stale.py
@@ -67,7 +67,7 @@ def create_pipeline(timeout=5, backlog_reassign_delay=5):
     return monitor_pipeline
 
 
-def start(timeout=5, backlog_reassign_delay=5):
+def start(timeout=5, backlog_reassign_delay=None):
     """Create, start, and return the block pipeline."""
     pipeline = create_pipeline(timeout=timeout,
                                backlog_reassign_delay=backlog_reassign_delay)


### PR DESCRIPTION
The stale monitor pipeline was harcoding the `backlog_reassign_delay` to 5 seconds instead of using the value provided in the config file.