### PR TITLE
Remove asset keywords

### DIFF
--- a/bigchaindb/common/exceptions.py
+++ b/bigchaindb/common/exceptions.py
@@ -87,4 +87,4 @@ class AssetIdMismatch(Exception):
 
 
 class AmountError(Exception):
-    """Raise when there is a problem with output amounts"""
+    """Raised when there is a problem with a transaction's output amounts"""

--- a/bigchaindb/common/exceptions.py
+++ b/bigchaindb/common/exceptions.py
@@ -87,4 +87,4 @@ class AssetIdMismatch(Exception):
 
 
 class AmountError(Exception):
-    """Raised when the amount of a non-divisible asset is different then 1"""
+    """Raise when there is a problem with output amounts"""

--- a/bigchaindb/common/schema/transaction.yaml
+++ b/bigchaindb/common/schema/transaction.yaml
@@ -112,18 +112,6 @@ definitions:
     properties:
       id:
         "$ref": "#/definitions/uuid4"
-      divisible:
-        type: boolean
-        description: |
-            Whether or not the asset has a quantity that may be partially spent.
-      updatable:
-        type: boolean
-        description: |
-            Whether or not the description of the asset may be updated. Defaults to false.
-      refillable:
-        type: boolean
-        description: |
-          Whether the amount of the asset can change after its creation. Defaults to false.
       data:
         description: |
           User provided metadata associated with the asset. May also be ``null``.
@@ -170,7 +158,6 @@ definitions:
         type: integer
         description: |
             Integral amount of the asset represented by this condition.
-            In the case of a non divisible asset, this will always be 1.
   fulfillment:
     type: "object"
     description:

--- a/bigchaindb/models.py
+++ b/bigchaindb/models.py
@@ -87,7 +87,7 @@ class Transaction(Transaction):
                                        ' match the asset id of the'
                                        ' transaction'))
 
-            # get the asset creation to see if its divisible or not
+            # get the asset creation
             asset = bigchain.get_asset_by_id(asset_id)
             # validate the asset
             asset.validate_asset(amount=input_amount)

--- a/docs/server/source/data-models/asset-model.md
+++ b/docs/server/source/data-models/asset-model.md
@@ -6,9 +6,6 @@ A digital asset's properties are defined in a `CREATE` transaction with the foll
 ```json
 {
     "id": "<uuid>",
-    "divisible": "<true | false>",
-    "updatable": "<true | false>",
-    "refillable": "<true | false>",
     "data": "<json document>"
 }
 ```
@@ -22,10 +19,4 @@ For `TRANSFER` transactions we only keep the asset id.
 
 
 - `id`: UUID version 4 (random) converted to a string of hex digits in standard form. Added server side.
-- `divisible`: Whether the asset is divisible or not. Defaults to false.
-- `updatable`: Whether the data in the asset can be updated in the future or not. Defaults to false.
-- `refillable`: Whether the amount of the asset can change after its creation. Defaults to false.
 - `data`: A user supplied JSON document with custom information about the asset. Defaults to null.
-- _amount_: The amount of "shares". Only relevant if the asset is marked as divisible. Defaults to 1. The amount is not specified in the asset, but in the conditions (see next section).
-
-At the time of this writing, updatable and refillable assets are not yet implemented.

