### PR TITLE
refactor database calls out of block

### DIFF
--- a/bigchaindb/db/backends/rethinkdb.py
+++ b/bigchaindb/db/backends/rethinkdb.py
@@ -90,7 +90,7 @@ class RethinkDBBackend:
                 r.table('backlog')
                 .filter(lambda tx: time() - tx['assignment_timestamp'] > reassign_delay))
 
-    def get_old_transactions(self, node):
+    def get_old_transactions(self, node_pubkey):
         """Returns the oldest transactions.
 
         Old transactions are not necessarily stale transactions.  If a node
@@ -98,15 +98,15 @@ class RethinkDBBackend:
         to find transactions that were previously assigned to it.
 
         Args:
-            node (str): public key of node
+            node_pubkey (str): public key of node
 
         Returns:
             A cursor of transactions.
         """
         return self.connection.run(
             r.table('backlog')
-            .between([node, r.minval],
-                     [node, r.maxval],
+            .between([node_pubkey, r.minval],
+                     [node_pubkey, r.maxval],
                      index='assignee__transaction_timestamp')
             .order_by(index=r.asc('assignee__transaction_timestamp')))
 

--- a/bigchaindb/db/backends/rethinkdb.py
+++ b/bigchaindb/db/backends/rethinkdb.py
@@ -90,6 +90,26 @@ class RethinkDBBackend:
                 r.table('backlog')
                 .filter(lambda tx: time() - tx['assignment_timestamp'] > reassign_delay))
 
+    def get_old_transactions(self, node):
+        """Returns the oldest transactions.
+
+        Old transactions are not necessarily stale transactions.  If a node
+        goes down and comes back up before the reassign_delay, it needs a way
+        to find transactions that were previously assigned to it.
+
+        Args:
+            node (str): public key of node
+
+        Returns:
+            A cursor of transactions.
+        """
+        return self.connection.run(
+            r.table('backlog')
+            .between([node, r.minval],
+                     [node, r.maxval],
+                     index='assignee__transaction_timestamp')
+            .order_by(index=r.asc('assignee__transaction_timestamp')))
+
     def get_transaction_from_block(self, transaction_id, block_id):
         """Get a transaction from a specific block.
 

--- a/bigchaindb/pipelines/block.py
+++ b/bigchaindb/pipelines/block.py
@@ -7,7 +7,6 @@ function.
 
 import logging
 
-import rethinkdb as r
 from multipipes import Pipeline, Node
 
 from bigchaindb.models import Transaction
@@ -139,13 +138,7 @@ def initial():
 
     bigchain = Bigchain()
 
-    return bigchain.connection.run(
-        r.table('backlog')
-        .between([bigchain.me, r.minval],
-                 [bigchain.me, r.maxval],
-                 index='assignee__transaction_timestamp')
-        .order_by(index=r.asc('assignee__transaction_timestamp')))
-
+    return bigchain.backend.get_old_transactions(bigchain.me)
 
 def get_changefeed():
     """Create and return the changefeed for the backlog."""

--- a/bigchaindb/pipelines/block.py
+++ b/bigchaindb/pipelines/block.py
@@ -140,6 +140,7 @@ def initial():
 
     return bigchain.backend.get_old_transactions(bigchain.me)
 
+
 def get_changefeed():
     """Create and return the changefeed for the backlog."""
 


### PR DESCRIPTION
Removes an explicit database call from the `block` module.

Actually, this code probably can be absorbed into the stale transaction monitor code.  It's kind of useless that a node can come back and pick up its misplaced transactions when `stale_transaction_monitor` would reassign them shortly anyway.  Also costs us an index (maybe that's needed elsewhere anyway).

But that's another PR!