### PR TITLE
Rename builtin-in input override in commands

### DIFF
--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 # We need this because `input` always prints on stdout, while it should print
 # to stderr. It's a very old bug, check it out here:
 # - https://bugs.python.org/issue1927
-def input_on_stderr(prompt):
+def input_on_stderr(prompt=''):
     print(prompt, end='', file=sys.stderr)
     return builtins.input()
 

--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 # We need this because `input` always prints on stdout, while it should print
 # to stderr. It's a very old bug, check it out here:
 # - https://bugs.python.org/issue1927
-def input(prompt):
+def input_on_stderr(prompt):
     print(prompt, end='', file=sys.stderr)
     return builtins.input()
 
@@ -70,8 +70,8 @@ def run_configure(args, skip_if_exists=False):
         return
 
     if config_file_exists and not args.yes:
-        want = input('Config file `{}` exists, do you want to override it? '
-                     '(cannot be undone) [y/N]: '.format(config_path))
+        want = input_on_stderr('Config file `{}` exists, do you want to '
+                               'override it? (cannot be undone) [y/N]: '.format(config_path))
         if want != 'y':
             return
 
@@ -90,24 +90,25 @@ def run_configure(args, skip_if_exists=False):
         for key in ('bind', ):
             val = conf['server'][key]
             conf['server'][key] = \
-                input('API Server {}? (default `{}`): '.format(key, val)) \
+                input_on_stderr('API Server {}? (default `{}`): '.format(key, val)) \
                 or val
 
         for key in ('host', 'port', 'name'):
             val = conf['database'][key]
             conf['database'][key] = \
-                input('Database {}? (default `{}`): '.format(key, val)) \
+                input_on_stderr('Database {}? (default `{}`): '.format(key, val)) \
                 or val
 
         for key in ('host', 'port', 'rate'):
             val = conf['statsd'][key]
             conf['statsd'][key] = \
-                input('Statsd {}? (default `{}`): '.format(key, val)) \
+                input_on_stderr('Statsd {}? (default `{}`): '.format(key, val)) \
                 or val
 
         val = conf['backlog_reassign_delay']
         conf['backlog_reassign_delay'] = \
-            input('Stale transaction reassignment delay (in seconds)? (default `{}`): '.format(val)) \
+            input_on_stderr(('Stale transaction reassignment delay (in '
+                             'seconds)? (default `{}`): '.format(val))) \
             or val
 
     if config_path != '-':
@@ -164,7 +165,7 @@ def run_drop(args):
     dbname = bigchaindb.config['database']['name']
 
     if not args.yes:
-        response = input('Do you want to drop `{}` database? [y/n]: '.format(dbname))
+        response = input_on_stderr('Do you want to drop `{}` database? [y/n]: '.format(dbname))
         if response != 'y':
             return
 

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -170,7 +170,7 @@ def test_drop_db_when_assumed_yes(mock_db_drop):
 def test_drop_db_when_interactive_yes(mock_db_drop, monkeypatch):
     from bigchaindb.commands.bigchain import run_drop
     args = Namespace(config=None, yes=False)
-    monkeypatch.setattr('bigchaindb.commands.bigchain.input', lambda x: 'y')
+    monkeypatch.setattr('bigchaindb.commands.bigchain.input_on_stderr', lambda x: 'y')
 
     run_drop(args)
     assert mock_db_drop.called
@@ -180,7 +180,7 @@ def test_drop_db_when_interactive_yes(mock_db_drop, monkeypatch):
 def test_drop_db_does_not_drop_when_interactive_no(mock_db_drop, monkeypatch):
     from bigchaindb.commands.bigchain import run_drop
     args = Namespace(config=None, yes=False)
-    monkeypatch.setattr('bigchaindb.commands.bigchain.input', lambda x: 'n')
+    monkeypatch.setattr('bigchaindb.commands.bigchain.input_on_stderr', lambda x: 'n')
 
     run_drop(args)
     assert not mock_db_drop.called
@@ -196,7 +196,7 @@ def test_run_configure_when_config_exists_and_skipping(monkeypatch):
 
 # TODO Beware if you are putting breakpoints in there, and using the '-s'
 # switch with pytest. It will just hang. Seems related to the monkeypatching of
-# input.
+# input_on_stderr.
 def test_run_configure_when_config_does_not_exist(monkeypatch,
                                                   mock_write_config,
                                                   mock_generate_key_pair,


### PR DESCRIPTION
Fixes #897.

Also allows the input override to not require a prompt (similar to how the built-in `input` behaves).