### PR TITLE
Broken integration test

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -44,3 +44,35 @@ def test_double_create(b, user_pk):
     last_voted_block = b.get_last_voted_block()
     assert len(last_voted_block.transactions) == 1
     assert count_blocks(b.connection) == 2
+
+
+@pytest.mark.usefixtures('processes', 'inputs')
+def test_get_owned_ids_works_after_double_spend(b, user_pk, user_sk):
+    """See issue 633."""
+    from bigchaindb.models import Transaction
+    input_valid = b.get_owned_ids(user_pk).pop()
+    input_valid = b.get_transaction(input_valid.txid)
+    tx_valid = Transaction.transfer(input_valid.to_inputs(),
+                                    [([user_pk], 1)],
+                                    input_valid.asset).sign([user_sk])
+
+    # write the valid tx and wait for voting/block to catch up
+    b.write_transaction(tx_valid)
+    time.sleep(2)
+
+    # doesn't throw an exception
+    b.get_owned_ids(user_pk)
+
+    # create another transaction with the same input
+    tx_double_spend = Transaction.transfer(input_valid.to_inputs(),
+                                           [([user_pk], 1)],
+                                           input_valid.asset) \
+                                 .sign([user_sk])
+
+    # write the double spend tx
+    b.write_transaction(tx_double_spend)
+    time.sleep(2)
+
+    # still doesn't throw an exception
+    b.get_owned_ids(user_pk)
+    assert b.is_valid_transaction(tx_double_spend) is False

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -46,15 +46,16 @@ def test_double_create(b, user_pk):
     assert count_blocks(b.connection) == 2
 
 
-@pytest.mark.usefixtures('processes', 'inputs')
+@pytest.mark.usefixtures('inputs')
 def test_get_owned_ids_works_after_double_spend(b, user_pk, user_sk):
-    """See issue 633."""
+    """ Test for #633 https://github.com/bigchaindb/bigchaindb/issues/633 """
     from bigchaindb.models import Transaction
     input_valid = b.get_owned_ids(user_pk).pop()
     input_valid = b.get_transaction(input_valid.txid)
     tx_valid = Transaction.transfer(input_valid.to_inputs(),
                                     [([user_pk], 1)],
-                                    input_valid.asset).sign([user_sk])
+                                    input_valid.id,
+                                    {'1': 1}).sign([user_sk])
 
     # write the valid tx and wait for voting/block to catch up
     b.write_transaction(tx_valid)
@@ -66,8 +67,8 @@ def test_get_owned_ids_works_after_double_spend(b, user_pk, user_sk):
     # create another transaction with the same input
     tx_double_spend = Transaction.transfer(input_valid.to_inputs(),
                                            [([user_pk], 1)],
-                                           input_valid.asset) \
-                                 .sign([user_sk])
+                                           input_valid.id,
+                                           {'2': 2}).sign([user_sk])
 
     # write the double spend tx
     b.write_transaction(tx_double_spend)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -49,6 +49,7 @@ def test_double_create(b, user_pk):
 @pytest.mark.usefixtures('inputs')
 def test_get_owned_ids_works_after_double_spend(b, user_pk, user_sk):
     """ Test for #633 https://github.com/bigchaindb/bigchaindb/issues/633 """
+    from bigchaindb.common.exceptions import DoubleSpend
     from bigchaindb.models import Transaction
     input_valid = b.get_owned_ids(user_pk).pop()
     input_valid = b.get_transaction(input_valid.txid)
@@ -76,4 +77,5 @@ def test_get_owned_ids_works_after_double_spend(b, user_pk, user_sk):
 
     # still doesn't throw an exception
     b.get_owned_ids(user_pk)
-    assert b.is_valid_transaction(tx_double_spend) is False
+    with pytest.raises(DoubleSpend):
+        b.validate_transaction(tx_double_spend)


### PR DESCRIPTION
See issue #633 and PR #614.  Basically, a doublespend test that worked before doesn't work anymore.

As far as I can tell, no doublespend occurs (i.e. no duplicate tx in bigchain)

To repeat, though, **a doublespend exception should be raised in this test but isn't**