### PR TITLE
Fix tests broken from abstracting the database

### DIFF
--- a/bigchaindb/backend/connection.py
+++ b/bigchaindb/backend/connection.py
@@ -40,5 +40,5 @@ def connect(backend=None, host=None, port=None, name=None):
 
 class Connection:
 
-    def run(self):
+    def run(self, query):
         raise NotImplementedError()

--- a/bigchaindb/backend/query.py
+++ b/bigchaindb/backend/query.py
@@ -225,7 +225,7 @@ def get_votes_by_block_id_and_voter(connection, block_id, node_pubkey):
 
 
 @singledispatch
-def write_block(connection, block, durability='soft'):
+def write_block(connection, block):
     """Write a block to the bigchain table.
 
     Args:

--- a/bigchaindb/backend/rethinkdb/query.py
+++ b/bigchaindb/backend/rethinkdb/query.py
@@ -208,7 +208,7 @@ def get_last_voted_block(connection, node_pubkey):
 
     except r.ReqlNonExistenceError:
         # return last vote if last vote exists else return Genesis block
-        return get_genesis_block()
+        return get_genesis_block(connection)
 
     # Now the fun starts. Since the resolution of timestamp is a second,
     # we might have more than one vote per timestamp. If this is the case

--- a/bigchaindb/backend/schema.py
+++ b/bigchaindb/backend/schema.py
@@ -7,78 +7,79 @@ from bigchaindb.backend.connection import connect
 
 
 @singledispatch
-def create_database(connection, name):
+def create_database(connection, dbname):
     """Create database to be used by BigchainDB
 
     Args:
-        name (str): the name of the database to create.
+        dbname (str): the name of the database to create.
 
     Raises:
         :exc:`~bigchaindb.common.exceptions.DatabaseAlreadyExists`: If the
-        given :attr:`name` already exists as a database.
+        given :attr:`dbname` already exists as a database.
     """
 
     raise NotImplementedError
 
 
 @singledispatch
-def create_tables(connection, name):
+def create_tables(connection, dbname):
     """Create the tables to be used by BigchainDB
 
     Args:
-        name (str): the name of the database to create tables for.
+        dbname (str): the name of the database to create tables for.
     """
 
     raise NotImplementedError
 
 
 @singledispatch
-def create_indexes(connection, name):
+def create_indexes(connection, dbname):
     """Create the indexes to be used by BigchainDB
 
     Args:
-        name (str): the name of the database to create indexes for.
+        dbname (str): the name of the database to create indexes for.
     """
 
     raise NotImplementedError
 
 
 @singledispatch
-def drop_database(connection, name):
+def drop_database(connection, dbname):
     """Drop the database used by BigchainDB
 
     Args:
-        name (str): the name of the database to drop.
+        dbname (str): the name of the database to drop.
 
     Raises:
         :exc:`~bigchaindb.common.exceptions.DatabaseDoesNotExist`: If the
-        given :attr:`name` does not exist as a database.
+        given :attr:`dbname` does not exist as a database.
     """
 
     raise NotImplementedError
 
 
-def init_database(conn=None, name=None):
+def init_database(conn=None, dbname=None):
     """Initialize the configured backend for use with BigchainDB.
 
-    Creates a database with :attr:`name` with any required tables
+    Creates a database with :attr:`dbname` with any required tables
     and supporting indexes.
 
     Args:
         conn (:class:`~bigchaindb.backend.connection.Connection`): an existing
             connection to use to initialize the database.
             Creates one if not given.
-        name (str): the name of the database to create.
-            Defaults to the name in the BigchainDB configuration.
+        dbname (str): the name of the database to create.
+            Defaults to the database name given in the BigchainDB
+            configuration.
 
     Raises:
         :exc:`~bigchaindb.common.exceptions.DatabaseAlreadyExists`: If the
-        given :attr:`name` already exists as a database.
+        given :attr:`dbname` already exists as a database.
     """
 
     conn = conn or connect()
-    name = name or bigchaindb.config['database']['name']
+    dbname = dbname or bigchaindb.config['database']['name']
 
-    create_database(conn, name)
-    create_tables(conn, name)
-    create_indexes(conn, name)
+    create_database(conn, dbname)
+    create_tables(conn, dbname)
+    create_indexes(conn, dbname)

--- a/bigchaindb/backend/schema.py
+++ b/bigchaindb/backend/schema.py
@@ -58,21 +58,25 @@ def drop_database(connection, name):
     raise NotImplementedError
 
 
-def init_database(name=None):
+def init_database(conn=None, name=None):
     """Initialize the configured backend for use with BigchainDB.
 
     Creates a database with :attr:`name` with any required tables
     and supporting indexes.
 
     Args:
+        conn (:class:`~bigchaindb.backend.connection.Connection`): an existing
+            connection to use to initialize the database.
+            Creates one if not given.
         name (str): the name of the database to create.
+            Defaults to the name in the BigchainDB configuration.
 
     Raises:
         :exc:`~bigchaindb.common.exceptions.DatabaseAlreadyExists`: If the
         given :attr:`name` already exists as a database.
     """
 
-    conn = connect()
+    conn = conn or connect()
     name = name or bigchaindb.config['database']['name']
 
     create_database(conn, name)

--- a/bigchaindb/backend/schema.py
+++ b/bigchaindb/backend/schema.py
@@ -58,15 +58,15 @@ def drop_database(connection, dbname):
     raise NotImplementedError
 
 
-def init_database(conn=None, dbname=None):
+def init_database(connection=None, dbname=None):
     """Initialize the configured backend for use with BigchainDB.
 
     Creates a database with :attr:`dbname` with any required tables
     and supporting indexes.
 
     Args:
-        conn (:class:`~bigchaindb.backend.connection.Connection`): an existing
-            connection to use to initialize the database.
+        connection (:class:`~bigchaindb.backend.connection.Connection`): an
+            existing connection to use to initialize the database.
             Creates one if not given.
         dbname (str): the name of the database to create.
             Defaults to the database name given in the BigchainDB
@@ -77,9 +77,9 @@ def init_database(conn=None, dbname=None):
         given :attr:`dbname` already exists as a database.
     """
 
-    conn = conn or connect()
+    connection = connection or connect()
     dbname = dbname or bigchaindb.config['database']['name']
 
-    create_database(conn, dbname)
-    create_tables(conn, dbname)
-    create_indexes(conn, dbname)
+    create_database(connection, dbname)
+    create_tables(connection, dbname)
+    create_indexes(connection, dbname)

--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -138,7 +138,7 @@ def _run_init():
     # Try to access the keypair, throws an exception if it does not exist
     b = bigchaindb.Bigchain()
 
-    schema.init_database(b.connection)
+    schema.init_database(connection=b.connection)
 
     logger.info('Create genesis block.')
     b.create_genesis_block()

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -61,7 +61,7 @@ class Bigchain(object):
         if not self.me or not self.me_private:
             raise exceptions.KeypairNotFoundException()
 
-    def write_transaction(self, signed_transaction, durability='soft'):
+    def write_transaction(self, signed_transaction):
         """Write the transaction to bigchain.
 
         When first writing a transaction to the bigchain the transaction will be kept in a backlog until
@@ -538,14 +538,14 @@ class Bigchain(object):
 
         return has_previous_vote
 
-    def write_block(self, block, durability='soft'):
+    def write_block(self, block):
         """Write a block to bigchain.
 
         Args:
             block (Block): block to write to bigchain.
         """
 
-        return backend.query.write_block(self.connection, block.to_str(), durability=durability)
+        return backend.query.write_block(self.connection, block.to_str())
 
     def transaction_exists(self, transaction_id):
         return backend.query.has_transaction(self.connection, transaction_id)
@@ -583,7 +583,7 @@ class Bigchain(object):
             raise exceptions.GenesisBlockAlreadyExistsError('Cannot create the Genesis block')
 
         block = self.prepare_genesis_block()
-        self.write_block(block, durability='hard')
+        self.write_block(block)
 
         return block
 

--- a/tests/assets/test_digital_assets.py
+++ b/tests/assets/test_digital_assets.py
@@ -91,7 +91,7 @@ def test_get_asset_id_transfer_transaction(b, user_pk, user_sk):
     tx_transfer_signed = tx_transfer.sign([user_sk])
     # create a block
     block = b.create_block([tx_transfer_signed])
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote the block valid
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
@@ -130,7 +130,7 @@ def test_get_transactions_by_asset_id(b, user_pk, user_sk):
     tx_transfer_signed = tx_transfer.sign([user_sk])
     # create the block
     block = b.create_block([tx_transfer_signed])
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote the block valid
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
@@ -163,7 +163,7 @@ def test_get_transactions_by_asset_id_with_invalid_block(b, user_pk, user_sk):
     tx_transfer_signed = tx_transfer.sign([user_sk])
     # create the block
     block = b.create_block([tx_transfer_signed])
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote the block invalid
     vote = b.vote(block.id, b.get_last_voted_block().id, False)
     b.write_vote(vote)
@@ -187,7 +187,7 @@ def test_get_asset_by_id(b, user_pk, user_sk):
     tx_transfer_signed = tx_transfer.sign([user_sk])
     # create the block
     block = b.create_block([tx_transfer_signed])
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote the block valid
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)

