### PR TITLE
Rename config.database.name to config.database.dbname

### DIFF
--- a/bigchaindb/__init__.py
+++ b/bigchaindb/__init__.py
@@ -18,7 +18,7 @@ config = {
         'backend': os.environ.get('BIGCHAINDB_DATABASE_BACKEND', 'rethinkdb'),
         'host': os.environ.get('BIGCHAINDB_DATABASE_HOST', 'localhost'),
         'port': int(os.environ.get('BIGCHAINDB_DATABASE_PORT', 28015)),
-        'name': 'bigchain',
+        'dbname': 'bigchain',
     },
     'keypair': {
         'public': None,

--- a/bigchaindb/backend/changefeed.py
+++ b/bigchaindb/backend/changefeed.py
@@ -44,11 +44,7 @@ class ChangeFeed(Node):
         self.prefeed = prefeed if prefeed else []
         self.table = table
         self.operation = operation
-        if connection:
-            self.connection = connection
-        else:
-            self.connection = bigchaindb.backend.connect(
-                **bigchaindb.config['database'])
+        self.connection = connection if connection else bigchaindb.backend.connect()
 
     def run_forever(self):
         """Main loop of the ``multipipes.Node``

--- a/bigchaindb/backend/changefeed.py
+++ b/bigchaindb/backend/changefeed.py
@@ -44,7 +44,7 @@ class ChangeFeed(Node):
         self.prefeed = prefeed if prefeed else []
         self.table = table
         self.operation = operation
-        self.connection = connection if connection else bigchaindb.backend.connect()
+        self.connection = connection or bigchaindb.backend.connect()
 
     def run_forever(self):
         """Main loop of the ``multipipes.Node``

--- a/bigchaindb/backend/connection.py
+++ b/bigchaindb/backend/connection.py
@@ -59,15 +59,15 @@ class Connection:
     from and implements this class.
     """
 
-    def __init__(self, host=None, port=None, dbname=None, *args, **kwargs):
+    def __init__(self, host, port, dbname, **kwargs):
         """Create a new :class:`~.Connection` instance.
 
         Args:
             host (str): the host to connect to.
             port (int): the port to connect to.
             dbname (str): the name of the database to use.
-            **kwargs: arbitrary keyword arguments provided by the
-                configuration's ``database`` settings
+            **kwargs: arbitrary keyword arguments provided by the node
+                configuration's ``database`` settings or :func:`connect`
         """
 
     def run(self, query):

--- a/bigchaindb/backend/connection.py
+++ b/bigchaindb/backend/connection.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 import logging
+from importlib import import_module
+from copy import copy
 
 import bigchaindb
 from bigchaindb.common.exceptions import ConfigurationError
@@ -13,32 +14,32 @@ BACKENDS = {
 logger = logging.getLogger(__name__)
 
 
-def connect(backend=None, host=None, port=None, name=None):
+def connect(**kwargs):
     """Create a new connection to the database backend.
 
-    All arguments default to the current configuration's values if not
-    given.
+    Uses the current node's configuration (``config.database``) to start the
+    connection, unless overridden via keyword arguments.
 
     Args:
-        backend (str): the name of the backend to use.
-        host (str): the host to connect to.
-        port (int): the port to connect to.
-        name (str): the name of the database to use.
+        **kwargs: arbitrary keyword arguments that will override the values
+            provided by the node configuration's ``database`` settings.
+            For example, giving ``port`` as a keyword argument will override
+            the ``config.database.port`` setting.
 
     Returns:
         An instance of :class:`~bigchaindb.backend.connection.Connection`
-        based on the given (or defaulted) :attr:`backend`.
+        based on the given or defaulted) :attr:`backend`.
 
     Raises:
         :exc:`~ConfigurationError`: If the given (or defaulted) :attr:`backend`
             is not supported or could not be loaded.
     """
 
-    backend = backend or bigchaindb.config['database']['backend']
-    host = host or bigchaindb.config['database']['host']
-    port = port or bigchaindb.config['database']['port']
-    dbname = name or bigchaindb.config['database']['name']
+    backend_config = copy(bigchaindb.config['database'])
+    backend_config.update(kwargs)
 
+    # We don't want to pass the `backend` property into Connection
+    backend = backend_config.pop('backend')
     try:
         module_name, _, class_name = BACKENDS[backend].rpartition('.')
         Class = getattr(import_module(module_name), class_name)
@@ -49,7 +50,7 @@ def connect(backend=None, host=None, port=None, name=None):
         raise ConfigurationError('Error loading backend `{}`'.format(backend)) from exc
 
     logger.debug('Connection: {}'.format(Class))
-    return Class(host, port, dbname)
+    return Class(**backend_config)
 
 
 class Connection:

--- a/bigchaindb/backend/mongodb/connection.py
+++ b/bigchaindb/backend/mongodb/connection.py
@@ -11,11 +11,12 @@ logger = logging.getLogger(__name__)
 
 class MongoDBConnection(Connection):
 
-    def __init__(self, host, port, dbname, max_tries=3):
+    def __init__(self, host, port, dbname, max_tries=3, **kwargs):
         """Create a new :class:`~.MongoDBConnection` instance.
 
         See :meth:`.Connection.__init__` for
