### PR TITLE
Extra renames and small fixes for inputs-outputs

### DIFF
--- a/bigchaindb/common/schema/transaction.yaml
+++ b/bigchaindb/common/schema/transaction.yaml
@@ -173,8 +173,8 @@ definitions:
   input:
     type: "object"
     description:
-      An input spends a previous output, by providing a fulfillment to the output's
-      condition.
+      An input spends a previous output, by providing one or more fulfillments
+      that fulfill the conditions of the previous output.
     additionalProperties: false
     required:
     - owners_before

--- a/bigchaindb/common/schema/transaction.yaml
+++ b/bigchaindb/common/schema/transaction.yaml
@@ -220,7 +220,7 @@ definitions:
             idx:
               "$ref": "#/definitions/offset"
               description: |
-                Index of the condition (in the output) being fulfilled
+                Index of the output containing the condition being fulfilled
             txid:
               "$ref": "#/definitions/sha3_hexdigest"
               description: |

--- a/bigchaindb/common/schema/transaction.yaml
+++ b/bigchaindb/common/schema/transaction.yaml
@@ -219,8 +219,12 @@ definitions:
           properties:
             idx:
               "$ref": "#/definitions/offset"
+              description: |
+                Index of the condition (in the output) being fulfilled
             txid:
               "$ref": "#/definitions/sha3_hexdigest"
+              description: |
+                Transaction ID containing the output to spend
         - type: 'null'
   metadata:
     anyOf:

--- a/bigchaindb/common/schema/transaction.yaml
+++ b/bigchaindb/common/schema/transaction.yaml
@@ -133,8 +133,8 @@ definitions:
   output:
     type: object
     description: |
-        A transaction output. Describes a quantity of an asset and a locking
-        script to spend the output.
+        A transaction output. Describes the quantity of an asset and the
+        requirements that must be met to spend the output.
 
         See also: Input_.
     additionalProperties: false

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -137,7 +137,7 @@ class TransactionLink(object):
     """
 
     def __init__(self, txid=None, idx=None):
-        """Used to point to a specific Condition of a Transaction.
+        """Create an instance of a :class:`~.TransactionLink`.
 
             Note:
                 In an IPLD implementation, this class is not necessary anymore,
@@ -202,7 +202,7 @@ class Output(object):
     """
 
     def __init__(self, fulfillment, public_keys=None, amount=1):
-        """Condition shims a Cryptocondition condition for BigchainDB.
+        """Create an instance of a :class:`~.Output`.
 
             Args:
                 fulfillment (:class:`cryptoconditions.Fulfillment`): A
@@ -513,7 +513,7 @@ class AssetLink(Asset):
     """
 
     def __init__(self, data_id=None):
-        """Used to point to a specific Asset.
+        """Create an instance of a :class:`~.AssetLink`.
 
             Args:
                 data_id (str): A Asset to link to.

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -16,6 +16,8 @@ from bigchaindb.common.util import serialize, gen_timestamp
 class Input(object):
     """A Input is used to spend assets locked by an Output.
 
+    Wraps around a Crypto-condition Fulfillment.
+
         Attributes:
             fulfillment (:class:`cryptoconditions.Fulfillment`): A Fulfillment
                 to be signed with a private key.
