### PR TITLE
[Proposal]: Suggest starting multi-line imports on the next line to pass flake8

### DIFF
--- a/PYTHON_STYLE_GUIDE.md
+++ b/PYTHON_STYLE_GUIDE.md
@@ -47,8 +47,15 @@ It seems the preference is for slashes, but using parentheses is okay too. (Ther
 
 If you need to `import` lots of names from a module or package, and they won't all fit in one line (without making the line too long), then use parentheses to spread the names across multiple lines, like so:
 ```python
+from Tkinter import (
+    Tk, Frame, Button, Entry, Canvas, Text,
+    LEFT, DISABLED, NORMAL, RIDGE, END,
+)
+
+# Or
+
 from Tkinter import (Tk, Frame, Button, Entry, Canvas, Text,
-    LEFT, DISABLED, NORMAL, RIDGE, END)
+                     LEFT, DISABLED, NORMAL, RIDGE, END)
 ```
 
 For the rationale, see [PEP 328](https://www.python.org/dev/peps/pep-0328/#rationale-for-parentheses).


### PR DESCRIPTION
@libscott found out that our [current recommendation for multi-line imports in the style guide](https://github.com/bigchaindb/bigchaindb/blob/master/PYTHON_STYLE_GUIDE.md#how-to-format-long-import-statements) will cause a flake8 error. If we do want to keep the import on the same line, it should be intended to where the brace starts:

 ```python
 from Tkinter import (Tk, Frame, Button, Entry, Canvas, Text,
                      LEFT, DISABLED, NORMAL, RIDGE, END)
```

However, I think it usually looks nicer if the imports just start on the next line (either grouped or each import in each line):

```python
 from Tkinter import (
     Tk, Frame, Button, Entry, Canvas, Text,
     LEFT, DISABLED, NORMAL, RIDGE, END,
)
 ```

I've left both as options.