-        :attr:`host`, :attr:`port`, and :attr:`dbname`.
+        :attr:`host`, :attr:`port`, and :attr:`dbname`. :attr:`kwargs`
+        is ignored.
 
         Args:
             max_tries (int, optional): how many tries before giving up.

--- a/bigchaindb/backend/mongodb/connection.py
+++ b/bigchaindb/backend/mongodb/connection.py
@@ -4,7 +4,6 @@ import logging
 from pymongo import MongoClient
 from pymongo.errors import ConnectionFailure
 
-import bigchaindb
 from bigchaindb.backend.connection import Connection
 
 logger = logging.getLogger(__name__)
@@ -12,19 +11,20 @@ logger = logging.getLogger(__name__)
 
 class MongoDBConnection(Connection):
 
-    def __init__(self, host=None, port=None, dbname=None, max_tries=3):
-        """Create a new Connection instance.
+    def __init__(self, host, port, dbname, max_tries=3):
+        """Create a new :class:`~.MongoDBConnection` instance.
+
+        See :meth:`.Connection.__init__` for
+        :attr:`host`, :attr:`port`, and :attr:`dbname`.
 
         Args:
-            host (str, optional): the host to connect to.
-            port (int, optional): the port to connect to.
-            dbname (str, optional): the database to use.
             max_tries (int, optional): how many tries before giving up.
+                Defaults to 3.
         """
 
-        self.host = host or bigchaindb.config['database']['host']
-        self.port = port or bigchaindb.config['database']['port']
-        self.dbname = dbname or bigchaindb.config['database']['name']
+        self.host = host
+        self.port = port
+        self.dbname = dbname
         self.max_tries = max_tries
         self.connection = None
 

--- a/bigchaindb/backend/rethinkdb/connection.py
+++ b/bigchaindb/backend/rethinkdb/connection.py
@@ -17,11 +17,12 @@ class RethinkDBConnection(Connection):
           more times to run the query or open a connection.
     """
 
-    def __init__(self, host, port, dbname, max_tries=3):
+    def __init__(self, host, port, dbname, max_tries=3, **kwargs):
         """Create a new :class:`~.RethinkDBConnection` instance.
 
         See :meth:`.Connection.__init__` for
-        :attr:`host`, :attr:`port`, and :attr:`dbname`.
+        :attr:`host`, :attr:`port`, and :attr:`dbname`. :attr:`kwargs`
+        is ignored.
 
         Args:
             max_tries (int, optional): how many tries before giving up.

--- a/bigchaindb/backend/schema.py
+++ b/bigchaindb/backend/schema.py
@@ -81,7 +81,7 @@ def init_database(connection=None, dbname=None):
     """
 
     connection = connection or connect()