@@ -27,7 +29,7 @@ class Input(object):
     """
 
     def __init__(self, fulfillment, owners_before, fulfills=None):
-        """Fulfillment shims a Cryptocondition Fulfillment for BigchainDB.
+        """Create an instance of an :class:`~.Input`.
 
             Args:
                 fulfillment (:class:`cryptoconditions.Fulfillment`): A
@@ -104,7 +106,7 @@ class Input(object):
                 Fulfillment that is not yet signed.
 
             Args:
-                data (dict): The Fulfillment to be transformed.
+                data (dict): The Input to be transformed.
 
             Returns:
                 :class:`~bigchaindb.common.transaction.Input`
@@ -591,7 +593,7 @@ class Transaction(object):
                 asset (:class:`~bigchaindb.common.transaction.Asset`): An Asset
                     to be transferred or created in a Transaction.
                 inputs (:obj:`list` of :class:`~bigchaindb.common.
-                    transaction.Fulfillment`, optional): Define the assets to
+                    transaction.Input`, optional): Define the assets to
                     spend.
                 outputs (:obj:`list` of :class:`~bigchaindb.common.
                     transaction.Condition`, optional): Define the assets to
@@ -792,7 +794,7 @@ class Transaction(object):
         """Adds an input to a Transaction's list of inputs.
 
             Args:
-                fulfillment (:class:`~bigchaindb.common.transaction.
+                input_ (:class:`~bigchaindb.common.transaction.
                     Input`): An Input to be added to the Transaction.
         """
         if not isinstance(input_, Input):

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -128,7 +128,7 @@ class Input(object):
 
 
 class TransactionLink(object):
-    """An object for unidirectional linking to a Transaction's Condition.
+    """An object for unidirectional linking to a Transaction's Output.
 
         Attributes:
             txid (str, optional): A Transaction to link to.
@@ -194,6 +194,8 @@ class TransactionLink(object):
 class Output(object):
     """An Output is used to lock an asset.
 
+    Wraps around a Crypto-condition Condition.
+
         Attributes:
             fulfillment (:class:`cryptoconditions.Fulfillment`): A Fulfillment
                 to extract a Condition from.
@@ -210,7 +212,7 @@ class Output(object):
                 public_keys (:obj:`list` of :obj:`str`, optional): A list of
                     owners before a Transaction was confirmed.
                 amount (int): The amount of Assets to be locked with this
-                    Condition.
+                    Output.
 
             Raises:
                 TypeError: if `public_keys` is not instance of `list`.
@@ -259,7 +261,7 @@ class Output(object):
 
     @classmethod
     def generate(cls, public_keys, amount):
-        """Generates a Condition from a specifically formed tuple or list.
+        """Generates a Output from a specifically formed tuple or list.
 
             Note:
                 If a ThresholdCondition has to be generated where the threshold
@@ -272,10 +274,10 @@ class Output(object):
                 public_keys (:obj:`list` of :obj:`str`): The public key of
                     the users that should be able to fulfill the Condition
                     that is being created.
-                amount (:obj:`int`): The amount locked by the condition.
+                amount (:obj:`int`): The amount locked by the Output.
 
             Returns:
-                A Condition that can be used in a Transaction.
+                An Output that can be used in a Transaction.
 
             Raises:
                 TypeError: If `public_keys` is not an instance of `list`.
@@ -310,7 +312,7 @@ class Output(object):
             Note:
                 This method is intended only to be used with a reduce function.
                 For a description on how to use this method, see
-                `Condition.generate`.
+                :meth:`~.Output.generate`.
 
             Args:
                 initial (:class:`cryptoconditions.ThresholdSha256Fulfillment`):
@@ -596,7 +598,7 @@ class Transaction(object):
                     transaction.Input`, optional): Define the assets to
                     spend.
                 outputs (:obj:`list` of :class:`~bigchaindb.common.
-                    transaction.Condition`, optional): Define the assets to
+                    transaction.Output`, optional): Define the assets to
                     lock.
                 metadata (dict):
                     Metadata to be stored along with the Transaction.
@@ -635,7 +637,7 @@ class Transaction(object):
         # for transactions other then CREATE we only have an id so there is
         # nothing we can validate
         if self.operation == self.CREATE:
-            amount = sum([condition.amount for condition in self.outputs])
+            amount = sum([output.amount for output in self.outputs])
             self.asset.validate_asset(amount=amount)
 
     @classmethod

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -1027,9 +1027,10 @@ class Transaction(object):
             tx_dict = Transaction._remove_signatures(tx_dict)
             tx_serialized = Transaction._to_str(tx_dict)
 
-            # TODO: Use local reference to class, not `Transaction.`
-            return Transaction._input_valid(input, self.operation,
-                                            tx_serialized, output_condition_uri)
+            return self.__class__._input_valid(input,
+                                               self.operation,
+                                               tx_serialized,
+                                               output_condition_uri)
 
         partial_transactions = map(gen_tx, self.inputs,
                                    self.outputs, output_condition_uris)

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -970,7 +970,7 @@ class Transaction(object):
 
             Note:
                 Given a `CREATE` or `GENESIS` Transaction is passed,
-                dummyvalues for Outputs are submitted for validation that
+                dummy values for Outputs are submitted for validation that
                 evaluate parts of the validation-checks to `True`.
 
             Args:
@@ -1061,7 +1061,7 @@ class Transaction(object):
 
         if operation in (Transaction.CREATE, Transaction.GENESIS):
             # NOTE: In the case of a `CREATE` or `GENESIS` transaction, the
-            #       output is always validate to `True`.
+            #       output is always valid.
             output_valid = True
         else:
             output_valid = output_uri == ccffill.condition_uri

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -2,8 +2,8 @@ from copy import deepcopy
 from functools import reduce
 from uuid import uuid4
 
-from cryptoconditions import (Fulfillment as CCFulfillment,
-                              ThresholdSha256Fulfillment, Ed25519Fulfillment)
+from cryptoconditions import (Fulfillment, ThresholdSha256Fulfillment,
+                              Ed25519Fulfillment)
 from cryptoconditions.exceptions import ParsingError
 
 from bigchaindb.common.crypto import PrivateKey, hash_data
@@ -113,14 +113,14 @@ class Input(object):
                 InvalidSignature: If an Input's URI couldn't be parsed.
         """
         try:
-            fulfillment = CCFulfillment.from_uri(data['fulfillment'])
+            fulfillment = Fulfillment.from_uri(data['fulfillment'])
         except ValueError:
             # TODO FOR CC: Throw an `InvalidSignature` error in this case.
             raise InvalidSignature("Fulfillment URI couldn't been parsed")
         except TypeError:
             # NOTE: See comment about this special case in
             #       `Input.to_dict`
-            fulfillment = CCFulfillment.from_dict(data['fulfillment'])
+            fulfillment = Fulfillment.from_dict(data['fulfillment'])
         fulfills = TransactionLink.from_dict(data['fulfills'])
         return cls(fulfillment, data['owners_before'], fulfills)
 
@@ -365,7 +365,7 @@ class Output(object):
                 :class:`~bigchaindb.common.transaction.Output`
         """
         try:
-            fulfillment = CCFulfillment.from_dict(data['condition']['details'])
+            fulfillment = Fulfillment.from_dict(data['condition']['details'])
         except KeyError:
             # NOTE: Hashlock condition case
             fulfillment = data['condition']['uri']
@@ -1058,7 +1058,7 @@ class Transaction(object):
         """
         ccffill = input_.fulfillment
         try:
-            parsed_ffill = CCFulfillment.from_uri(ccffill.serialize_uri())
+            parsed_ffill = Fulfillment.from_uri(ccffill.serialize_uri())
         except (TypeError, ValueError, ParsingError):
             return False
 

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -195,7 +195,7 @@ class Output(object):
         Attributes:
             fulfillment (:class:`cryptoconditions.Fulfillment`): A Fulfillment
                 to extract a Condition from.
-            owners_after (:obj:`list` of :obj:`str`, optional): A list of
+            public_keys (:obj:`list` of :obj:`str`, optional): A list of
                 owners before a Transaction was confirmed.
     """
 
@@ -302,7 +302,7 @@ class Output(object):
             return cls(threshold_cond, public_keys, amount=amount)
 
     @classmethod
-    def _gen_condition(cls, initial, current):
+    def _gen_condition(cls, initial, new_public_keys):
         """Generates ThresholdSha256 conditions from a list of new owners.
 
             Note:
@@ -313,38 +313,37 @@ class Output(object):
             Args:
                 initial (:class:`cryptoconditions.ThresholdSha256Fulfillment`):
                     A Condition representing the overall root.
-                current (:obj:`list` of :obj:`str`|str): A list of new owners
-                    or a single new owner.
+                new_public_keys (:obj:`list` of :obj:`str`|str): A list of new
+                    owners or a single new owner.
 
             Returns:
                 :class:`cryptoconditions.ThresholdSha256Fulfillment`:
         """
-        owners_after = current
         try:
-            threshold = len(owners_after)
+            threshold = len(new_public_keys)
         except TypeError:
             threshold = None
 
-        if isinstance(owners_after, list) and len(owners_after) > 1:
+        if isinstance(new_public_keys, list) and len(new_public_keys) > 1:
             ffill = ThresholdSha256Fulfillment(threshold=threshold)
-            reduce(cls._gen_condition, owners_after, ffill)
-        elif isinstance(owners_after, list) and len(owners_after) <= 1:
+            reduce(cls._gen_condition, new_public_keys, ffill)
+        elif isinstance(new_public_keys, list) and len(new_public_keys) <= 1:
             raise ValueError('Sublist cannot contain single owner')
         else:
             try:
-                owners_after = owners_after.pop()
+                new_public_keys = new_public_keys.pop()
             except AttributeError:
                 pass
             try:
-                ffill = Ed25519Fulfillment(public_key=owners_after)
+                ffill = Ed25519Fulfillment(public_key=new_public_keys)
             except TypeError:
                 # NOTE: Instead of submitting base58 encoded addresses, a user
                 #       of this class can also submit fully instantiated
-                #       Cryptoconditions. In the case of casting `owners_after`
-                #       to a Ed25519Fulfillment with the result of a
-                #       `TypeError`, we're assuming that `owners_after` is a
-                #       Cryptocondition then.
-                ffill = owners_after
+                #       Cryptoconditions. In the case of casting
+                #       `new_public_keys` to a Ed25519Fulfillment with the
+                #       result of a `TypeError`, we're assuming that
+                #       `new_public_keys` is a Cryptocondition then.
+                ffill = new_public_keys
         initial.add_subfulfillment(ffill)
         return initial
 

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -777,6 +777,8 @@ class Transaction(object):
                 :obj:`list` of :class:`~bigchaindb.common.transaction.
                     Input`
         """
+        # NOTE: If no indices are passed, we just assume to take all outputs
+        #       as inputs.
         indices = indices or range(len(self.outputs))
         return [
             Input(self.outputs[idx].fulfillment,

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -998,26 +998,26 @@ class Transaction(object):
             raise TypeError('`operation` must be one of {}'
                             .format(allowed_ops))
 
-    def _inputs_valid(self, output_uris):
+    def _inputs_valid(self, output_condition_uris):
         """Validates an Input against a given set of Outputs.
 
             Note:
-                The number of `output_uris` must be equal to the
+                The number of `output_condition_uris` must be equal to the
                 number of Inputs a Transaction has.
 
             Args:
-                output_uris (:obj:`list` of :obj:`str`): A list of
+                output_condition_uris (:obj:`list` of :obj:`str`): A list of
                     Outputs to check the Inputs against.
 
             Returns:
                 bool: If all Outputs are valid.
         """
 
-        if len(self.inputs) != len(output_uris):
+        if len(self.inputs) != len(output_condition_uris):
             raise ValueError('Inputs and '
-                             'output_uris must have the same count')
+                             'output_condition_uris must have the same count')
 
-        def gen_tx(input, output, output_uri=None):
+        def gen_tx(input, output, output_condition_uri=None):
             """Splits multiple IO Transactions into partial single IO
             Transactions.
             """
@@ -1029,19 +1029,19 @@ class Transaction(object):
 
             # TODO: Use local reference to class, not `Transaction.`
             return Transaction._input_valid(input, self.operation,
-                                            tx_serialized, output_uri)
+                                            tx_serialized, output_condition_uri)
 
         partial_transactions = map(gen_tx, self.inputs,
-                                   self.outputs, output_uris)
+                                   self.outputs, output_condition_uris)
         return all(partial_transactions)
 
     @staticmethod
-    def _input_valid(input, operation, tx_serialized, output_uri=None):
+    def _input_valid(input, operation, tx_serialized, output_condition_uri=None):
         """Validates a single Input against a single Output.
 
             Note:
                 In case of a `CREATE` or `GENESIS` Transaction, this method
-                does not validate against `output_uri`.
+                does not validate against `output_condition_uri`.
 
             Args:
                 input (:class:`~bigchaindb.common.transaction.
