### PR TITLE
fix mongodb write_block

### DIFF
--- a/bigchaindb/backend/rethinkdb/query.py
+++ b/bigchaindb/backend/rethinkdb/query.py
@@ -134,7 +134,7 @@ def get_votes_by_block_id_and_voter(connection, block_id, node_pubkey):
 def write_block(connection, block):
     return connection.run(
             r.table('bigchain')
-            .insert(r.json(block), durability=WRITE_DURABILITY))
+            .insert(r.json(block.to_str()), durability=WRITE_DURABILITY))
 
 
 @register_query(RethinkDBConnection)

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -516,7 +516,7 @@ class Bigchain(object):
             block (Block): block to write to bigchain.
         """
 
-        return backend.query.write_block(self.connection, block.to_str())
+        return backend.query.write_block(self.connection, block)
 
     def transaction_exists(self, transaction_id):
         return backend.query.has_transaction(self.connection, transaction_id)


### PR DESCRIPTION
`core.write_block` was passing the block already serialized to to the backend query. The problem is that mongodb uses a different serialization format.

With this change `core` passes a block instance to the backend query and the query serializes it as needed.