-    dbname = dbname or bigchaindb.config['database']['name']
+    dbname = dbname or bigchaindb.config['database']['dbname']
 
     create_database(connection, dbname)
     create_tables(connection, dbname)

--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -161,7 +161,7 @@ def run_init(args):
 def run_drop(args):
     """Drop the database"""
     bigchaindb.config_utils.autoconfigure(filename=args.config, force=True)
-    dbname = bigchaindb.config['database']['name']
+    dbname = bigchaindb.config['database']['dbname']
 
     if not args.yes:
         response = input('Do you want to drop `{}` database? [y/n]: '.format(dbname))
@@ -169,7 +169,7 @@ def run_drop(args):
             return
 
     conn = backend.connect()
-    dbname = bigchaindb.config['database']['name']
+    dbname = bigchaindb.config['database']['dbname']
     schema.drop_database(conn, dbname)
 
 

--- a/bigchaindb/commands/utils.py
+++ b/bigchaindb/commands/utils.py
@@ -28,7 +28,7 @@ def start_rethinkdb():
                             stderr=subprocess.STDOUT,
                             universal_newlines=True)
 
-    dbname = bigchaindb.config['database']['name']
+    dbname = bigchaindb.config['database']['dbname']
     line = ''
 
     for line in proc.stdout:

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -57,7 +57,7 @@ class Bigchain(object):
         self.nodes_except_me = keyring or bigchaindb.config['keyring']
         self.backlog_reassign_delay = backlog_reassign_delay or bigchaindb.config['backlog_reassign_delay']
         self.consensus = BaseConsensusRules
-        self.connection = connection if connection else backend.connect(**bigchaindb.config['database'])
+        self.connection = connection if connection else backend.connect()
         if not self.me or not self.me_private:
             raise exceptions.KeypairNotFoundException()
 

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -57,7 +57,7 @@ class Bigchain(object):
         self.nodes_except_me = keyring or bigchaindb.config['keyring']
         self.backlog_reassign_delay = backlog_reassign_delay or bigchaindb.config['backlog_reassign_delay']
         self.consensus = BaseConsensusRules
-        self.connection = connection if connection else backend.connect()
+        self.connection = connection or backend.connect()
         if not self.me or not self.me_private:
             raise exceptions.KeypairNotFoundException()
 

--- a/bigchaindb/pipelines/block.py
+++ b/bigchaindb/pipelines/block.py
@@ -9,7 +9,6 @@ import logging
 
 from multipipes import Pipeline, Node, Pipe
 
-import bigchaindb
 from bigchaindb import backend
 from bigchaindb.backend.changefeed import ChangeFeed
 from bigchaindb.models import Transaction

--- a/bigchaindb/pipelines/block.py
+++ b/bigchaindb/pipelines/block.py
@@ -155,7 +155,7 @@ def create_pipeline():
 
 
 def get_changefeed():
-    connection = backend.connect(**bigchaindb.config['database'])
+    connection = backend.connect()
     return backend.get_changefeed(connection, 'backlog',
                                   ChangeFeed.INSERT | ChangeFeed.UPDATE)
 

--- a/bigchaindb/pipelines/election.py
+++ b/bigchaindb/pipelines/election.py
@@ -64,7 +64,7 @@ def create_pipeline():
 
 
 def get_changefeed():
-    connection = backend.connect(**bigchaindb.config['database'])
+    connection = backend.connect()
     return backend.get_changefeed(connection, 'votes', ChangeFeed.INSERT)
 
 

--- a/bigchaindb/pipelines/election.py
+++ b/bigchaindb/pipelines/election.py
@@ -8,7 +8,6 @@ import logging
 
 from multipipes import Pipeline, Node
 
-import bigchaindb
 from bigchaindb import backend
 from bigchaindb.backend.changefeed import ChangeFeed
 from bigchaindb.models import Block

--- a/bigchaindb/pipelines/vote.py
+++ b/bigchaindb/pipelines/vote.py
@@ -10,7 +10,6 @@ from collections import Counter
 from multipipes import Pipeline, Node
 from bigchaindb.common import exceptions
 
