### PR TITLE
remove rethinkdb calls

### DIFF
--- a/tests/assets/conftest.py
+++ b/tests/assets/conftest.py
@@ -8,12 +8,6 @@ def restore_config(request, node_config):
     config_utils.set_config(node_config)
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope='function', autouse=True)
 def setup_database(request, node_config):
     conftest.setup_database(request, node_config)
-
-
-@pytest.fixture(scope='function', autouse=True)
-def cleanup_tables(request, node_config):
-    conftest.cleanup_tables(request, node_config)
-

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -11,8 +11,7 @@ import pytest
 from bigchaindb import Bigchain
 from bigchaindb.backend import connect, schema
 from bigchaindb.common import crypto
-from bigchaindb.common.exceptions import (DatabaseAlreadyExists,
-                                          DatabaseDoesNotExist)
+from bigchaindb.common.exceptions import DatabaseDoesNotExist
 
 
 USER2_SK, USER2_PK = crypto.generate_key_pair()
@@ -31,11 +30,11 @@ def setup_database(request, node_config):
     conn = connect()
 
     try:
-        schema.init_database(conn)
-    except DatabaseAlreadyExists:
-        print('Database already exists.')
         schema.drop_database(conn, db_name)
-        schema.init_database(conn)
+    except DatabaseDoesNotExist:
+        pass
+
+    schema.init_database(conn)
 
     print('Finishing init database')
 
@@ -44,9 +43,9 @@ def setup_database(request, node_config):
         print('Deleting `{}` database'.format(db_name))
         try:
             schema.drop_database(conn, db_name)
-        except DatabaseDoesNotExist as e:
-            if str(e) != 'Database `{}` does not exist'.format(db_name):
-                raise
+        except DatabaseDoesNotExist:
+            pass
+
         print('Finished deleting `{}`'.format(db_name))
 
     request.addfinalizer(fin)

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -23,7 +23,7 @@ def restore_config(request, node_config):
     config_utils.set_config(node_config)
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope='function', autouse=True)
 def setup_database(request, node_config):
     print('Initializing test db')
     db_name = node_config['database']['name']
@@ -47,24 +47,6 @@ def setup_database(request, node_config):
             pass
 
         print('Finished deleting `{}`'.format(db_name))
-
-    request.addfinalizer(fin)
-
-
-@pytest.fixture(scope='function', autouse=True)
-def cleanup_tables(request, node_config):
-    db_name = node_config['database']['name']
-
-    def fin():
-        conn = connect()
-        try:
-            schema.drop_database(conn, db_name)
-            schema.create_database(conn, db_name)
-            schema.create_tables(conn, db_name)
-            schema.create_indexes(conn, db_name)
-        except DatabaseDoesNotExist as e:
-            if str(e) != 'Database `{}` does not exist'.format(db_name):
-                raise
 
     request.addfinalizer(fin)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,14 +11,9 @@ def restore_config(request, node_config):
     config_utils.set_config(node_config)
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope='function', autouse=True)
 def setup_database(request, node_config):
     conftest.setup_database(request, node_config)
-
-
-@pytest.fixture(scope='function', autouse=True)
-def cleanup_tables(request, node_config):
-    conftest.cleanup_tables(request, node_config)
 
 
 @pytest.fixture

--- a/tests/pipelines/conftest.py
+++ b/tests/pipelines/conftest.py
@@ -8,11 +8,6 @@ def restore_config(request, node_config):
     config_utils.set_config(node_config)
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope='function', autouse=True)
 def setup_database(request, node_config):
     conftest.setup_database(request, node_config)
-
-
-@pytest.fixture(scope='function', autouse=True)
-def cleanup_tables(request, node_config):
-    conftest.cleanup_tables(request, node_config)

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -8,14 +8,9 @@ def restore_config(request, node_config):
     config_utils.set_config(node_config)
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope='function', autouse=True)
 def setup_database(request, node_config):
     conftest.setup_database(request, node_config)
-
-
-@pytest.fixture(scope='function', autouse=True)
-def cleanup_tables(request, node_config):
-    conftest.cleanup_tables(request, node_config)
 
 
 @pytest.fixture


### PR DESCRIPTION
Remove explicit rethinkdb calls.  A little slower, because we can't just tear down tables each time; the whole db has to be regenerated