@@ -1049,7 +1049,7 @@ class Transaction(object):
                 operation (str): The type of Transaction.
                 tx_serialized (str): The Transaction used as a message when
                     initially signing it.
-                output_uri (str, optional): An Output to check the
+                output_condition_uri (str, optional): An Output to check the
                     Input against.
 
             Returns:
@@ -1066,7 +1066,7 @@ class Transaction(object):
             #       output is always valid.
             output_valid = True
         else:
-            output_valid = output_uri == ccffill.condition_uri
+            output_valid = output_condition_uri == ccffill.condition_uri
 
         # NOTE: We pass a timestamp to `.validate`, as in case of a timeout
         #       condition we'll have to validate against it

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -653,9 +653,11 @@ class Transaction(object):
 
             Args:
                 creators (:obj:`list` of :obj:`str`): A list of keys that
-                    represent the creators of this Transaction.
+                    represent the creators of the asset created by this
+                    Transaction.
                 recipients (:obj:`list` of :obj:`str`): A list of keys that
-                    represent the recipients of this Transaction.
+                    represent the recipients of the asset created by this
+                    Transaction.
                 metadata (dict): Python dictionary to be stored along with the
                     Transaction.
                 asset (:class:`~bigchaindb.common.transaction.Asset`): An Asset

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -424,17 +424,17 @@ class Bigchain(object):
             # use it after the execution of this function.
             # a transaction can contain multiple outputs so we need to iterate over all of them
             # to get a list of outputs available to spend
