### PR TITLE
Add tox usage to testing docs

### DIFF
--- a/PYTHON_STYLE_GUIDE.md
+++ b/PYTHON_STYLE_GUIDE.md
@@ -96,6 +96,27 @@ python setup.py test
 
 If you want to learn about all the things you can do with pytest, see [the pytest documentation](http://pytest.org/latest/).
 
+### Tox
+
+We use [tox](https://tox.readthedocs.io/en/latest/) to run multiple suites of tests against multiple environments during automated testing. Generally you don't need to run this yourself, but it might be useful when troubleshooting a failing CI build.
+
+To run all the tox tests, use:
+```bash
+tox
+```
+
+or:
+```bash
+python -m tox
+```
+
+To run only a few environments, use the `-e` flag:
+```bash
+tox -e {ENVLIST}
+```
+
+where `{ENVLIST}` is one or more of the environments specified in the [tox.ini file](tox.ini).
+
 ### Automated testing of pull requests
 
 We use [Travis CI](https://travis-ci.com/), so that whenever someone creates a new BigchainDB pull request on GitHub, Travis CI gets the new code and does _a bunch of stuff_. You can find out what we tell Travis CI to do in [the `.travis.yml` file](.travis.yml): it tells Travis CI how to install BigchainDB, how to run all the tests, and what to do "after success" (e.g. run `codecov`). (We use [Codecov](https://codecov.io/) to get a rough estimate of our test coverage.)

--- a/PYTHON_STYLE_GUIDE.md
+++ b/PYTHON_STYLE_GUIDE.md
@@ -96,4 +96,6 @@ python setup.py test
 
 If you want to learn about all the things you can do with pytest, see [the pytest documentation](http://pytest.org/latest/).
 
-**Automated testing of pull requests.** We use [Travis CI](https://travis-ci.com/), so that whenever someone creates a new BigchainDB pull request on GitHub, Travis CI gets the new code and does _a bunch of stuff_. You can find out what we tell Travis CI to do in [the `.travis.yml` file](.travis.yml): it tells Travis CI how to install BigchainDB, how to run all the tests, and what to do "after success" (e.g. run `codecov`). (We use [Codecov](https://codecov.io/) to get a rough estimate of our test coverage.)
+### Automated testing of pull requests
+
+We use [Travis CI](https://travis-ci.com/), so that whenever someone creates a new BigchainDB pull request on GitHub, Travis CI gets the new code and does _a bunch of stuff_. You can find out what we tell Travis CI to do in [the `.travis.yml` file](.travis.yml): it tells Travis CI how to install BigchainDB, how to run all the tests, and what to do "after success" (e.g. run `codecov`). (We use [Codecov](https://codecov.io/) to get a rough estimate of our test coverage.)

--- a/PYTHON_STYLE_GUIDE.md
+++ b/PYTHON_STYLE_GUIDE.md
@@ -73,13 +73,13 @@ flake8 --max-line-length 119 bigchaindb/
 ```
 
 
-## Writing and Running (Python) Unit Tests
+## Writing and Running (Python) Tests
 
-We write unit tests for our Python code using the [pytest](http://pytest.org/latest/) framework.
+We write unit and integration tests for our Python code using the [pytest](http://pytest.org/latest/) framework.
 
 All tests go in the `bigchaindb/tests` directory or one of its subdirectories. You can use the tests already in there as templates or examples.
 
-You can run all unit tests using:
+You can run all tests using:
 ```bash
 py.test -v
 ```

--- a/PYTHON_STYLE_GUIDE.md
+++ b/PYTHON_STYLE_GUIDE.md
@@ -68,7 +68,7 @@ we use the `format()` version. The [official Python documentation says](https://
 ## Runnng the Flake8 Style Checker
 
 We use [Flake8](http://flake8.pycqa.org/en/latest/index.html) to check our Python code style. Once you have it installed, you can run it using:
-```text
+```bash
 flake8 --max-line-length 119 bigchaindb/
 ```
 
@@ -80,17 +80,17 @@ We write unit tests for our Python code using the [pytest](http://pytest.org/lat
 All tests go in the `bigchaindb/tests` directory or one of its subdirectories. You can use the tests already in there as templates or examples.
 
 You can run all unit tests using:
-```text
+```bash
 py.test -v
 ```
 
 or, if that doesn't work, try:
-```text
+```bash
 python -m pytest -v
 ```
 
 or:
-```text
+```bash
 python setup.py test
 ```
 

--- a/PYTHON_STYLE_GUIDE.md
+++ b/PYTHON_STYLE_GUIDE.md
@@ -68,7 +68,7 @@ we use the `format()` version. The [official Python documentation says](https://
 ## Runnng the Flake8 Style Checker
 
 We use [Flake8](http://flake8.pycqa.org/en/latest/index.html) to check our Python code style. Once you have it installed, you can run it using:
-```bash
+```text
 flake8 --max-line-length 119 bigchaindb/
 ```
 
@@ -80,17 +80,17 @@ We write unit and integration tests for our Python code using the [pytest](http:
 All tests go in the `bigchaindb/tests` directory or one of its subdirectories. You can use the tests already in there as templates or examples.
 
 You can run all tests using:
-```bash
+```text
 py.test -v
 ```
 
 or, if that doesn't work, try:
-```bash
+```text
 python -m pytest -v
 ```
 
 or:
-```bash
+```text
 python setup.py test
 ```
 
@@ -101,17 +101,17 @@ If you want to learn about all the things you can do with pytest, see [the pytes
 We use [tox](https://tox.readthedocs.io/en/latest/) to run multiple suites of tests against multiple environments during automated testing. Generally you don't need to run this yourself, but it might be useful when troubleshooting a failing CI build.
 
 To run all the tox tests, use:
-```bash
+```text
 tox
 ```
 
 or:
-```bash
+```text
 python -m tox
 ```
 
 To run only a few environments, use the `-e` flag:
-```bash
+```text
 tox -e {ENVLIST}
 ```
 


### PR DESCRIPTION
Adds some notes about tox usage now that https://github.com/bigchaindb/bigchaindb/pull/907 has been merged.