### PR TITLE
Tests/973/genesis block fixture

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,8 +3,7 @@ from bigchaindb.pipelines import block, election, vote, stale
 
 
 @pytest.fixture
-def processes(b):
-    b.create_genesis_block()
+def processes(genesis_block):
     block_maker = block.start()
     voter = vote.start()
     election_runner = election.start()


### PR DESCRIPTION
Adds a marker for tests requiring both BigchainDB and a genesis block to be available.