### PR TITLE
chore: fix printing out transactions on block creation

### DIFF
--- a/bigchaindb/pipelines/block.py
+++ b/bigchaindb/pipelines/block.py
@@ -116,7 +116,7 @@ class BlockPipeline:
         Returns:
             :class:`~bigchaindb.models.Block`: The Block.
         """
-        logger.info('Write new block %s with %s transactions', block.id, block.transactions)
+        logger.info('Write new block %s with %s transactions', block.id, len(block.transactions))
         self.bigchain.write_block(block)
         return block
 


### PR DESCRIPTION
instead of printing the list `block.transactions` print `len(block.transactions)`

FYI: this edit was done in the browser ;-)