-import bigchaindb
 from bigchaindb import Bigchain
 from bigchaindb import backend
 from bigchaindb.backend.changefeed import ChangeFeed

--- a/bigchaindb/pipelines/vote.py
+++ b/bigchaindb/pipelines/vote.py
@@ -162,7 +162,7 @@ def create_pipeline():
 
 
 def get_changefeed():
-    connection = backend.connect(**bigchaindb.config['database'])
+    connection = backend.connect()
     return backend.get_changefeed(connection, 'bigchain', ChangeFeed.INSERT,
                                   prefeed=initial())
 

--- a/docs/server/source/server-reference/configuration.md
+++ b/docs/server/source/server-reference/configuration.md
@@ -12,9 +12,9 @@ For convenience, here's a list of all the relevant environment variables (docume
 `BIGCHAINDB_KEYPAIR_PRIVATE`<br>
 `BIGCHAINDB_KEYRING`<br>
 `BIGCHAINDB_DATABASE_BACKEND`<br>
+`BIGCHAINDB_DATABASE_DBNAME`<br>
 `BIGCHAINDB_DATABASE_HOST`<br>
 `BIGCHAINDB_DATABASE_PORT`<br>
-`BIGCHAINDB_DATABASE_NAME`<br>
 `BIGCHAINDB_SERVER_BIND`<br>
 `BIGCHAINDB_SERVER_WORKERS`<br>
 `BIGCHAINDB_SERVER_THREADS`<br>
@@ -84,9 +84,9 @@ The database backend to use (e.g. RethinkDB) and its hostname, port and name.
 **Example using environment variables**
 ```text
 export BIGCHAINDB_DATABASE_BACKEND=rethinkdb
+export BIGCHAINDB_DATABASE_DBNAME=bigchain
 export BIGCHAINDB_DATABASE_HOST=localhost
 export BIGCHAINDB_DATABASE_PORT=28015
-export BIGCHAINDB_DATABASE_NAME=bigchain
 ```
 
 **Example config file snippet**

--- a/tests/backend/mongodb/test_schema.py
+++ b/tests/backend/mongodb/test_schema.py
@@ -10,7 +10,7 @@ def test_init_creates_db_tables_and_indexes():
     from bigchaindb.backend.schema import init_database
 
     conn = backend.connect()
-    dbname = bigchaindb.config['database']['name']
+    dbname = bigchaindb.config['database']['dbname']
 
     # the db is set up by the fixture so we need to remove it
     conn.conn.drop_database(dbname)
@@ -38,7 +38,7 @@ def test_init_database_fails_if_db_exists():
     from bigchaindb.common import exceptions
 
     conn = backend.connect()
-    dbname = bigchaindb.config['database']['name']
+    dbname = bigchaindb.config['database']['dbname']
 
     # The db is set up by the fixtures
     assert dbname in conn.conn.database_names()
@@ -53,7 +53,7 @@ def test_create_tables():
     from bigchaindb.backend import schema
 
     conn = backend.connect()
-    dbname = bigchaindb.config['database']['name']
+    dbname = bigchaindb.config['database']['dbname']
 
     # The db is set up by the fixtures so we need to remove it
     conn.conn.drop_database(dbname)
@@ -70,7 +70,7 @@ def test_create_secondary_indexes():
     from bigchaindb.backend import schema
 
     conn = backend.connect()
-    dbname = bigchaindb.config['database']['name']
+    dbname = bigchaindb.config['database']['dbname']
 
     # The db is set up by the fixtures so we need to remove it
     conn.conn.drop_database(dbname)
@@ -98,7 +98,7 @@ def test_drop():
     from bigchaindb.backend import schema
 
     conn = backend.connect()
-    dbname = bigchaindb.config['database']['name']
+    dbname = bigchaindb.config['database']['dbname']
 
     # The db is set up by fixtures
     assert dbname in conn.conn.database_names()