--- a/tests/assets/test_divisible_assets.py
+++ b/tests/assets/test_divisible_assets.py
@@ -14,7 +14,7 @@ def test_single_in_single_own_single_out_single_own_create(b, user_pk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx = Transaction.create([b.me], [([user_pk], 100)], asset=asset)
     tx_signed = tx.sign([b.me_private])
 
@@ -33,7 +33,7 @@ def test_single_in_single_own_multiple_out_single_own_create(b, user_pk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx = Transaction.create([b.me], [([user_pk], 50), ([user_pk], 50)],
                             asset=asset)
     tx_signed = tx.sign([b.me_private])
@@ -54,7 +54,7 @@ def test_single_in_single_own_single_out_multiple_own_create(b, user_pk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx = Transaction.create([b.me], [([user_pk, user_pk], 100)], asset=asset)
     tx_signed = tx.sign([b.me_private])
 
@@ -79,7 +79,7 @@ def test_single_in_single_own_multiple_out_mix_own_create(b, user_pk):
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx = Transaction.create([b.me],
                             [([user_pk], 50), ([user_pk, user_pk], 50)],
                             asset=asset)
@@ -106,7 +106,7 @@ def test_single_in_multiple_own_single_out_single_own_create(b, user_pk,
     from bigchaindb.models import Transaction
     from bigchaindb.common.transaction import Asset
 
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx = Transaction.create([b.me, user_pk], [([user_pk], 100)], asset=asset)
     tx_signed = tx.sign([b.me_private, user_sk])
     assert tx_signed.validate(b) == tx_signed
@@ -135,7 +135,7 @@ def test_single_in_single_own_single_out_single_own_transfer(b, user_pk,
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx_create = Transaction.create([b.me], [([user_pk], 100)], asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
@@ -169,7 +169,7 @@ def test_single_in_single_own_multiple_out_single_own_transfer(b, user_pk,
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx_create = Transaction.create([b.me], [([user_pk], 100)], asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
@@ -205,7 +205,7 @@ def test_single_in_single_own_single_out_multiple_own_transfer(b, user_pk,
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx_create = Transaction.create([b.me], [([user_pk], 100)], asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
@@ -246,7 +246,7 @@ def test_single_in_single_own_multiple_out_mix_own_transfer(b, user_pk,
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx_create = Transaction.create([b.me], [([user_pk], 100)], asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
@@ -287,7 +287,7 @@ def test_single_in_multiple_own_single_out_single_own_transfer(b, user_pk,
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx_create = Transaction.create([b.me], [([b.me, user_pk], 100)],
                                    asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
@@ -326,7 +326,7 @@ def test_multiple_in_single_own_single_out_single_own_transfer(b, user_pk,
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx_create = Transaction.create([b.me], [([user_pk], 50), ([user_pk], 50)],
                                    asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
@@ -361,7 +361,7 @@ def test_multiple_in_multiple_own_single_out_single_own_transfer(b, user_pk,
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx_create = Transaction.create([b.me],
                                    [([user_pk, b.me], 50),
                                     ([user_pk, b.me], 50)],
@@ -406,7 +406,7 @@ def test_muiltiple_in_mix_own_multiple_out_single_own_transfer(b, user_pk,
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx_create = Transaction.create([b.me],
                                    [([user_pk], 50),
                                     ([user_pk, b.me], 50)],
@@ -451,7 +451,7 @@ def test_muiltiple_in_mix_own_multiple_out_mix_own_transfer(b, user_pk,
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx_create = Transaction.create([b.me],
                                    [([user_pk], 50),
                                     ([user_pk, b.me], 50)],
@@ -503,7 +503,7 @@ def test_multiple_in_different_transactions(b, user_pk, user_sk):
     # CREATE divisible asset
     # `b` creates a divisible asset and assigns 50 shares to `b` and
     # 50 shares to `user_pk`
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx_create = Transaction.create([b.me],
                                    [([user_pk], 50),
                                     ([b.me], 50)],
@@ -563,7 +563,7 @@ def test_amount_error_transfer(b, user_pk, user_sk):
     from bigchaindb.common.exceptions import AmountError
 
     # CREATE divisible asset
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx_create = Transaction.create([b.me], [([user_pk], 100)], asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
     # create block
@@ -605,7 +605,7 @@ def test_threshold_same_public_key(b, user_pk, user_sk):
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx_create = Transaction.create([b.me], [([user_pk, user_pk], 100)],
                                    asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
@@ -631,7 +631,7 @@ def test_sum_amount(b, user_pk, user_sk):
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset with 3 outputs with amount 1
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx_create = Transaction.create([b.me],
                                    [([user_pk], 1),
                                     ([user_pk], 1),
@@ -663,7 +663,7 @@ def test_divide(b, user_pk, user_sk):
     from bigchaindb.common.transaction import Asset
 
     # CREATE divisible asset with 1 output with amount 3
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx_create = Transaction.create([b.me], [([user_pk], 3)],
                                    asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
@@ -696,7 +696,7 @@ def test_non_positive_amounts_on_transfer(b, user_pk):
     from bigchaindb.common.exceptions import AmountError
 
     # CREATE divisible asset with 1 output with amount 3
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx_create = Transaction.create([b.me], [([user_pk], 3)],
                                    asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
@@ -722,7 +722,7 @@ def test_non_positive_amounts_on_transfer_validate(b, user_pk, user_sk):
     from bigchaindb.common.exceptions import AmountError
 
     # CREATE divisible asset with 1 output with amount 3
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx_create = Transaction.create([b.me], [([user_pk], 3)],
                                    asset=asset)
     tx_create_signed = tx_create.sign([b.me_private])
@@ -754,7 +754,7 @@ def test_non_positive_amounts_on_create(b, user_pk):
     from bigchaindb.common.exceptions import AmountError
 
     # CREATE divisible asset with 1 output with amount 3
-    asset = Asset(divisible=True)
+    asset = Asset()
     with pytest.raises(AmountError):
         Transaction.create([b.me], [([user_pk], -3)],
                            asset=asset)
@@ -768,7 +768,7 @@ def test_non_positive_amounts_on_create_validate(b, user_pk):
     from bigchaindb.common.exceptions import AmountError
 
     # CREATE divisible asset with 1 output with amount 3
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx_create = Transaction.create([b.me], [([user_pk], 3)],
                                    asset=asset)
     tx_create.conditions[0].amount = -3

--- a/tests/common/test_asset.py
+++ b/tests/common/test_asset.py
@@ -7,9 +7,6 @@ def test_asset_default_values():
     asset = Asset()
     assert asset.data is None
     assert asset.data_id
-    assert asset.divisible is False
-    assert asset.updatable is False
-    assert asset.refillable is False
 
 
 def test_asset_creation_with_data(data):
@@ -25,18 +22,6 @@ def test_asset_invalid_asset_initialization():
     # check types
     with raises(TypeError):
         Asset(data='some wrong type')
-    with raises(TypeError):
-        Asset(divisible=1)
-    with raises(TypeError):
-        Asset(refillable=1)
-    with raises(TypeError):
-        Asset(updatable=1)
-
-    # check for features that are not yet implemented
-    with raises(NotImplementedError):
-        Asset(updatable=True)
-    with raises(NotImplementedError):
-        Asset(refillable=True)
 
 
 def test_invalid_asset_comparison(data, data_id):
@@ -50,9 +35,6 @@ def test_asset_serialization(data, data_id):
 
     expected = {
         'id': data_id,
-        'divisible': False,
-        'updatable': False,
-        'refillable': False,
         'data': data,
     }
     asset = Asset(data, data_id)
@@ -64,9 +46,6 @@ def test_asset_deserialization(data, data_id):
 
     asset_dict = {
         'id': data_id,
-        'divisible': False,
-        'updatable': False,
-        'refillable': False,
         'data': data,
     }
     asset = Asset.from_dict(asset_dict)
@@ -76,17 +55,8 @@ def test_asset_deserialization(data, data_id):
 
 def test_validate_asset():
     from bigchaindb.common.transaction import Asset
-    from bigchaindb.common.exceptions import AmountError
 
     # test amount errors
-    asset = Asset(divisible=False)
-    with raises(AmountError):
-        asset.validate_asset(amount=2)
-
-    asset = Asset(divisible=True)
-    with raises(AmountError):
-        asset.validate_asset(amount=1)
-
     asset = Asset()
     with raises(TypeError):
         asset.validate_asset(amount='a')

--- a/tests/common/test_transaction.py
+++ b/tests/common/test_transaction.py
@@ -309,9 +309,6 @@ def test_transaction_serialization(user_ffill, user_cond, data, data_id):
         'metadata': None,
         'asset': {
             'id': data_id,
-            'divisible': False,
-            'updatable': False,
-            'refillable': False,
             'data': data,
         }
     }
@@ -348,9 +345,6 @@ def test_transaction_deserialization(user_ffill, user_cond, data, uuid4):
         'metadata': None,
         'asset': {
             'id': uuid4,
-            'divisible': False,
-            'updatable': False,
-            'refillable': False,
             'data': data,
         }
     }
@@ -632,7 +626,7 @@ def test_validate_multiple_fulfillments(user_ffill, user_cond, user_priv):
     from bigchaindb.common.transaction import Transaction, Asset
     from .util import validate_transaction_model
 
-    tx = Transaction(Transaction.CREATE, Asset(divisible=True),
+    tx = Transaction(Transaction.CREATE, Asset(),
                      [user_ffill, deepcopy(user_ffill)],
                      [user_cond, deepcopy(user_cond)])
 
@@ -696,7 +690,7 @@ def test_multiple_fulfillment_validation_of_transfer_tx(user_ffill, user_cond,
     from cryptoconditions import Ed25519Fulfillment
     from .util import validate_transaction_model
 
-    tx = Transaction(Transaction.CREATE, Asset(divisible=True),
+    tx = Transaction(Transaction.CREATE, Asset(),
                      [user_ffill, deepcopy(user_ffill)],
                      [user_cond, deepcopy(user_cond)])
     tx.sign([user_priv])
@@ -750,9 +744,6 @@ def test_create_create_transaction_single_io(user_cond, user_pub, data, uuid4):
         'metadata': data,
         'asset': {
             'id': uuid4,
-            'divisible': False,
-            'updatable': False,
-            'refillable': False,
             'data': data,
         },
         'fulfillments': [
@@ -804,7 +795,7 @@ def test_create_create_transaction_multiple_io(user_cond, user2_cond, user_pub,
         'operation': 'CREATE',
         'version': 1
     }
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx = Transaction.create([user_pub, user2_pub],
                             [([user_pub], 1), ([user2_pub], 1)],
                             asset=asset,
@@ -823,7 +814,7 @@ def test_validate_multiple_io_create_transaction(user_pub, user_priv,
     tx = Transaction.create([user_pub, user2_pub],
                             [([user_pub], 1), ([user2_pub], 1)],
                             metadata={'message': 'hello'},
-                            asset=Asset(divisible=True))
+                            asset=Asset())
     tx = tx.sign([user_priv, user2_priv])
     assert tx.fulfillments_valid() is True
 
@@ -841,9 +832,6 @@ def test_create_create_transaction_threshold(user_pub, user2_pub, user3_pub,
         'metadata': data,
         'asset': {
             'id': uuid4,
-            'divisible': False,
-            'updatable': False,
-            'refillable': False,
             'data': data,
         },
         'fulfillments': [
@@ -963,7 +951,7 @@ def test_create_transfer_transaction_multiple_io(user_pub, user_priv,
                                                  user3_pub, user2_cond):
     from bigchaindb.common.transaction import Transaction, Asset
 
-    asset = Asset(divisible=True)
+    asset = Asset()
     tx = Transaction.create([user_pub], [([user_pub], 1), ([user2_pub], 1)],
                             asset=asset, metadata={'message': 'hello'})
     tx = tx.sign([user_priv])

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -940,7 +940,7 @@ class TestMultipleInputs(object):
         user2_sk, user2_pk = crypto.generate_key_pair()
 
         # create divisible asset
-        asset = Asset(divisible=True)
+        asset = Asset()
         tx_create = Transaction.create([b.me],
                                        [([user_pk], 1), ([user_pk], 1)],
                                        asset=asset)
@@ -1080,7 +1080,7 @@ class TestMultipleInputs(object):
         user2_sk, user2_pk = crypto.generate_key_pair()
 
         # create a divisible asset with 3 outputs
-        asset = Asset(divisible=True)
+        asset = Asset()
         tx_create = Transaction.create([b.me],
                                        [([user_pk], 1),
                                         ([user_pk], 1),


### PR DESCRIPTION
This change removes keywords from the `Asset`.

* `divisible`: This is indicated by the amount of the asset. 
* `refillable`: This logic will be implemented in an asset Policy
* `updatable`: This logic will be implemented in an asset Policy