### PR TITLE
update pysha3 to 1.0b1, sha3 NIST 2015 standard

### DIFF
--- a/docs/server/source/appendices/cryptography.md
+++ b/docs/server/source/appendices/cryptography.md
@@ -15,8 +15,9 @@ algorithm provided by the
 which is a wrapper around the optimized reference implementation
 from [http://keccak.noekeon.org](http://keccak.noekeon.org).
 
-Here's the relevant code from `bigchaindb/bigchaindb/common/crypto.py`
-(as of 11 December 2016):
+**Important**: Since selecting the Keccak hashing algorithm for SHA-3 in 2012, NIST [released a new version](https://en.wikipedia.org/wiki/SHA-3#cite_note-14) of the hash using the same algorithm but slightly different parameters. As of version 0.9, BigchainDB is using the latest version. See below for an example output of the hash function.
+
+Here's the relevant code from `bigchaindb/bigchaindb/common/crypto.py:
 
 ```python
 import sha3
@@ -37,7 +38,10 @@ For example:
 >>> import sha3
 >>> data = '字'
 >>> sha3.sha3_256(data.encode()).hexdigest()
-'c67820de36d949a35ca24492e15767e2972b22f77213f6704ac0adec123c5690'
+'2b38731ba4ef72d4034bef49e87c381d1fbe75435163b391dd33249331f91fe7'
+>>> data = 'hello world'
+>>> sha3.sha3_256(data.encode()).hexdigest()
+'644bcc7e564373040999aac89e7622f3ca71fba1d972fd94a31c3bfbf24e3938'
 ```
 
 Note: Hashlocks (which are one kind of crypto-condition)

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ install_requires = [
     # TODO Consider not installing the db drivers, or putting them in extras.
     'rethinkdb~=2.3',  # i.e. a version between 2.3 and 3.0
     'pymongo~=3.4',
-    'pysha3>=0.3',
+    'pysha3==1.0b1',
     'cryptoconditions>=0.5.0',
     'statsd>=3.2.1',
     'python-rapidjson>=0.0.8',


### PR DESCRIPTION
Fixes #884.

I wonder if we can get this into 0.9? For the sake of this blog post?