--- a/tests/backend/rethinkdb/test_schema.py
+++ b/tests/backend/rethinkdb/test_schema.py
@@ -10,7 +10,7 @@ from bigchaindb.backend.rethinkdb import schema
 def test_init_creates_db_tables_and_indexes():
     from bigchaindb.backend.schema import init_database
     conn = backend.connect()
-    dbname = bigchaindb.config['database']['name']
+    dbname = bigchaindb.config['database']['dbname']
 
     # The db is set up by fixtures so we need to remove it
     conn.run(r.db_drop(dbname))
@@ -34,7 +34,7 @@ def test_init_database_fails_if_db_exists():
     from bigchaindb.common import exceptions
 
     conn = backend.connect()
-    dbname = bigchaindb.config['database']['name']
+    dbname = bigchaindb.config['database']['dbname']
 
     # The db is set up by fixtures
     assert conn.run(r.db_list().contains(dbname)) is True
@@ -52,7 +52,7 @@ def test_create_database(not_yet_created_db):
 @pytest.mark.bdb
 def test_create_tables():
     conn = backend.connect()
-    dbname = bigchaindb.config['database']['name']
+    dbname = bigchaindb.config['database']['dbname']
 
     # The db is set up by fixtures so we need to remove it
     # and recreate it just with one table
@@ -69,7 +69,7 @@ def test_create_tables():
 @pytest.mark.bdb
 def test_create_secondary_indexes():
     conn = backend.connect()
-    dbname = bigchaindb.config['database']['name']
+    dbname = bigchaindb.config['database']['dbname']
 
     # The db is set up by fixtures so we need to remove it
     # and recreate it just with one table

--- a/tests/backend/test_changefeed.py
+++ b/tests/backend/test_changefeed.py
@@ -22,10 +22,9 @@ def mock_changefeed_data():
 
 @pytest.fixture
 def mock_changefeed_connection(mock_changefeed_data):
-    import bigchaindb
     from bigchaindb.backend import connect
 
-    connection = connect(**bigchaindb.config['database'])
+    connection = connect()
     connection.run = Mock(return_value=mock_changefeed_data)
     return connection
 

--- a/tests/backend/test_connection.py
+++ b/tests/backend/test_connection.py
@@ -1,4 +1,53 @@
+from copy import copy
+
 import pytest
+from unittest.mock import Mock, patch
+
+
+@pytest.fixture
+def mock_imported_connection_cls(monkeypatch):
+    from bigchaindb import config
+    monkeypatch.setattr('bigchaindb.backend.connection.BACKENDS',
+                        {config['database']['backend']:
+                         'bigchaindb.backend.mock.MockDBConnection'})
+
+    with patch('bigchaindb.backend.connection.import_module') as mock_import:
+        # Set up mocks for imported connection lib
+        mock_connection_cls = Mock()
+        mock_connection_module = Mock()
+        mock_connection_module.MockDBConnection = mock_connection_cls
+        mock_import.return_value = mock_connection_module
+
+        yield mock_connection_cls
+
+
+def test_get_connection_uses_current_configuration1(mock_imported_connection_cls):
+    from bigchaindb import config
+    from bigchaindb.backend import connect
+    expected_args = copy(config['database'])
+    del expected_args['backend']
+
+    connect()
+    mock_imported_connection_cls.assert_called_once_with(**expected_args)
+
+
+def test_get_connection_overrides_current_configuration_from_kwargs(mock_imported_connection_cls):
+    from bigchaindb import config
+    from bigchaindb.backend import connect
+    mock_port = 123
+    mock_hostname = 'hostname'
+    mock_extra_value = 'extra'
+
+    expected_args = copy(config['database'])
+    expected_args.update({
+        'port': mock_port,
+        'host': mock_hostname,
+        'extra_value': mock_extra_value,
+    })
+    del expected_args['backend']
+
+    connect(port=mock_port, host=mock_hostname, extra_value=mock_extra_value)
+    mock_imported_connection_cls.assert_called_once_with(**expected_args)
 
 
 def test_get_connection_raises_a_configuration_error(monkeypatch):
