### PR TITLE
Add option to switch backend

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,15 @@ USER_PRIVATE_KEY = '8eJ8q9ZQpReWyQT5aFCiwtZ5wDZC4eDnCen88p3tQ6ie'
 USER_PUBLIC_KEY = 'JEAkEJqLbbgDRAtMm8YAjGp759Aq2qTn9eaEHUj2XePE'
 
 
+def pytest_addoption(parser):
+    from bigchaindb.backend import connection
+
+    backends = ', '.join(connection.BACKENDS.keys())
+
+    parser.addoption('--database-backend', action='store', default='rethinkdb',
+                     help='Defines the backend to use (available: {})'.format(backends))
+
+
 # We need this function to avoid loading an existing
 # conf file located in the home of the user running
 # the tests. If it's too aggressive we can change it
@@ -48,8 +57,10 @@ def restore_config(request, node_config):
 
 
 @pytest.fixture(scope='module')
-def node_config():
-    return copy.deepcopy(CONFIG)
+def node_config(request):
+    config = copy.deepcopy(CONFIG)
+    config['database']['backend'] = request.config.getoption('--database-backend')
+    return config
 
 
 @pytest.fixture


### PR DESCRIPTION
I've added a new `--database-backend` option to py.test, so we can run the whole suite of tests on different backends. This is just a proposal and it **should** work. IMO we can integrate it soon because we need the `backend` key anyway.