--- a/tests/assets/test_divisible_assets.py
+++ b/tests/assets/test_divisible_assets.py
@@ -141,7 +141,7 @@ def test_single_in_single_own_single_out_single_own_transfer(b, user_pk,
     # create block
     block = b.create_block([tx_create_signed])
     assert block.validate(b) == block
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
@@ -175,7 +175,7 @@ def test_single_in_single_own_multiple_out_single_own_transfer(b, user_pk,
     # create block
     block = b.create_block([tx_create_signed])
     assert block.validate(b) == block
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
@@ -211,7 +211,7 @@ def test_single_in_single_own_single_out_multiple_own_transfer(b, user_pk,
     # create block
     block = b.create_block([tx_create_signed])
     assert block.validate(b) == block
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
@@ -252,7 +252,7 @@ def test_single_in_single_own_multiple_out_mix_own_transfer(b, user_pk,
     # create block
     block = b.create_block([tx_create_signed])
     assert block.validate(b) == block
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
@@ -294,7 +294,7 @@ def test_single_in_multiple_own_single_out_single_own_transfer(b, user_pk,
     # create block
     block = b.create_block([tx_create_signed])
     assert block.validate(b) == block
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
@@ -333,7 +333,7 @@ def test_multiple_in_single_own_single_out_single_own_transfer(b, user_pk,
     # create block
     block = b.create_block([tx_create_signed])
     assert block.validate(b) == block
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
@@ -370,7 +370,7 @@ def test_multiple_in_multiple_own_single_out_single_own_transfer(b, user_pk,
     # create block
     block = b.create_block([tx_create_signed])
     assert block.validate(b) == block
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
@@ -415,7 +415,7 @@ def test_muiltiple_in_mix_own_multiple_out_single_own_transfer(b, user_pk,
     # create block
     block = b.create_block([tx_create_signed])
     assert block.validate(b) == block
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
@@ -460,7 +460,7 @@ def test_muiltiple_in_mix_own_multiple_out_mix_own_transfer(b, user_pk,
     # create block
     block = b.create_block([tx_create_signed])
     assert block.validate(b) == block
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
@@ -512,7 +512,7 @@ def test_multiple_in_different_transactions(b, user_pk, user_sk):
     # create block
     block = b.create_block([tx_create_signed])
     assert block.validate(b) == block
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
@@ -528,7 +528,7 @@ def test_multiple_in_different_transactions(b, user_pk, user_sk):
     # create block
     block = b.create_block([tx_transfer1_signed])
     assert block.validate(b) == block
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
@@ -569,7 +569,7 @@ def test_amount_error_transfer(b, user_pk, user_sk):
     # create block
     block = b.create_block([tx_create_signed])
     assert block.validate(b) == block
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
@@ -612,7 +612,7 @@ def test_threshold_same_public_key(b, user_pk, user_sk):
     # create block
     block = b.create_block([tx_create_signed])
     assert block.validate(b) == block
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
@@ -641,7 +641,7 @@ def test_sum_amount(b, user_pk, user_sk):
     # create block
     block = b.create_block([tx_create_signed])
     assert block.validate(b) == block
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
@@ -670,7 +670,7 @@ def test_divide(b, user_pk, user_sk):
     # create block
     block = b.create_block([tx_create_signed])
     assert block.validate(b) == block
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
@@ -703,7 +703,7 @@ def test_non_positive_amounts_on_transfer(b, user_pk):
     # create block
     block = b.create_block([tx_create_signed])
     assert block.validate(b) == block
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
@@ -729,7 +729,7 @@ def test_non_positive_amounts_on_transfer_validate(b, user_pk, user_sk):
     # create block
     block = b.create_block([tx_create_signed])
     assert block.validate(b) == block
-    b.write_block(block, durability='hard')
+    b.write_block(block)
     # vote
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)

--- a/tests/backend/test_utils.py
+++ b/tests/backend/test_utils.py
@@ -45,11 +45,11 @@ def test_module_dispatch_dispatches(mock_module):
 def test_module_dispatch_errors_on_missing_func(mock_module):
     from bigchaindb.backend.utils import (
         module_dispatch_registrar,
-        BackendModuleDispatchRegisterError,
+        ModuleDispatchRegistrationError,
     )
     mock_dispatch = module_dispatch_registrar(mock_module)
 
-    with pytest.raises(BackendModuleDispatchRegisterError):
+    with pytest.raises(ModuleDispatchRegistrationError):
         @mock_dispatch(str)
         def dispatched():
             pass
@@ -58,7 +58,7 @@ def test_module_dispatch_errors_on_missing_func(mock_module):
 def test_module_dispatch_errors_on_non_dispatchable_func(mock_module):
     from bigchaindb.backend.utils import (
         module_dispatch_registrar,
-        BackendModuleDispatchRegisterError,
+        ModuleDispatchRegistrationError,
     )
 
     def dispatcher():
@@ -66,7 +66,7 @@ def test_module_dispatch_errors_on_non_dispatchable_func(mock_module):
     mock_module.dispatched = dispatcher
     mock_dispatch = module_dispatch_registrar(mock_module)
 
-    with pytest.raises(BackendModuleDispatchRegisterError):
+    with pytest.raises(ModuleDispatchRegistrationError):
         @mock_dispatch(str)
         def dispatched():
             pass

--- a/tests/backend/test_utils.py
+++ b/tests/backend/test_utils.py
@@ -10,13 +10,13 @@ def mock_module():
 
 
 def test_module_dispatch_registers(mock_module):
-    from bigchaindb.backend.utils import make_module_dispatch_registrar
+    from bigchaindb.backend.utils import module_dispatch_registrar
 
     @singledispatch
     def dispatcher(t):
         pass
     mock_module.dispatched = dispatcher
-    mock_dispatch = make_module_dispatch_registrar(mock_module)
+    mock_dispatch = module_dispatch_registrar(mock_module)
 
     @mock_dispatch(str)
     def dispatched(t):
@@ -26,13 +26,13 @@ def test_module_dispatch_registers(mock_module):
 
 
 def test_module_dispatch_dispatches(mock_module):
-    from bigchaindb.backend.utils import make_module_dispatch_registrar
+    from bigchaindb.backend.utils import module_dispatch_registrar
 
     @singledispatch
     def dispatcher(t):
         return False
     mock_module.dispatched = dispatcher
-    mock_dispatch = make_module_dispatch_registrar(mock_module)
+    mock_dispatch = module_dispatch_registrar(mock_module)
 
     @mock_dispatch(str)
     def dispatched(t):
@@ -44,10 +44,10 @@ def test_module_dispatch_dispatches(mock_module):
 
 def test_module_dispatch_errors_on_missing_func(mock_module):
     from bigchaindb.backend.utils import (
-        make_module_dispatch_registrar,
+        module_dispatch_registrar,
         BackendModuleDispatchRegisterError,
     )
-    mock_dispatch = make_module_dispatch_registrar(mock_module)
+    mock_dispatch = module_dispatch_registrar(mock_module)
 
     with pytest.raises(BackendModuleDispatchRegisterError):
         @mock_dispatch(str)
@@ -57,14 +57,14 @@ def test_module_dispatch_errors_on_missing_func(mock_module):
 
 def test_module_dispatch_errors_on_non_dispatchable_func(mock_module):
     from bigchaindb.backend.utils import (
-        make_module_dispatch_registrar,
+        module_dispatch_registrar,
         BackendModuleDispatchRegisterError,
     )
 
     def dispatcher():
         pass
     mock_module.dispatched = dispatcher
-    mock_dispatch = make_module_dispatch_registrar(mock_module)
+    mock_dispatch = module_dispatch_registrar(mock_module)
 
     with pytest.raises(BackendModuleDispatchRegisterError):
         @mock_dispatch(str)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,11 +16,12 @@ DB_NAME = 'bigchain_test_{}'.format(os.getpid())
 
 CONFIG = {
     'database': {
-        'name': DB_NAME
+        'backend': 'rethinkdb',
+        'name': DB_NAME,
     },
     'keypair': {
         'private': '31Lb1ZGKTyHnmVK3LUMrAUrPNfd4sE2YyBt3UA4A25aA',
-        'public': '4XYfCbabAWVUCbjTmRTFEu2sc3dFEdkse4r6X498B1s8'
+        'public': '4XYfCbabAWVUCbjTmRTFEu2sc3dFEdkse4r6X498B1s8',
     }
 }
 

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -89,7 +89,7 @@ def inputs(user_pk):
             for i in range(10)
         ]
         block = b.create_block(transactions)
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         # 3. vote the blocks valid, so that the inputs are valid
         vote = b.vote(block.id, prev_block_id, True)
@@ -127,7 +127,7 @@ def inputs_shared(user_pk, user2_pk):
             for i in range(10)
         ]
         block = b.create_block(transactions)
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         # 3. vote the blocks valid, so that the inputs are valid
         vote = b.vote(block.id, prev_block_id, True)

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -10,7 +10,7 @@ import pytest
 import rethinkdb as r
 
 from bigchaindb import Bigchain
-from bigchaindb.backend import connect, init_database
+from bigchaindb.backend import connect, schema
 from bigchaindb.common import crypto
 from bigchaindb.common.exceptions import DatabaseAlreadyExists
 
@@ -34,7 +34,7 @@ def setup_database(request, node_config):
         conn.run(r.db_drop(db_name))
 
     try:
-        init_database()
+        schema.init_database()
     except DatabaseAlreadyExists:
         print('Database already exists.')
 

--- a/tests/db/rethinkdb/test_schema.py
+++ b/tests/db/rethinkdb/test_schema.py
@@ -4,7 +4,7 @@ import rethinkdb as r
 import bigchaindb
 from bigchaindb import backend
 from bigchaindb.backend.rethinkdb import schema
-from .conftest import setup_database as _setup_database
+from ..conftest import setup_database as _setup_database
 
 
 # Since we are testing database initialization and database drop,

--- a/tests/db/rethinkdb/test_schema.py
+++ b/tests/db/rethinkdb/test_schema.py
@@ -21,7 +21,7 @@ def test_init_creates_db_tables_and_indexes():
     # The db is set up by fixtures so we need to remove it
     conn.run(r.db_drop(dbname))
 
-    schema.create_database()
+    schema.create_database(conn, dbname)
 
     assert conn.run(r.db_list().contains(dbname)) is True
 

--- a/tests/db/rethinkdb/test_schema.py
+++ b/tests/db/rethinkdb/test_schema.py
@@ -76,7 +76,7 @@ def test_create_tables():
     assert len(conn.run(r.db(dbname).table_list())) == 3
 
 
-def test_create_bigchain_secondary_index():
+def test_create_secondary_indexes():
     conn = backend.connect()
     dbname = bigchaindb.config['database']['name']
 
@@ -85,7 +85,7 @@ def test_create_bigchain_secondary_index():
     conn.run(r.db_drop(dbname))
     schema.create_database(conn, dbname)
     schema.create_tables(conn, dbname)
-    schema.create_bigchain_secondary_index(conn, dbname)
+    schema.create_indexes(conn, dbname)
 
     # Bigchain table
     assert conn.run(r.db(dbname).table('bigchain').index_list().contains(

--- a/tests/db/rethinkdb/test_schema.py
+++ b/tests/db/rethinkdb/test_schema.py
@@ -165,31 +165,6 @@ def test_drop_interactively_drops_the_database_when_user_says_yes(monkeypatch):
     assert r.db_list().contains(dbname).run(conn) is False
 
 
-def test_drop_programmatically_drops_the_database_when_assume_yes_is_true(monkeypatch):
-    conn = utils.get_conn()
-    dbname = bigchaindb.config['database']['name']
-
-    # The db is set up by fixtures
-    assert r.db_list().contains(dbname).run(conn) is True
-
-    utils.drop(assume_yes=True)
-
-    assert r.db_list().contains(dbname).run(conn) is False
-
-
-def test_drop_interactively_does_not_drop_the_database_when_user_says_no(monkeypatch):
-    conn = utils.get_conn()
-    dbname = bigchaindb.config['database']['name']
-
-    # The db is set up by fixtures
-    print(r.db_list().contains(dbname).run(conn))
-    assert r.db_list().contains(dbname).run(conn) is True
-
-    monkeypatch.setattr(builtins, 'input', lambda x: 'n')
-    utils.drop()
-
-    assert r.db_list().contains(dbname).run(conn) is True
-
 def test_drop_non_existent_db_raises_an_error():
     conn = utils.get_conn()
     dbname = bigchaindb.config['database']['name']
@@ -200,4 +175,3 @@ def test_drop_non_existent_db_raises_an_error():
 
     with pytest.raises(exceptions.DatabaseDoesNotExist):
         utils.drop(assume_yes=True)
-

--- a/tests/db/rethinkdb/test_schema.py
+++ b/tests/db/rethinkdb/test_schema.py
@@ -1,11 +1,9 @@
-import builtins
-
-from bigchaindb.common import exceptions
 import pytest
 import rethinkdb as r
 
 import bigchaindb
-from bigchaindb.db import utils
+from bigchaindb import backend
+from bigchaindb.backend.rethinkdb import schema
 from .conftest import setup_database as _setup_database
 
 
@@ -17,161 +15,116 @@ def setup_database(request, node_config):
 
 
 def test_init_creates_db_tables_and_indexes():
-    conn = utils.get_conn()
+    conn = backend.connect()
     dbname = bigchaindb.config['database']['name']
 
     # The db is set up by fixtures so we need to remove it
-    r.db_drop(dbname).run(conn)
+    conn.run(r.db_drop(dbname))
 
-    utils.init()
+    schema.create_database()
 
-    assert r.db_list().contains(dbname).run(conn) is True
+    assert conn.run(r.db_list().contains(dbname)) is True
 
-    assert r.db(dbname).table_list().contains('backlog', 'bigchain').run(conn) is True
+    assert conn.run(r.db(dbname).table_list().contains('backlog', 'bigchain')) is True
 
-    assert r.db(dbname).table('bigchain').index_list().contains(
-        'block_timestamp').run(conn) is True
+    assert conn.run(r.db(dbname).table('bigchain').index_list().contains(
+        'block_timestamp')) is True
 
-    assert r.db(dbname).table('backlog').index_list().contains(
-        'assignee__transaction_timestamp').run(conn) is True
+    assert conn.run(r.db(dbname).table('backlog').index_list().contains(
+        'assignee__transaction_timestamp')) is True
 
 
 def test_create_database():
-    conn = utils.get_conn()
-    dbname = utils.get_database_name()
+    conn = backend.connect()
+    dbname = bigchaindb.config['database']['name']
 
     # The db is set up by fixtures so we need to remove it
     # and recreate it just with one table
-    r.db_drop(dbname).run(conn)
-    utils.create_database(conn, dbname)
-    assert r.db_list().contains(dbname).run(conn) is True
+    conn.run(r.db_drop(dbname))
+    schema.create_database(conn, dbname)
+    assert conn.run(r.db_list().contains(dbname)) is True
 
 
-def test_create_bigchain_table():
-    conn = utils.get_conn()
-    dbname = utils.get_database_name()
+def test_create_tables():
+    conn = backend.connect()
+    dbname = bigchaindb.config['database']['name']
 
     # The db is set up by fixtures so we need to remove it
     # and recreate it just with one table
-    r.db_drop(dbname).run(conn)
-    utils.create_database(conn, dbname)
-    utils.create_table(conn, dbname, 'bigchain')
+    conn.run(r.db_drop(dbname))
+    schema.create_database(conn, dbname)
+    schema.create_tables(conn, dbname)
 
-    assert r.db(dbname).table_list().contains('bigchain').run(conn) is True
-    assert r.db(dbname).table_list().contains('backlog').run(conn) is False
-    assert r.db(dbname).table_list().contains('votes').run(conn) is False
+    assert conn.run(r.db(dbname).table_list().contains('bigchain')) is True
+    assert conn.run(r.db(dbname).table_list().contains('backlog')) is True
+    assert conn.run(r.db(dbname).table_list().contains('votes')) is True
+    assert len(conn.run(r.db(dbname).table_list())) == 3
 
 
 def test_create_bigchain_secondary_index():
-    conn = utils.get_conn()
-    dbname = utils.get_database_name()
+    conn = backend.connect()
+    dbname = bigchaindb.config['database']['name']
 
     # The db is set up by fixtures so we need to remove it
     # and recreate it just with one table
-    r.db_drop(dbname).run(conn)
-    utils.create_database(conn, dbname)
-    utils.create_table(conn, dbname, 'bigchain')
-    utils.create_bigchain_secondary_index(conn, dbname)
+    conn.run(r.db_drop(dbname))
+    schema.create_database(conn, dbname)
+    schema.create_tables(conn, dbname)
+    schema.create_bigchain_secondary_index(conn, dbname)
 
-    assert r.db(dbname).table('bigchain').index_list().contains(
-        'block_timestamp').run(conn) is True
-    assert r.db(dbname).table('bigchain').index_list().contains(
-        'transaction_id').run(conn) is True
-    assert r.db(dbname).table('bigchain').index_list().contains(
-        'metadata_id').run(conn) is True
+    # Bigchain table
+    assert conn.run(r.db(dbname).table('bigchain').index_list().contains(
+        'block_timestamp')) is True
+    assert conn.run(r.db(dbname).table('bigchain').index_list().contains(
+        'transaction_id')) is True
+    assert conn.run(r.db(dbname).table('bigchain').index_list().contains(
+        'metadata_id')) is True
+    assert conn.run(r.db(dbname).table('bigchain').index_list().contains(
+        'asset_id')) is True
 
+    # Backlog table
+    assert conn.run(r.db(dbname).table('backlog').index_list().contains(
+        'assignee__transaction_timestamp')) is True
 
-def test_create_backlog_table():
-    conn = utils.get_conn()
-    dbname = utils.get_database_name()
-
-    # The db is set up by fixtures so we need to remove it
-    # and recreate it just with one table
-    r.db_drop(dbname).run(conn)
-    utils.create_database(conn, dbname)
-    utils.create_table(conn, dbname, 'backlog')
-
-    assert r.db(dbname).table_list().contains('backlog').run(conn) is True
-    assert r.db(dbname).table_list().contains('bigchain').run(conn) is False
-    assert r.db(dbname).table_list().contains('votes').run(conn) is False
+    # Votes table
+    assert conn.run(r.db(dbname).table('votes').index_list().contains(
+        'block_and_voter')) is True
 
 
-def test_create_backlog_secondary_index():
-    conn = utils.get_conn()
-    dbname = utils.get_database_name()
+def test_init_database_fails_if_db_exists():
+    from bigchaindb.common import exceptions
 
-    # The db is set up by fixtures so we need to remove it
-    # and recreate it just with one table
-    r.db_drop(dbname).run(conn)
-    utils.create_database(conn, dbname)
-    utils.create_table(conn, dbname, 'backlog')
-    utils.create_backlog_secondary_index(conn, dbname)
-
-    assert r.db(dbname).table('backlog').index_list().contains(
-        'assignee__transaction_timestamp').run(conn) is True
-
-
-def test_create_votes_table():
-    conn = utils.get_conn()
-    dbname = utils.get_database_name()
-
-    # The db is set up by fixtures so we need to remove it
-    # and recreate it just with one table
-    r.db_drop(dbname).run(conn)
-    utils.create_database(conn, dbname)
-    utils.create_table(conn, dbname, 'votes')
-
-    assert r.db(dbname).table_list().contains('votes').run(conn) is True
-    assert r.db(dbname).table_list().contains('bigchain').run(conn) is False
-    assert r.db(dbname).table_list().contains('backlog').run(conn) is False
-
-
-def test_create_votes_secondary_index():
-    conn = utils.get_conn()
-    dbname = utils.get_database_name()
-
-    # The db is set up by fixtures so we need to remove it
-    # and recreate it just with one table
-    r.db_drop(dbname).run(conn)
-    utils.create_database(conn, dbname)
-    utils.create_table(conn, dbname, 'votes')
-    utils.create_votes_secondary_index(conn, dbname)
-
-    assert r.db(dbname).table('votes').index_list().contains(
-        'block_and_voter').run(conn) is True
-
-
-def test_init_fails_if_db_exists():
-    conn = utils.get_conn()
+    conn = backend.connect()
     dbname = bigchaindb.config['database']['name']
 
     # The db is set up by fixtures
-    assert r.db_list().contains(dbname).run(conn) is True
+    assert conn.run(r.db_list().contains(dbname)) is True
 
     with pytest.raises(exceptions.DatabaseAlreadyExists):
-        utils.init()
+        schema.init_database()
 
 
-def test_drop_interactively_drops_the_database_when_user_says_yes(monkeypatch):
-    conn = utils.get_conn()
+def test_drop():
+    conn = backend.connect()
     dbname = bigchaindb.config['database']['name']
 
     # The db is set up by fixtures
-    assert r.db_list().contains(dbname).run(conn) is True
+    assert conn.run(r.db_list().contains(dbname)) is True
 
-    monkeypatch.setattr(builtins, 'input', lambda x: 'y')
-    utils.drop()
-
-    assert r.db_list().contains(dbname).run(conn) is False
+    schema.drop_database(conn, dbname)
+    assert conn.run(r.db_list().contains(dbname)) is False
 
 
 def test_drop_non_existent_db_raises_an_error():
-    conn = utils.get_conn()
+    from bigchaindb.common import exceptions
+
+    conn = backend.connect()
     dbname = bigchaindb.config['database']['name']
 
     # The db is set up by fixtures
-    assert r.db_list().contains(dbname).run(conn) is True
-    utils.drop(assume_yes=True)
+    assert conn.run(r.db_list().contains(dbname)) is True
+
+    schema.drop_database(conn, dbname)
 
     with pytest.raises(exceptions.DatabaseDoesNotExist):
-        utils.drop(assume_yes=True)
+        schema.drop_database(conn, dbname)

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -303,7 +303,8 @@ class TestBigchainApi(object):
 
     @pytest.mark.usefixtures('inputs')
     def test_genesis_block(self, b):
-        block = b.backend.get_genesis_block()
+        from bigchaindb.backend import query
+        block = query.get_genesis_block(b.connection)
 
         assert len(block['block']['transactions']) == 1
         assert block['block']['transactions'][0]['transaction']['operation'] == 'GENESIS'
@@ -319,8 +320,9 @@ class TestBigchainApi(object):
 
     @pytest.mark.skipif(reason='This test may not make sense after changing the chainification mode')
     def test_get_last_block(self, b):
+        from bigchaindb.backend import query
         # get the number of blocks
-        num_blocks = b.backend.count_blocks()
+        num_blocks = query.count_blocks(b.connection)
 
         # get the last block
         last_block = b.get_last_block()
@@ -373,9 +375,10 @@ class TestBigchainApi(object):
 
     def test_get_last_voted_block_returns_genesis_if_no_votes_has_been_casted(self, b):
         from bigchaindb.models import Block
+        from bigchaindb.backend import query
 
         b.create_genesis_block()
-        genesis = b.backend.get_genesis_block()
+        genesis = query.get_genesis_block(b.connection)
         genesis = Block.from_dict(genesis)
         gb = b.get_last_voted_block()
         assert gb == genesis
@@ -510,6 +513,7 @@ class TestBigchainApi(object):
 
     @pytest.mark.usefixtures('inputs')
     def test_assign_transaction_one_node(self, b, user_pk, user_sk):
+        from bigchaindb.backend import query
         from bigchaindb.models import Transaction
 
         input_tx = b.get_owned_ids(user_pk).pop()
@@ -520,13 +524,14 @@ class TestBigchainApi(object):
         b.write_transaction(tx)
 
         # retrieve the transaction
-        response = list(b.backend.get_stale_transactions(0))[0]
+        response = list(query.get_stale_transactions(b.connection, 0))[0]
 
         # check if the assignee is the current node
         assert response['assignee'] == b.me
 
     @pytest.mark.usefixtures('inputs')
     def test_assign_transaction_multiple_nodes(self, b, user_pk, user_sk):
+        from bigchaindb.backend import query
         from bigchaindb.common.crypto import generate_key_pair
         from bigchaindb.models import Transaction
 
@@ -544,12 +549,11 @@ class TestBigchainApi(object):
             b.write_transaction(tx)
 
         # retrieve the transaction
-        response = b.backend.get_stale_transactions(0)
+        response = query.get_stale_transactions(b.connection, 0)
 
         # check if the assignee is one of the _other_ federation nodes
         for tx in response:
             assert tx['assignee'] in b.nodes_except_me
-
 
     @pytest.mark.usefixtures('inputs')
     def test_non_create_input_not_found(self, b, user_pk):
@@ -570,6 +574,7 @@ class TestBigchainApi(object):
             tx.validate(Bigchain())
 
     def test_count_backlog(self, b, user_pk):
+        from bigchaindb.backend import query
         from bigchaindb.models import Transaction
 
         for _ in range(4):
@@ -577,7 +582,7 @@ class TestBigchainApi(object):
                                     [([user_pk], 1)]).sign([b.me_private])
             b.write_transaction(tx)
 
-        assert b.backend.count_backlog() == 4
+        assert query.count_backlog(b.connection) == 4
 
 
 class TestTransactionValidation(object):

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -41,7 +41,7 @@ class TestBigchainApi(object):
         tx = tx.sign([b.me_private])
         monkeypatch.setattr('time.time', lambda: 1)
         block1 = b.create_block([tx])
-        b.write_block(block1, durability='hard')
+        b.write_block(block1)
 
         # Manipulate vote to create a cyclic Blockchain
         vote = b.vote(block1.id, b.get_last_voted_block().id, True)
@@ -79,7 +79,7 @@ class TestBigchainApi(object):
 
         monkeypatch.setattr('time.time', lambda: 1)
         block = b.create_block([tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         assert b.has_previous_vote(block.id, block.voters) is False
 
@@ -99,21 +99,21 @@ class TestBigchainApi(object):
 
         monkeypatch.setattr('time.time', lambda: 1)
         block1 = b.create_block([tx])
-        b.write_block(block1, durability='hard')
+        b.write_block(block1)
 
         monkeypatch.setattr('time.time', lambda: 2)
         transfer_tx = Transaction.transfer(tx.to_inputs(), [([b.me], 1)],
                                            tx.asset)
         transfer_tx = transfer_tx.sign([b.me_private])
         block2 = b.create_block([transfer_tx])
-        b.write_block(block2, durability='hard')
+        b.write_block(block2)
 
         monkeypatch.setattr('time.time', lambda: 3)
         transfer_tx2 = Transaction.transfer(tx.to_inputs(), [([b.me], 1)],
                                             tx.asset)
         transfer_tx2 = transfer_tx2.sign([b.me_private])
         block3 = b.create_block([transfer_tx2])
-        b.write_block(block3, durability='hard')
+        b.write_block(block3)
 
         # Vote both block2 and block3 valid to provoke a double spend
         vote = b.vote(block2.id, b.get_last_voted_block().id, True)
@@ -135,11 +135,11 @@ class TestBigchainApi(object):
 
         monkeypatch.setattr('time.time', lambda: 1)
         block1 = b.create_block([tx])
-        b.write_block(block1, durability='hard')
+        b.write_block(block1)
 
         monkeypatch.setattr('time.time', lambda: 2)
         block2 = b.create_block([tx])
-        b.write_block(block2, durability='hard')
+        b.write_block(block2)
 
         # Vote both blocks valid (creating a double spend)
         vote = b.vote(block1.id, b.get_last_voted_block().id, True)
@@ -159,13 +159,13 @@ class TestBigchainApi(object):
         tx1 = Transaction.create([b.me], [([b.me], 1)])
         tx1 = tx1.sign([b.me_private])
         block1 = b.create_block([tx1])
-        b.write_block(block1, durability='hard')
+        b.write_block(block1)
 
         monkeypatch.setattr('time.time', lambda: 2)
         tx2 = Transaction.create([b.me], [([b.me], 1)])
         tx2 = tx2.sign([b.me_private])
         block2 = b.create_block([tx2])
-        b.write_block(block2, durability='hard')
+        b.write_block(block2)
 
         # vote the first block invalid
         vote = b.vote(block1.id, b.get_last_voted_block().id, False)
@@ -185,7 +185,7 @@ class TestBigchainApi(object):
         tx = Transaction.create([b.me], [([user_pk], 1)], metadata=metadata)
 
         block = b.create_block([tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         matches = b.get_transaction_by_metadata_id(tx.metadata.data_id)
         assert len(matches) == 1
@@ -199,7 +199,7 @@ class TestBigchainApi(object):
         tx = Transaction.create([b.me], [([user_pk], 1)], metadata=metadata)
 
         block = b.create_block([tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
         # vote block invalid
         vote = b.vote(block.id, b.get_last_voted_block().id, False)
         b.write_vote(vote)
@@ -242,7 +242,7 @@ class TestBigchainApi(object):
 
         # create block and write it to the bighcain before retrieving the transaction
         block = b.create_block([tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         response, status = b.get_transaction(tx.id, include_status=True)
         # add validity information, which will be returned
@@ -262,7 +262,7 @@ class TestBigchainApi(object):
 
         # create block
         block = b.create_block([tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         # vote the block invalid
         vote = b.vote(block.id, b.get_last_voted_block().id, False)
@@ -288,7 +288,7 @@ class TestBigchainApi(object):
 
         # create block
         block = b.create_block([tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         # vote the block invalid
         vote = b.vote(block.id, b.get_last_voted_block().id, False)
@@ -338,7 +338,7 @@ class TestBigchainApi(object):
     def test_get_previous_block(self, b):
         last_block = b.get_last_block()
         new_block = b.create_block([])
-        b.write_block(new_block, durability='hard')
+        b.write_block(new_block)
 
         prev_block = b.get_previous_block(new_block)
 
@@ -348,7 +348,7 @@ class TestBigchainApi(object):
     def test_get_previous_block_id(self, b):
         last_block = b.get_last_block()
         new_block = b.create_block([])
-        b.write_block(new_block, durability='hard')
+        b.write_block(new_block)
 
         prev_block_id = b.get_previous_block_id(new_block)
 
@@ -365,7 +365,7 @@ class TestBigchainApi(object):
     @pytest.mark.usefixtures('inputs')
     def test_get_block_by_id(self, b):
         new_block = dummy_block()
-        b.write_block(new_block, durability='hard')
+        b.write_block(new_block)
 
         assert b.get_block(new_block.id) == new_block.to_dict()
         block, status = b.get_block(new_block.id, include_status=True)
@@ -393,9 +393,9 @@ class TestBigchainApi(object):
         monkeypatch.setattr('time.time', lambda: 3)
         block_3 = dummy_block()
 
-        b.write_block(block_1, durability='hard')
-        b.write_block(block_2, durability='hard')
-        b.write_block(block_3, durability='hard')
+        b.write_block(block_1)
+        b.write_block(block_2)
+        b.write_block(block_3)
 
         # make sure all the votes are written with the same timestamps
         monkeypatch.setattr('time.time', lambda: 4)
@@ -420,9 +420,9 @@ class TestBigchainApi(object):
         monkeypatch.setattr('time.time', lambda: 3)
         block_3 = dummy_block()
 
-        b.write_block(block_1, durability='hard')
-        b.write_block(block_2, durability='hard')
-        b.write_block(block_3, durability='hard')
+        b.write_block(block_1)
+        b.write_block(block_2)
+        b.write_block(block_3)
 
         # make sure all the votes are written with different timestamps
         monkeypatch.setattr('time.time', lambda: 4)
@@ -442,7 +442,7 @@ class TestBigchainApi(object):
 
         genesis = b.create_genesis_block()
         block_1 = dummy_block()
-        b.write_block(block_1, durability='hard')
+        b.write_block(block_1)
 
         b.write_vote(b.vote(block_1.id, genesis.id, True))
         retrieved_block_1 = b.get_block(block_1.id)
@@ -460,7 +460,7 @@ class TestBigchainApi(object):
 
         b.create_genesis_block()
         block_1 = dummy_block()
-        b.write_block(block_1, durability='hard')
+        b.write_block(block_1)
         # insert duplicate votes
         vote_1 = b.vote(block_1.id, b.get_last_voted_block().id, True)
         vote_2 = b.vote(block_1.id, b.get_last_voted_block().id, True)
@@ -478,7 +478,7 @@ class TestBigchainApi(object):
 
         genesis = b.create_genesis_block()
         block_1 = dummy_block()
-        b.write_block(block_1, durability='hard')
+        b.write_block(block_1)
         # insert duplicate votes
         for i in range(2):
             b.write_vote(b.vote(block_1.id, genesis.id, True))
@@ -498,7 +498,7 @@ class TestBigchainApi(object):
 
         b.create_genesis_block()
         block_1 = dummy_block()
-        b.write_block(block_1, durability='hard')
+        b.write_block(block_1)
         vote_1 = b.vote(block_1.id, b.get_last_voted_block().id, True)
         # mangle the signature
         vote_1['signature'] = 'a' * 87
@@ -638,7 +638,7 @@ class TestTransactionValidation(object):
 
         b.write_transaction(signed_transfer_tx)
         block = b.create_block([signed_transfer_tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         # vote block valid
         vote = b.vote(block.id, b.get_last_voted_block().id, True)
@@ -669,7 +669,7 @@ class TestTransactionValidation(object):
         # create block
         block = b.create_block([transfer_tx])
         assert b.validate_block(block) == block
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         # check that the transaction is still valid after being written to the
         # bigchain
@@ -693,7 +693,7 @@ class TestTransactionValidation(object):
 
         # create block
         block = b.create_block([transfer_tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         # create transaction with the undecided input
         tx_invalid = Transaction.transfer(transfer_tx.to_inputs(),
@@ -838,7 +838,7 @@ class TestMultipleInputs(object):
         tx = Transaction.create([b.me], [([user_pk, user2_pk], 1)])
         tx = tx.sign([b.me_private])
         block = b.create_block([tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         # vote block valid
         vote = b.vote(block.id, b.get_last_voted_block().id, True)
@@ -871,7 +871,7 @@ class TestMultipleInputs(object):
         tx = Transaction.create([b.me], [([user_pk, user2_pk], 1)])
         tx = tx.sign([b.me_private])
         block = b.create_block([tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         # vote block valid
         vote = b.vote(block.id, b.get_last_voted_block().id, True)
@@ -899,7 +899,7 @@ class TestMultipleInputs(object):
         tx = Transaction.create([b.me], [([user_pk], 1)])
         tx = tx.sign([b.me_private])
         block = b.create_block([tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         owned_inputs_user1 = b.get_owned_ids(user_pk)
         owned_inputs_user2 = b.get_owned_ids(user2_pk)
@@ -909,7 +909,7 @@ class TestMultipleInputs(object):
         tx = Transaction.transfer(tx.to_inputs(), [([user2_pk], 1)], tx.asset)
         tx = tx.sign([user_sk])
         block = b.create_block([tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         owned_inputs_user1 = b.get_owned_ids(user_pk)
         owned_inputs_user2 = b.get_owned_ids(user2_pk)
@@ -929,7 +929,7 @@ class TestMultipleInputs(object):
         tx = Transaction.create([b.me], [([user_pk], 1)])
         tx = tx.sign([b.me_private])
         block = b.create_block([tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         # vote the block VALID
         vote = b.vote(block.id, genesis.id, True)
@@ -946,7 +946,7 @@ class TestMultipleInputs(object):
                                           tx.asset)
         tx_invalid = tx_invalid.sign([user_sk])
         block = b.create_block([tx_invalid])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         # vote the block invalid
         vote = b.vote(block.id, b.get_last_voted_block().id, False)
@@ -974,7 +974,7 @@ class TestMultipleInputs(object):
                                        asset=asset)
         tx_create_signed = tx_create.sign([b.me_private])
         block = b.create_block([tx_create_signed])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         # get input
         owned_inputs_user1 = b.get_owned_ids(user_pk)
@@ -991,7 +991,7 @@ class TestMultipleInputs(object):
                                            asset=tx_create.asset)
         tx_transfer_signed = tx_transfer.sign([user_sk])
         block = b.create_block([tx_transfer_signed])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         owned_inputs_user1 = b.get_owned_ids(user_pk)
         owned_inputs_user2 = b.get_owned_ids(user2_pk)
@@ -1010,7 +1010,7 @@ class TestMultipleInputs(object):
         tx = Transaction.create([b.me], [([user_pk, user2_pk], 1)])
         tx = tx.sign([b.me_private])
         block = b.create_block([tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         owned_inputs_user1 = b.get_owned_ids(user_pk)
         owned_inputs_user2 = b.get_owned_ids(user2_pk)
@@ -1022,7 +1022,7 @@ class TestMultipleInputs(object):
         tx = Transaction.transfer(tx.to_inputs(), [([user3_pk], 1)], tx.asset)
         tx = tx.sign([user_sk, user2_sk])
         block = b.create_block([tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         owned_inputs_user1 = b.get_owned_ids(user_pk)
         owned_inputs_user2 = b.get_owned_ids(user2_pk)
@@ -1038,7 +1038,7 @@ class TestMultipleInputs(object):
         tx = Transaction.create([b.me], [([user_pk], 1)])
         tx = tx.sign([b.me_private])
         block = b.create_block([tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         owned_inputs_user1 = b.get_owned_ids(user_pk).pop()
 
@@ -1052,7 +1052,7 @@ class TestMultipleInputs(object):
         tx = Transaction.transfer(tx.to_inputs(), [([user2_pk], 1)], tx.asset)
         tx = tx.sign([user_sk])
         block = b.create_block([tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         spent_inputs_user1 = b.get_spent(input_txid, input_cid)
         assert spent_inputs_user1 == tx
@@ -1069,7 +1069,7 @@ class TestMultipleInputs(object):
         tx = Transaction.create([b.me], [([user_pk], 1)])
         tx = tx.sign([b.me_private])
         block = b.create_block([tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         # vote the block VALID
         vote = b.vote(block.id, genesis.id, True)
@@ -1087,7 +1087,7 @@ class TestMultipleInputs(object):
         tx = Transaction.transfer(tx.to_inputs(), [([user2_pk], 1)], tx.asset)
         tx = tx.sign([user_sk])
         block = b.create_block([tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         # vote the block invalid
         vote = b.vote(block.id, b.get_last_voted_block().id, False)
@@ -1116,7 +1116,7 @@ class TestMultipleInputs(object):
                                        asset=asset)
         tx_create_signed = tx_create.sign([b.me_private])
         block = b.create_block([tx_create_signed])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         owned_inputs_user1 = b.get_owned_ids(user_pk)
 
@@ -1130,7 +1130,7 @@ class TestMultipleInputs(object):
                                            asset=tx_create.asset)
         tx_transfer_signed = tx_transfer.sign([user_sk])
         block = b.create_block([tx_transfer_signed])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         # check that used inputs are marked as spent
         for ffill in tx_create.to_inputs()[:2]:
@@ -1157,7 +1157,7 @@ class TestMultipleInputs(object):
             tx = tx.sign([b.me_private])
             transactions.append(tx)
         block = b.create_block(transactions)
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         owned_inputs_user1 = b.get_owned_ids(user_pk)
 
@@ -1170,7 +1170,7 @@ class TestMultipleInputs(object):
                                   [([user3_pk], 1)], transactions[0].asset)
         tx = tx.sign([user_sk, user2_sk])
         block = b.create_block([tx])
-        b.write_block(block, durability='hard')
+        b.write_block(block)
 
         # check that used inputs are marked as spent
         assert b.get_spent(transactions[0].id, 0) == tx

--- a/tests/pipelines/test_election.py
+++ b/tests/pipelines/test_election.py
@@ -29,7 +29,7 @@ def test_check_for_quorum_invalid(b, user_pk):
 
     # split_vote (invalid)
     votes = [member.vote(test_block.id, 'abc', True) for member in test_federation[:2]] + \
-                   [member.vote(test_block.id, 'abc', False) for member in test_federation[2:]]
+            [member.vote(test_block.id, 'abc', False) for member in test_federation[2:]]
 
     # cast votes
     for vote in votes:
@@ -59,7 +59,7 @@ def test_check_for_quorum_invalid_prev_node(b, user_pk):
 
     # split vote over prev node
     votes = [member.vote(test_block.id, 'abc', True) for member in test_federation[:2]] + \
-                   [member.vote(test_block.id, 'def', True) for member in test_federation[2:]]
+            [member.vote(test_block.id, 'def', True) for member in test_federation[2:]]
 
     # cast votes
     for vote in votes:
@@ -111,10 +111,9 @@ def test_check_requeue_transaction(b, user_pk):
     e.requeue_transactions(test_block)
 
     backlog_tx, status = b.get_transaction(tx1.id, include_status=True)
-    #backlog_tx = b.connection.run(r.table('backlog').get(tx1.id))
+    # backlog_tx = b.connection.run(r.table('backlog').get(tx1.id))
     assert status == b.TX_IN_BACKLOG
     assert backlog_tx == tx1
-
 
 
 @patch.object(Pipeline, 'start')

--- a/tests/pipelines/test_election.py
+++ b/tests/pipelines/test_election.py
@@ -128,6 +128,7 @@ def test_start(mock_start):
 
 def test_full_pipeline(b, user_pk):
     import random
+    from bigchaindb.backend import query
     from bigchaindb.models import Transaction
 
     outpipe = Pipe()
@@ -169,8 +170,8 @@ def test_full_pipeline(b, user_pk):
 
     # only transactions from the invalid block should be returned to
     # the backlog
-    assert b.backend.count_backlog() == 100
+    assert query.count_backlog(b.connection) == 100
     # NOTE: I'm still, I'm still tx from the block.
     tx_from_block = set([tx.id for tx in invalid_block.transactions])
-    tx_from_backlog = set([tx['id'] for tx in list(b.backend.get_stale_transactions(0))])
+    tx_from_backlog = set([tx['id'] for tx in list(query.get_stale_transactions(b.connection, 0))])
     assert tx_from_block == tx_from_backlog

--- a/tests/pipelines/test_stale_monitor.py
+++ b/tests/pipelines/test_stale_monitor.py
@@ -10,7 +10,7 @@ def test_get_stale(b, user_pk):
     from bigchaindb.models import Transaction
     tx = Transaction.create([b.me], [([user_pk], 1)])
     tx = tx.sign([b.me_private])
-    b.write_transaction(tx, durability='hard')
+    b.write_transaction(tx)
 
     stm = stale.StaleTransactionMonitor(timeout=0.001,
                                         backlog_reassign_delay=0.001)
@@ -27,7 +27,7 @@ def test_reassign_transactions(b, user_pk):
     # test with single node
     tx = Transaction.create([b.me], [([user_pk], 1)])
     tx = tx.sign([b.me_private])
-    b.write_transaction(tx, durability='hard')
+    b.write_transaction(tx)
 
     stm = stale.StaleTransactionMonitor(timeout=0.001,
                                         backlog_reassign_delay=0.001)
@@ -36,7 +36,7 @@ def test_reassign_transactions(b, user_pk):
     # test with federation
     tx = Transaction.create([b.me], [([user_pk], 1)])
     tx = tx.sign([b.me_private])
-    b.write_transaction(tx, durability='hard')
+    b.write_transaction(tx)
 
     stm = stale.StaleTransactionMonitor(timeout=0.001,
                                         backlog_reassign_delay=0.001)
@@ -52,7 +52,7 @@ def test_reassign_transactions(b, user_pk):
     tx = Transaction.create([b.me], [([user_pk], 1)])
     tx = tx.sign([b.me_private])
     stm.bigchain.nodes_except_me = ['lol']
-    b.write_transaction(tx, durability='hard')
+    b.write_transaction(tx)
     stm.bigchain.nodes_except_me = None
 
     tx = list(b.backend.get_stale_transactions(0))[0]

--- a/tests/pipelines/test_stale_monitor.py
+++ b/tests/pipelines/test_stale_monitor.py
@@ -23,6 +23,7 @@ def test_get_stale(b, user_pk):
 
 
 def test_reassign_transactions(b, user_pk):
+    from bigchaindb.backend import query
     from bigchaindb.models import Transaction
     # test with single node
     tx = Transaction.create([b.me], [([user_pk], 1)])
@@ -41,10 +42,10 @@ def test_reassign_transactions(b, user_pk):
     stm = stale.StaleTransactionMonitor(timeout=0.001,
                                         backlog_reassign_delay=0.001)
     stm.bigchain.nodes_except_me = ['aaa', 'bbb', 'ccc']
-    tx = list(b.backend.get_stale_transactions(0))[0]
+    tx = list(query.get_stale_transactions(b.connection, 0))[0]
     stm.reassign_transactions(tx)
 
-    reassigned_tx = list(b.backend.get_stale_transactions(0))[0]
+    reassigned_tx = list(query.get_stale_transactions(b.connection, 0))[0]
     assert reassigned_tx['assignment_timestamp'] > tx['assignment_timestamp']
     assert reassigned_tx['assignee'] != tx['assignee']
 
@@ -55,12 +56,13 @@ def test_reassign_transactions(b, user_pk):
     b.write_transaction(tx)
     stm.bigchain.nodes_except_me = None
 
-    tx = list(b.backend.get_stale_transactions(0))[0]
+    tx = list(query.get_stale_transactions(b.connection, 0))[0]
     stm.reassign_transactions(tx)
     assert tx['assignee'] != 'lol'
 
 
 def test_full_pipeline(monkeypatch, user_pk):
+    from bigchaindb.backend import query
     from bigchaindb.models import Transaction
     CONFIG = {
         'database': {
@@ -87,7 +89,7 @@ def test_full_pipeline(monkeypatch, user_pk):
         original_txc.append(tx.to_dict())
 
         b.write_transaction(tx)
-    original_txs = list(b.backend.get_stale_transactions(0))
+    original_txs = list(query.get_stale_transactions(b.connection, 0))
     original_txs = {tx['id']: tx for tx in original_txs}
 
     assert len(original_txs) == 100
@@ -111,13 +113,14 @@ def test_full_pipeline(monkeypatch, user_pk):
 
     pipeline.terminate()
 
-    assert len(list(b.backend.get_stale_transactions(0))) == 100
-    reassigned_txs= list(b.backend.get_stale_transactions(0))
+    assert len(list(query.get_stale_transactions(b.connection, 0))) == 100
+    reassigned_txs = list(query.get_stale_transactions(b.connection, 0))
 
     # check that every assignment timestamp has increased, and every tx has a new assignee
     for reassigned_tx in reassigned_txs:
         assert reassigned_tx['assignment_timestamp'] > original_txs[reassigned_tx['id']]['assignment_timestamp']
         assert reassigned_tx['assignee'] != original_txs[reassigned_tx['id']]['assignee']
+
 
 @patch.object(Pipeline, 'start')
 def test_start(mock_start):

--- a/tests/pipelines/test_utils.py
+++ b/tests/pipelines/test_utils.py
@@ -1,56 +1,67 @@
-from unittest.mock import patch
+import pytest
+from unittest.mock import Mock
 
 from multipipes import Pipe
+from bigchaindb import Bigchain
 from bigchaindb.backend.connection import Connection
 from bigchaindb.pipelines.utils import ChangeFeed
 
 
-MOCK_CHANGEFEED_DATA = [{
-    'new_val': 'seems like we have an insert here',
-    'old_val': None,
-}, {
-    'new_val': None,
-    'old_val': 'seems like we have a delete here',
-}, {
-    'new_val': 'seems like we have an update here',
-    'old_val': 'seems like we have an update here',
-}]
+@pytest.fixture
+def mock_changefeed_data():
+    return [
+        {
+            'new_val': 'seems like we have an insert here',
+            'old_val': None,
+        }, {
+            'new_val': None,
+            'old_val': 'seems like we have a delete here',
+        }, {
+            'new_val': 'seems like we have an update here',
+            'old_val': 'seems like we have an update here',
+        }
+    ]
 
 
-@patch.object(Connection, 'run', return_value=MOCK_CHANGEFEED_DATA)
-def test_changefeed_insert(mock_run):
+@pytest.fixture
+def mock_changefeed_bigchain(mock_changefeed_data):
+    connection = Connection()
+    connection.run = Mock(return_value=mock_changefeed_data)
+    return Bigchain(connection=connection)
+
+
+def test_changefeed_insert(mock_changefeed_bigchain):
     outpipe = Pipe()
-    changefeed = ChangeFeed('backlog', ChangeFeed.INSERT)
+    changefeed = ChangeFeed('backlog', ChangeFeed.INSERT, bigchain=mock_changefeed_bigchain)
     changefeed.outqueue = outpipe
     changefeed.run_forever()
     assert outpipe.get() == 'seems like we have an insert here'
     assert outpipe.qsize() == 0
 
 
-@patch.object(Connection, 'run', return_value=MOCK_CHANGEFEED_DATA)
-def test_changefeed_delete(mock_run):
+def test_changefeed_delete(mock_changefeed_bigchain):
     outpipe = Pipe()
-    changefeed = ChangeFeed('backlog', ChangeFeed.DELETE)
+    changefeed = ChangeFeed('backlog', ChangeFeed.DELETE, bigchain=mock_changefeed_bigchain)
     changefeed.outqueue = outpipe
     changefeed.run_forever()
     assert outpipe.get() == 'seems like we have a delete here'
     assert outpipe.qsize() == 0
 
 
-@patch.object(Connection, 'run', return_value=MOCK_CHANGEFEED_DATA)
-def test_changefeed_update(mock_run):
+def test_changefeed_update(mock_changefeed_bigchain):
     outpipe = Pipe()
-    changefeed = ChangeFeed('backlog', ChangeFeed.UPDATE)
+    changefeed = ChangeFeed('backlog', ChangeFeed.UPDATE, bigchain=mock_changefeed_bigchain)
     changefeed.outqueue = outpipe
     changefeed.run_forever()
     assert outpipe.get() == 'seems like we have an update here'
     assert outpipe.qsize() == 0
 
 
-@patch.object(Connection, 'run', return_value=MOCK_CHANGEFEED_DATA)
-def test_changefeed_multiple_operations(mock_run):
+def test_changefeed_multiple_operations(mock_changefeed_bigchain):
     outpipe = Pipe()
-    changefeed = ChangeFeed('backlog', ChangeFeed.INSERT | ChangeFeed.UPDATE)
+    changefeed = ChangeFeed('backlog',
+                            ChangeFeed.INSERT | ChangeFeed.UPDATE,
+                            bigchain=mock_changefeed_bigchain)
     changefeed.outqueue = outpipe
     changefeed.run_forever()
     assert outpipe.get() == 'seems like we have an insert here'
@@ -58,10 +69,12 @@ def test_changefeed_multiple_operations(mock_run):
     assert outpipe.qsize() == 0
 
 
-@patch.object(Connection, 'run', return_value=MOCK_CHANGEFEED_DATA)
-def test_changefeed_prefeed(mock_run):
+def test_changefeed_prefeed(mock_changefeed_bigchain):
     outpipe = Pipe()
-    changefeed = ChangeFeed('backlog', ChangeFeed.INSERT, prefeed=[1, 2, 3])
+    changefeed = ChangeFeed('backlog',
+                            ChangeFeed.INSERT,
+                            prefeed=[1, 2, 3],
+                            bigchain=mock_changefeed_bigchain)
     changefeed.outqueue = outpipe
     changefeed.run_forever()
     assert outpipe.qsize() == 4

--- a/tests/pipelines/test_utils.py
+++ b/tests/pipelines/test_utils.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 from multipipes import Pipe
-from bigchaindb.db.utils import Connection
+from bigchaindb.backend.connection import Connection
 from bigchaindb.pipelines.utils import ChangeFeed
 
 

--- a/tests/pipelines/test_vote.py
+++ b/tests/pipelines/test_vote.py
@@ -270,7 +270,7 @@ def test_valid_block_voting_with_transfer_transactions(monkeypatch, b):
 
     monkeypatch.setattr('time.time', lambda: 1)
     block = b.create_block([tx])
-    b.write_block(block, durability='hard')
+    b.write_block(block)
 
     # create a `TRANSFER` transaction
     test_user2_priv, test_user2_pub = crypto.generate_key_pair()
@@ -280,7 +280,7 @@ def test_valid_block_voting_with_transfer_transactions(monkeypatch, b):
 
     monkeypatch.setattr('time.time', lambda: 2)
     block2 = b.create_block([tx2])
-    b.write_block(block2, durability='hard')
+    b.write_block(block2)
 
     inpipe = Pipe()
     outpipe = Pipe()
@@ -489,11 +489,11 @@ def test_voter_considers_unvoted_blocks_when_single_node(monkeypatch, b):
     monkeypatch.setattr('time.time', lambda: 2)
     block_1 = dummy_block(b)
     block_ids.append(block_1.id)
-    b.write_block(block_1, durability='hard')
+    b.write_block(block_1)
     monkeypatch.setattr('time.time', lambda: 3)
     block_2 = dummy_block(b)
     block_ids.append(block_2.id)
-    b.write_block(block_2, durability='hard')
+    b.write_block(block_2)
 
     vote_pipeline = vote.create_pipeline()
     vote_pipeline.setup(indata=vote.get_changefeed(), outdata=outpipe)
@@ -508,7 +508,7 @@ def test_voter_considers_unvoted_blocks_when_single_node(monkeypatch, b):
     monkeypatch.setattr('time.time', lambda: 4)
     block_3 = dummy_block(b)
     block_ids.append(block_3.id)
-    b.write_block(block_3, durability='hard')
+    b.write_block(block_3)
 
     # Same as before with the two `get`s
     outpipe.get()
@@ -534,12 +534,12 @@ def test_voter_chains_blocks_with_the_previous_ones(monkeypatch, b):
     monkeypatch.setattr('time.time', lambda: 2)
     block_1 = dummy_block(b)
     block_ids.append(block_1.id)
-    b.write_block(block_1, durability='hard')
+    b.write_block(block_1)
 
     monkeypatch.setattr('time.time', lambda: 3)
     block_2 = dummy_block(b)
     block_ids.append(block_2.id)
-    b.write_block(block_2, durability='hard')
+    b.write_block(block_2)
 
     vote_pipeline = vote.create_pipeline()
     vote_pipeline.setup(indata=vote.get_changefeed(), outdata=outpipe)

--- a/tests/pipelines/test_vote.py
+++ b/tests/pipelines/test_vote.py
@@ -179,7 +179,7 @@ def test_valid_block_voting_sequential(b, monkeypatch):
     serialized_vote = util.serialize(vote_doc['vote']).encode()
     assert vote_doc['node_pubkey'] == b.me
     assert crypto.PublicKey(b.me).verify(serialized_vote,
-                                            vote_doc['signature']) is True
+                                         vote_doc['signature']) is True
 
 
 def test_valid_block_voting_multiprocessing(b, monkeypatch):
@@ -214,7 +214,7 @@ def test_valid_block_voting_multiprocessing(b, monkeypatch):
     serialized_vote = util.serialize(vote_doc['vote']).encode()
     assert vote_doc['node_pubkey'] == b.me
     assert crypto.PublicKey(b.me).verify(serialized_vote,
-                                            vote_doc['signature']) is True
+                                         vote_doc['signature']) is True
 
 
 def test_valid_block_voting_with_create_transaction(b, monkeypatch):
@@ -256,7 +256,7 @@ def test_valid_block_voting_with_create_transaction(b, monkeypatch):
     serialized_vote = util.serialize(vote_doc['vote']).encode()
     assert vote_doc['node_pubkey'] == b.me
     assert crypto.PublicKey(b.me).verify(serialized_vote,
-                                            vote_doc['signature']) is True
+                                         vote_doc['signature']) is True
 
 
 def test_valid_block_voting_with_transfer_transactions(monkeypatch, b):
@@ -312,7 +312,7 @@ def test_valid_block_voting_with_transfer_transactions(monkeypatch, b):
     serialized_vote = util.serialize(vote_doc['vote']).encode()
     assert vote_doc['node_pubkey'] == b.me
     assert crypto.PublicKey(b.me).verify(serialized_vote,
-                                            vote_doc['signature']) is True
+                                         vote_doc['signature']) is True
 
     vote2_rs = query.get_votes_by_block_id_and_voter(b.connection, block2.id, b.me)
     vote2_doc = vote2_rs.next()
@@ -364,7 +364,7 @@ def test_unsigned_tx_in_block_voting(monkeypatch, b, user_pk):
     serialized_vote = util.serialize(vote_doc['vote']).encode()
     assert vote_doc['node_pubkey'] == b.me
     assert crypto.PublicKey(b.me).verify(serialized_vote,
-                                            vote_doc['signature']) is True
+                                         vote_doc['signature']) is True
 
 
 def test_invalid_id_tx_in_block_voting(monkeypatch, b, user_pk):
@@ -404,7 +404,7 @@ def test_invalid_id_tx_in_block_voting(monkeypatch, b, user_pk):
     serialized_vote = util.serialize(vote_doc['vote']).encode()
     assert vote_doc['node_pubkey'] == b.me
     assert crypto.PublicKey(b.me).verify(serialized_vote,
-                                            vote_doc['signature']) is True
+                                         vote_doc['signature']) is True
 
 
 def test_invalid_content_in_tx_in_block_voting(monkeypatch, b, user_pk):
@@ -444,7 +444,7 @@ def test_invalid_content_in_tx_in_block_voting(monkeypatch, b, user_pk):
     serialized_vote = util.serialize(vote_doc['vote']).encode()
     assert vote_doc['node_pubkey'] == b.me
     assert crypto.PublicKey(b.me).verify(serialized_vote,
-                                            vote_doc['signature']) is True
+                                         vote_doc['signature']) is True
 
 
 def test_invalid_block_voting(monkeypatch, b, user_pk):
@@ -480,7 +480,7 @@ def test_invalid_block_voting(monkeypatch, b, user_pk):
     serialized_vote = util.serialize(vote_doc['vote']).encode()
     assert vote_doc['node_pubkey'] == b.me
     assert crypto.PublicKey(b.me).verify(serialized_vote,
-                                            vote_doc['signature']) is True
+                                         vote_doc['signature']) is True
 
 
 def test_voter_considers_unvoted_blocks_when_single_node(monkeypatch, b):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,4 +1,3 @@
-import builtins
 import json
 from unittest.mock import Mock, patch
 from argparse import Namespace
@@ -216,7 +215,7 @@ def test_bigchain_run_init_when_db_exists(mock_db_init_with_existing_db):
     run_init(args)
 
 
-@patch('bigchaindb.schema.drop_database')
+@patch('bigchaindb.backend.schema.drop_database')
 def test_drop_db_when_assumed_yes(mock_db_drop):
     from bigchaindb.commands.bigchain import run_drop
     args = Namespace(config=None, yes=True)
@@ -225,21 +224,21 @@ def test_drop_db_when_assumed_yes(mock_db_drop):
     assert mock_db_drop.called
 
 
-@patch('bigchaindb.schema.drop_database')
+@patch('bigchaindb.backend.schema.drop_database')
 def test_drop_db_when_interactive_yes(mock_db_drop, monkeypatch):
     from bigchaindb.commands.bigchain import run_drop
     args = Namespace(config=None, yes=False)
-    monkeypatch.setattr(builtins, 'input', lambda x: 'y')
+    monkeypatch.setattr('bigchaindb.commands.bigchain.input', lambda x: 'y')
 
     run_drop(args)
     assert mock_db_drop.called
 
 
-@patch('bigchaindb.schema.drop_database')
+@patch('bigchaindb.backend.schema.drop_database')
 def test_drop_db_does_not_drop_when_interactive_no(mock_db_drop, monkeypatch):
     from bigchaindb.commands.bigchain import run_drop
     args = Namespace(config=None, yes=False)
-    monkeypatch.setattr(builtins, 'input', lambda x: 'n')
+    monkeypatch.setattr('bigchaindb.commands.bigchain.input', lambda x: 'n')
 
     run_drop(args)
     assert not mock_db_drop.called

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -137,6 +137,7 @@ def test_autoconfigure_read_both_from_file_and_env(monkeypatch):
             'threads': None,
         },
         'database': {
+            'backend': 'rethinkdb',
             'host': 'test-host',
             'port': 4242,
             'name': 'test-dbname',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -49,7 +49,7 @@ def test_bigchain_class_initialization_with_parameters(config):
         'keyring': ['key_one', 'key_two'],
     }
     connection = Connection()
-    bigchain = Bigchain(**init_kwargs, connection=connection)
+    bigchain = Bigchain(connection=connection, **init_kwargs)
     assert bigchain.connection == connection
     assert bigchain.me == init_kwargs['public_key']
     assert bigchain.me_private == init_kwargs['private_key']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -31,8 +31,12 @@ def config(request, monkeypatch):
 def test_bigchain_class_default_initialization(config):
     from bigchaindb.core import Bigchain
     from bigchaindb.consensus import BaseConsensusRules
+    from bigchaindb.backend.connection import Connection
     bigchain = Bigchain()
-    assert bigchain.connection
+    assert isinstance(bigchain.connection, Connection)
+    assert bigchain.connection.host == config['database']['host']
+    assert bigchain.connection.port == config['database']['port']
+    assert bigchain.connection.dbname == config['database']['name']
     assert bigchain.me == config['keypair']['public']
     assert bigchain.me_private == config['keypair']['private']
     assert bigchain.nodes_except_me == config['keyring']
@@ -41,16 +45,25 @@ def test_bigchain_class_default_initialization(config):
 
 def test_bigchain_class_initialization_with_parameters(config):
     from bigchaindb.core import Bigchain
-    from bigchaindb.backend.connection import Connection
+    from bigchaindb.backend import connect
     from bigchaindb.consensus import BaseConsensusRules
     init_kwargs = {
         'public_key': 'white',
         'private_key': 'black',
         'keyring': ['key_one', 'key_two'],
     }
-    connection = Connection()
+    init_db_kwargs = {
+        'backend': 'rethinkdb',
+        'host': 'this_is_the_db_host',
+        'port': 12345,
+        'name': 'this_is_the_db_name',
+    }
+    connection = connect(**init_db_kwargs)
     bigchain = Bigchain(connection=connection, **init_kwargs)
     assert bigchain.connection == connection
+    assert bigchain.connection.host == init_db_kwargs['host']
+    assert bigchain.connection.port == init_db_kwargs['port']
+    assert bigchain.connection.dbname == init_db_kwargs['name']
     assert bigchain.me == init_kwargs['public_key']
     assert bigchain.me_private == init_kwargs['private_key']
     assert bigchain.nodes_except_me == init_kwargs['keyring']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -62,12 +62,12 @@ def test_bigchain_class_initialization_with_parameters(config):
 
 
 def test_get_blocks_status_containing_tx(monkeypatch):
-    from bigchaindb.db.backends.rethinkdb import RethinkDBBackend
+    from bigchaindb.backend import query as backend_query
     from bigchaindb.core import Bigchain
     blocks = [
         {'id': 1}, {'id': 2}
     ]
-    monkeypatch.setattr(RethinkDBBackend, 'get_blocks_status_from_transaction', lambda x: blocks)
+    monkeypatch.setattr(backend_query, 'get_blocks_status_from_transaction', lambda x: blocks)
     monkeypatch.setattr(Bigchain, 'block_election_status', lambda x, y, z: Bigchain.BLOCK_VALID)
     bigchain = Bigchain(public_key='pubkey', private_key='privkey')
     with pytest.raises(Exception):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,6 +9,7 @@ import pytest
 def config(request, monkeypatch):
     config = {
         'database': {
+            'backend': 'rethinkdb',
             'host': 'host',
             'port': 28015,
             'name': 'bigchain',
@@ -44,9 +45,6 @@ def test_bigchain_class_initialization_with_parameters(config):
     from bigchaindb.core import Bigchain
     from bigchaindb.consensus import BaseConsensusRules
     init_kwargs = {
-        'host': 'some_node',
-        'port': '12345',
-        'dbname': 'atom',
         'public_key': 'white',
         'private_key': 'black',
         'keyring': ['key_one', 'key_two'],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -32,9 +32,7 @@ def test_bigchain_class_default_initialization(config):
     from bigchaindb.core import Bigchain
     from bigchaindb.consensus import BaseConsensusRules
     bigchain = Bigchain()
-    assert bigchain.host == config['database']['host']
-    assert bigchain.port == config['database']['port']
-    assert bigchain.dbname == config['database']['name']
+    assert bigchain.connection
     assert bigchain.me == config['keypair']['public']
     assert bigchain.me_private == config['keypair']['private']
     assert bigchain.nodes_except_me == config['keyring']
@@ -43,16 +41,16 @@ def test_bigchain_class_default_initialization(config):
 
 def test_bigchain_class_initialization_with_parameters(config):
     from bigchaindb.core import Bigchain
+    from bigchaindb.backend.connection import Connection
     from bigchaindb.consensus import BaseConsensusRules
     init_kwargs = {
         'public_key': 'white',
         'private_key': 'black',
         'keyring': ['key_one', 'key_two'],
     }
-    bigchain = Bigchain(**init_kwargs)
-    assert bigchain.host == init_kwargs['host']
-    assert bigchain.port == init_kwargs['port']
-    assert bigchain.dbname == init_kwargs['dbname']
+    connection = Connection()
+    bigchain = Bigchain(**init_kwargs, connection=connection)
+    assert bigchain.connection == connection
     assert bigchain.me == init_kwargs['public_key']
     assert bigchain.me_private == init_kwargs['private_key']
     assert bigchain.nodes_except_me == init_kwargs['keyring']

--- a/tests/test_run_query_util.py
+++ b/tests/test_run_query_util.py
@@ -3,11 +3,11 @@ import pytest
 
 import rethinkdb as r
 
-from bigchaindb.db.utils import Connection
+from bigchaindb.backend import connect
 
 
 def test_run_a_simple_query():
-    conn = Connection()
+    conn = connect()
     query = r.expr('1')
     assert conn.run(query) == '1'
 
@@ -17,7 +17,7 @@ def test_raise_exception_when_max_tries():
         def run(self, conn):
             raise r.ReqlDriverError('mock')
 
-    conn = Connection()
+    conn = connect()
 
     with pytest.raises(r.ReqlDriverError):
         conn.run(MockQuery())
@@ -30,7 +30,7 @@ def test_reconnect_when_connection_lost():
     def raise_exception(*args, **kwargs):
         raise r.ReqlDriverError('mock')
 
-    conn = Connection()
+    conn = connect()
     original_connect = r.connect
     r.connect = raise_exception
 
@@ -74,7 +74,6 @@ def test_changefeed_reconnects_when_connection_lost(monkeypatch):
                          'old_val': None }
             else:
                 time.sleep(10)
-
 
     bigchain = Bigchain()
     bigchain.connection = MockConnection()


### PR DESCRIPTION
Based on merging #895 and #896 into #788.

All tests are a go with Rethinkdb 🚨  (some tests are still coupled to Rethinkdb, but this will be done in the future).