-            for index, out in enumerate(tx['outputs']):
+            for index, output in enumerate(tx['outputs']):
                 # for simple signature conditions there are no subfulfillments
                 # check if the owner is in the condition `owners_after`
-                if len(out['public_keys']) == 1:
-                    if out['condition']['details']['public_key'] == owner:
+                if len(output['public_keys']) == 1:
+                    if output['condition']['details']['public_key'] == owner:
                         tx_link = TransactionLink(tx['id'], index)
                 else:
                     # for transactions with multiple `public_keys` there will be several subfulfillments nested
                     # in the condition. We need to iterate the subfulfillments to make sure there is a
                     # subfulfillment for `owner`
-                    if util.condition_details_has_owner(out['condition']['details'], owner):
+                    if util.condition_details_has_owner(output['condition']['details'], owner):
                         tx_link = TransactionLink(tx['id'], index)
                 # check if input was already spent
                 if not self.get_spent(tx_link.txid, tx_link.idx):

--- a/bigchaindb/models.py
+++ b/bigchaindb/models.py
@@ -44,7 +44,7 @@ class Transaction(Transaction):
             if inputs_defined:
                 raise ValueError('A CREATE operation has no inputs')
             # validate asset
-            amount = sum([out.amount for out in self.outputs])
+            amount = sum([output.amount for output in self.outputs])
             self.asset.validate_asset(amount=amount)
         elif self.operation == Transaction.TRANSFER:
             if not inputs_defined:

