### PR TITLE
[Spec] [WIP] Remove Input.owners_before

### DIFF
--- a/bigchaindb/common/schema/transaction.yaml
+++ b/bigchaindb/common/schema/transaction.yaml
@@ -179,14 +179,9 @@ definitions:
       ``CREATE`` transaction, a fulfillment may provide no ``input``.
     additionalProperties: false
     required:
-    - owners_before
     - input
     - fulfillment
     properties:
-      owners_before:
-        "$ref": "#/definitions/owners_list"
-        description: |
-            List of public keys of the previous owners of the asset.
       fulfillment:
         anyOf:
         - type: object


### PR DESCRIPTION
"owners_before" is inaccurate and perhaps also unneccesary, we should consider removing it. However, in the case of a threshold condition with `m` public keys it is useful to indicate which `n` keys were involved in fulfillment.

Questions:

* Does there exist a function: `did_sign(signature, pubkey)` which would indicate if a key was involved in a signature?
* From a product perspective (@TimDaub), do we need to keep the list of people that signed, perhaps for the purposes of auditability?
* If we do, how can we be sure that the list of public keys given in `owners_after` is actually the real list? The signatorys could enter the wrong list, so perhaps it's meaningless. And, if it's verifiable via a `did_sign` method as described above, we don't need it because we have the list of `m` keys in the `output`, alongside the condition.
* Speaking of which, I suppose that list is not verified either, what are the implications?