@@ -6,12 +55,12 @@ def test_get_connection_raises_a_configuration_error(monkeypatch):
     from bigchaindb.backend import connect
 
     with pytest.raises(ConfigurationError):
-        connect('msaccess', 'localhost', '1337', 'mydb')
+        connect(backend='msaccess', host='localhost', port='1337', extra='mydb')
 
     with pytest.raises(ConfigurationError):
         # We need to force a misconfiguration here
         monkeypatch.setattr('bigchaindb.backend.connection.BACKENDS',
                             {'catsandra':
-                             'bigchaindb.backend.meowmeow.Catsandra'})
+                             'bigchaindb.backend.meowmeow.CatsandraConnection'})
 
-        connect('catsandra', 'localhost', '1337', 'mydb')
+        connect(backend='catsandra', host='localhost', port='1337', extra='mydb')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,7 +117,7 @@ def _configure_bigchaindb(request):
         test_db_name = '{}_{}'.format(TEST_DB_NAME, xdist_suffix)
     config = {
         'database': {
-            'name': test_db_name,
+            'dbname': test_db_name,
             'backend': request.config.getoption('--database-backend'),
         },
         'keypair': {
@@ -138,7 +138,7 @@ def _setup_database(_configure_bigchaindb):
     from bigchaindb.backend import connect, schema
     from bigchaindb.common.exceptions import DatabaseDoesNotExist
     print('Initializing test db')
-    dbname = config['database']['name']
+    dbname = config['database']['dbname']
     conn = connect()
 
     try:
@@ -167,7 +167,7 @@ def _bdb(_setup_database, _configure_bigchaindb):
     from bigchaindb import config
     from bigchaindb.backend import connect
     from .utils import flush_db
-    dbname = config['database']['name']
+    dbname = config['database']['dbname']
     conn = connect()
     flush_db(conn, dbname)
 

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -124,9 +124,9 @@ def test_autoconfigure_read_both_from_file_and_env(monkeypatch, request):
         },
         'database': {
             'backend': request.config.getoption('--database-backend'),
+            'dbname': 'test-dbname',
             'host': 'test-host',
             'port': 4242,
-            'name': 'test-dbname',
         },
         'keypair': {
             'public': None,
@@ -144,7 +144,7 @@ def test_autoconfigure_read_both_from_file_and_env(monkeypatch, request):
 
 def test_autoconfigure_env_precedence(monkeypatch):
     file_config = {
-        'database': {'host': 'test-host', 'name': 'bigchaindb', 'port': 28015}
+        'database': {'host': 'test-host', 'dbname': 'bigchaindb', 'port': 28015}
     }
     monkeypatch.setattr('bigchaindb.config_utils.file_config', lambda *args, **kwargs: file_config)
     monkeypatch.setattr('os.environ', {'BIGCHAINDB_DATABASE_NAME': 'test-dbname',
@@ -157,7 +157,7 @@ def test_autoconfigure_env_precedence(monkeypatch):
 
     assert bigchaindb.config['CONFIGURED']
     assert bigchaindb.config['database']['host'] == 'test-host'
-    assert bigchaindb.config['database']['name'] == 'test-dbname'
+    assert bigchaindb.config['database']['dbname'] == 'test-dbname'
     assert bigchaindb.config['database']['port'] == 4242
     assert bigchaindb.config['server']['bind'] == 'localhost:9985'
 
@@ -167,16 +167,16 @@ def test_update_config(monkeypatch):
     from bigchaindb import config_utils
 
     file_config = {
-        'database': {'host': 'test-host', 'name': 'bigchaindb', 'port': 28015}
+        'database': {'host': 'test-host', 'dbname': 'bigchaindb', 'port': 28015}
     }
     monkeypatch.setattr('bigchaindb.config_utils.file_config', lambda *args, **kwargs: file_config)
     config_utils.autoconfigure(config=file_config)
 
     # update configuration, retaining previous changes
-    config_utils.update_config({'database': {'port': 28016, 'name': 'bigchaindb_other'}})
+    config_utils.update_config({'database': {'port': 28016, 'dbname': 'bigchaindb_other'}})
 
     assert bigchaindb.config['database']['host'] == 'test-host'
-    assert bigchaindb.config['database']['name'] == 'bigchaindb_other'
+    assert bigchaindb.config['database']['dbname'] == 'bigchaindb_other'
     assert bigchaindb.config['database']['port'] == 28016
 
 

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -106,7 +106,7 @@ def test_autoconfigure_read_both_from_file_and_env(monkeypatch, request):
         'backlog_reassign_delay': 5
     }
     monkeypatch.setattr('bigchaindb.config_utils.file_config', lambda *args, **kwargs: file_config)
-    monkeypatch.setattr('os.environ', {'BIGCHAINDB_DATABASE_NAME': 'test-dbname',
+    monkeypatch.setattr('os.environ', {'BIGCHAINDB_DATABASE_DBNAME': 'test-dbname',
                                        'BIGCHAINDB_DATABASE_PORT': '4242',
                                        'BIGCHAINDB_SERVER_BIND': '1.2.3.4:56',
                                        'BIGCHAINDB_KEYRING': 'pubkey_0:pubkey_1:pubkey_2'})
@@ -147,7 +147,7 @@ def test_autoconfigure_env_precedence(monkeypatch):
         'database': {'host': 'test-host', 'dbname': 'bigchaindb', 'port': 28015}
     }
     monkeypatch.setattr('bigchaindb.config_utils.file_config', lambda *args, **kwargs: file_config)
-    monkeypatch.setattr('os.environ', {'BIGCHAINDB_DATABASE_NAME': 'test-dbname',
+    monkeypatch.setattr('os.environ', {'BIGCHAINDB_DATABASE_DBNAME': 'test-dbname',
                                        'BIGCHAINDB_DATABASE_PORT': '4242',
                                        'BIGCHAINDB_SERVER_BIND': 'localhost:9985'})
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,9 +6,9 @@ def config(request, monkeypatch):
     config = {
         'database': {
             'backend': request.config.getoption('--database-backend'),
+            'dbname': 'bigchain',
             'host': 'host',
             'port': 28015,
-            'name': 'bigchain',
         },
         'keypair': {
             'public': 'pubkey',
@@ -32,7 +32,7 @@ def test_bigchain_class_default_initialization(config):
     assert isinstance(bigchain.connection, Connection)
     assert bigchain.connection.host == config['database']['host']
     assert bigchain.connection.port == config['database']['port']
-    assert bigchain.connection.dbname == config['database']['name']
+    assert bigchain.connection.dbname == config['database']['dbname']
     assert bigchain.me == config['keypair']['public']
     assert bigchain.me_private == config['keypair']['private']
     assert bigchain.nodes_except_me == config['keyring']
@@ -50,16 +50,16 @@ def test_bigchain_class_initialization_with_parameters(config):
     }
     init_db_kwargs = {
         'backend': 'rethinkdb',
+        'dbname': 'this_is_the_db_name',
         'host': 'this_is_the_db_host',
         'port': 12345,
-        'name': 'this_is_the_db_name',
     }
     connection = connect(**init_db_kwargs)
     bigchain = Bigchain(connection=connection, **init_kwargs)
     assert bigchain.connection == connection
     assert bigchain.connection.host == init_db_kwargs['host']
     assert bigchain.connection.port == init_db_kwargs['port']
-    assert bigchain.connection.dbname == init_db_kwargs['name']
+    assert bigchain.connection.dbname == init_db_kwargs['dbname']
     assert bigchain.me == init_kwargs['public_key']
     assert bigchain.me_private == init_kwargs['private_key']
     assert bigchain.nodes_except_me == init_kwargs['keyring']


### PR DESCRIPTION
Fixes #949.

Doing this rename also allows us to have a simpler implementation of `backend.connect()`, whereby we update the current node's config with any given keyword arguments and pass the result to instantiate a `Connection` instance.

As such, the `Connection` interface has been broadened to accept other arguments (as necessary; nothing takes advantage of this currently) and the `config.database` settings can be customized for each backend.