### PR TITLE
Treat warnings as errors in documentation builds

### DIFF
--- a/docs/root/Makefile
+++ b/docs/root/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build

--- a/docs/server/Makefile
+++ b/docs/server/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build


### PR DESCRIPTION
This will cause the build to fail if the documentation contains any warnings, like an invalid section reference. The tests will now fail if the docs dont build without warnings: https://github.com/bigchaindb/bigchaindb/blob/master/tests/test_docs.py. This is both during travis build and locally.