--- a/bigchaindb/models.py
+++ b/bigchaindb/models.py
@@ -37,7 +37,7 @@ class Transaction(Transaction):
             raise ValueError('Transaction contains no inputs')
 
         input_conditions = []
-        inputs_defined = all([inp.fulfills for inp in self.inputs])
+        inputs_defined = all([input_.fulfills for input_ in self.inputs])
 
         if self.operation in (Transaction.CREATE, Transaction.GENESIS):
             # validate inputs

--- a/docs/root/source/transaction-concepts.md
+++ b/docs/root/source/transaction-concepts.md
@@ -28,7 +28,7 @@ Protocol (ILP)](https://interledger.org/).
 ## TRANSFER Transactions
 
 A TRANSFER transaction can transfer an asset
-by provding inputs which fulfill the current output conditions on the asset.
+by providing inputs which fulfill the current output conditions on the asset.
 It must also specify new transfer conditions.
 
 **Example 1:** Suppose a red car is owned and controlled by Joe.

--- a/docs/root/source/transaction-concepts.md
+++ b/docs/root/source/transaction-concepts.md
@@ -18,12 +18,14 @@ That means you can create/register an asset with an initial quantity,
 e.g. 700 oak trees. Divisible assets can be split apart or recombined
 by transfer transactions (described more below).
 
-A CREATE transaction also establishes the conditions (outputs) that must be met to
-transfer the asset(s). For example, there may be a condition that any transfer
-must be signed (cryptographically) by the private key associated with a
-given public key. More sophisticated conditions are possible.
-BigchainDB's conditions are based on the crypto-conditions of the [Interledger
-Protocol (ILP)](https://interledger.org/).
+A CREATE transaction also establishes, in its outputs, the conditions that must
+be met to transfer the asset(s). The conditions may also be associated with a
+list of public keys that, depending on the condition, may have full or partial
+control over the asset(s). For example, there may be a condition that any
+transfer must be signed (cryptographically) by the private key associated with a
+given public key. More sophisticated conditions are possible. BigchainDB's
+conditions are based on the crypto-conditions of the [Interledger Protocol
+(ILP)](https://interledger.org/).
 
 ## TRANSFER Transactions
 

--- a/docs/server/generate_schema_documentation.py
+++ b/docs/server/generate_schema_documentation.py
@@ -72,12 +72,12 @@ Transaction
 %(transaction)s
 
 Input
-----------
+-----
 
 %(input)s
 
 Output
------------
+------
 
 %(output)s
 

--- a/docs/server/source/data-models/index.rst
+++ b/docs/server/source/data-models/index.rst
@@ -3,7 +3,7 @@ Data Models
 
 BigchainDB stores all data in the underlying database as JSON documents (conceptually, at least). There are three main kinds:
 
-1. Transactions, which contain digital assets, inputs, outputs and other things
+1. Transactions, which contain digital assets, inputs, outputs, and other things
 2. Blocks
 3. Votes
 

--- a/tests/common/test_transaction.py
+++ b/tests/common/test_transaction.py
@@ -814,10 +814,10 @@ def test_create_create_transaction_threshold(user_pub, user2_pub, user3_pub,
         'inputs': [
             {
                 'owners_before': [
-                    user_pub
+                    user_pub,
                 ],
                 'fulfillment': None,
-                'fulfills': None
+                'fulfills': None,
             },
         ],
         'operation': 'CREATE',


### PR DESCRIPTION
@libscott this ended up being larger than expected (after finding some usages of fulfillments / conditions weren't changed in `common/transaction.py`), so I've pulled this out into its own PR. Feel free to rollback any commit that you don't want merged :).

**[Proposal]**: I've used `input_` to avoid hiding the built-in for now, but I'd agree if you think this looks ugly (since we're using it as argument names, etc). I guess we could change it to `in` / `out`?

Fixes #822.