### PR TITLE
Fixed bug in create_rethinkdb_conf.py

### DIFF
--- a/deploy-cluster-aws/awsdeploy.sh
+++ b/deploy-cluster-aws/awsdeploy.sh
@@ -44,7 +44,8 @@ echo "IMAGE_ID = "$IMAGE_ID
 echo "INSTANCE_TYPE = "$INSTANCE_TYPE
 echo "SECURITY_GROUP = "$SECURITY_GROUP
 echo "USING_EBS = "$USING_EBS
-if [ "$USING_EBS" = True ]; then
+# Treat booleans as strings which must be either "True" or "False"
+if [ "$USING_EBS" == "True" ]; then
     echo "EBS_VOLUME_SIZE = "$EBS_VOLUME_SIZE
     echo "EBS_OPTIMIZED = "$EBS_OPTIMIZED
 fi
@@ -117,7 +118,11 @@ fab upgrade_setuptools
 
 if [ "$WHAT_TO_DEPLOY" == "servers" ]; then
     # (Re)create the RethinkDB configuration file conf/rethinkdb.conf
-    python create_rethinkdb_conf.py --bind-http-to-localhost $BIND_HTTP_TO_LOCALHOST
+    if [ "$BIND_HTTP_TO_LOCALHOST" == "True" ]; then
+        python create_rethinkdb_conf.py --bind-http-to-localhost
+    else
+        python create_rethinkdb_conf.py
+    fi
     # Rollout RethinkDB and start it
     fab prep_rethinkdb_storage:$USING_EBS
     fab install_rethinkdb

--- a/deploy-cluster-aws/create_rethinkdb_conf.py
+++ b/deploy-cluster-aws/create_rethinkdb_conf.py
@@ -17,9 +17,9 @@ parser.add_argument("--bind-http-to-localhost",
                     help="should RethinkDB web interface be bound to localhost?",
                     required=True)
 args = parser.parse_args()
-bind_http_to_localhost = args.bind_http_to_localhost
-
-print('bind_http_to_localhost = {}'.format(bind_http_to_localhost))
+# args.bind_http_to_localhost is a string at this point.
+# It's either 'True' or 'False' but we want a boolean:
+bind_http_to_localhost = (args.bind_http_to_localhost == 'True')
 
 # cwd = current working directory
 old_cwd = os.getcwd()

--- a/deploy-cluster-aws/create_rethinkdb_conf.py
+++ b/deploy-cluster-aws/create_rethinkdb_conf.py
@@ -13,13 +13,13 @@ from hostlist import public_dns_names
 
 # Parse the command-line arguments
 parser = argparse.ArgumentParser()
-parser.add_argument("--bind-http-to-localhost",
-                    help="should RethinkDB web interface be bound to localhost?",
-                    required=True)
+# The next line isn't strictly necessary, but it clarifies the default case:
+parser.set_defaults(bind_http_to_localhost=False)
+parser.add_argument('--bind-http-to-localhost',
+                    action='store_true',
+                    help='should RethinkDB web interface be bound to localhost?')
 args = parser.parse_args()
-# args.bind_http_to_localhost is a string at this point.
-# It's either 'True' or 'False' but we want a boolean:
-bind_http_to_localhost = (args.bind_http_to_localhost == 'True')
+bind_http_to_localhost = args.bind_http_to_localhost
 
 # cwd = current working directory
 old_cwd = os.getcwd()


### PR DESCRIPTION
Before, `bind_http_to_localhost` was a string, either "True" or "False", and so the line:
```python
    if bind_http_to_localhost:
```
saw a nonempty string and always evaluated it as `True` (even if the string was "False").

I fixed it.