### PR TITLE
Added ENABLE_WEB_ADMIN config setting to AWS depl. configs

### DIFF
--- a/deploy-cluster-aws/awsdeploy.sh
+++ b/deploy-cluster-aws/awsdeploy.sh
@@ -49,7 +49,10 @@ if [ "$USING_EBS" == "True" ]; then
     echo "EBS_VOLUME_SIZE = "$EBS_VOLUME_SIZE
     echo "EBS_OPTIMIZED = "$EBS_OPTIMIZED
 fi
-echo "BIND_HTTP_TO_LOCALHOST = "$BIND_HTTP_TO_LOCALHOST
+echo "ENABLE_WEB_ADMIN = "$ENABLE_WEB_ADMIN
+if [ "$ENABLE_WEB_ADMIN" == "True" ]; then
+    echo "BIND_HTTP_TO_LOCALHOST = "$BIND_HTTP_TO_LOCALHOST
+fi
 
 # Check for the SSH private key file
 if [ ! -f "$HOME/.ssh/$SSH_KEY_NAME" ]; then
@@ -118,8 +121,12 @@ fab upgrade_setuptools
 
 if [ "$WHAT_TO_DEPLOY" == "servers" ]; then
     # (Re)create the RethinkDB configuration file conf/rethinkdb.conf
-    if [ "$BIND_HTTP_TO_LOCALHOST" == "True" ]; then
-        python create_rethinkdb_conf.py --bind-http-to-localhost
+    if [ "$ENABLE_WEB_ADMIN" == "True" ]; then
+        if [ "$BIND_HTTP_TO_LOCALHOST" == "True" ]; then
+            python create_rethinkdb_conf.py --enable-web-admin --bind-http-to-localhost
+        else
+            python create_rethinkdb_conf.py --enable-web-admin
+        fi
     else
         python create_rethinkdb_conf.py
     fi

--- a/deploy-cluster-aws/create_rethinkdb_conf.py
+++ b/deploy-cluster-aws/create_rethinkdb_conf.py
@@ -14,11 +14,17 @@ from hostlist import public_dns_names
 # Parse the command-line arguments
 parser = argparse.ArgumentParser()
 # The next line isn't strictly necessary, but it clarifies the default case:
+parser.set_defaults(enable_web_admin=False)
+parser.add_argument('--enable-web-admin',
+                    action='store_true',
+                    help='should the RethinkDB web interface be enabled?')
+# The next line isn't strictly necessary, but it clarifies the default case:
 parser.set_defaults(bind_http_to_localhost=False)
 parser.add_argument('--bind-http-to-localhost',
                     action='store_true',
                     help='should RethinkDB web interface be bound to localhost?')
 args = parser.parse_args()
+enable_web_admin = args.enable_web_admin
 bind_http_to_localhost = args.bind_http_to_localhost
 
 # cwd = current working directory
@@ -35,10 +41,15 @@ with open('rethinkdb.conf', 'a') as f:
     f.write('## The host:port of a node that RethinkDB will connect to\n')
     for public_dns_name in public_dns_names:
         f.write('join=' + public_dns_name + ':29015\n')
-    if bind_http_to_localhost:
-        f.write('## Bind the web interface port to localhost\n')
-        # 127.0.0.1 is the usual IP address for localhost
-        f.write('bind-http=127.0.0.1\n')
+    if not enable_web_admin:
+        f.write('## Disable the RethinkDB web administration console\n')
+        f.write('no-http-admin\n')
+    else:
+        # enable the web admin, i.e. don't disable it (the default), and:
+        if bind_http_to_localhost:
+            f.write('## Bind the web interface port to localhost\n')
+            # 127.0.0.1 is the usual IP address for localhost
+            f.write('bind-http=127.0.0.1\n')
 
 os.chdir(old_cwd)
 

--- a/deploy-cluster-aws/example_deploy_conf.py
+++ b/deploy-cluster-aws/example_deploy_conf.py
@@ -75,7 +75,12 @@ EBS_VOLUME_SIZE=30
 # If USING_EBS=False, EBS_OPTIMIZED is irrelevant and not used
 EBS_OPTIMIZED=False
 
+# ENABLE_WEB_ADMIN is True or False, depending on whether you want
+# the RethinkDB web administration console / interface to be enabled.
+ENABLE_WEB_ADMIN=True
+
 # BIND_HTTP_TO_LOCALHOST is True or False, depending on whether
 # you want the RethinkDB web interface port to be bound to localhost
 # (which is more secure). See https://www.rethinkdb.com/docs/security/
+# If ENABLE_WEB_ADMIN is False, BIND_HTTP_TO_LOCALHOST is irrelevant and not used
 BIND_HTTP_TO_LOCALHOST=True

--- a/deploy-cluster-aws/launch_ec2_nodes.py
+++ b/deploy-cluster-aws/launch_ec2_nodes.py
@@ -28,7 +28,8 @@ from awscommon import get_naeips
 
 SETTINGS = ['NUM_NODES', 'BRANCH', 'WHAT_TO_DEPLOY', 'SSH_KEY_NAME',
             'USE_KEYPAIRS_FILE', 'IMAGE_ID', 'INSTANCE_TYPE', 'SECURITY_GROUP',
-            'USING_EBS', 'EBS_VOLUME_SIZE', 'EBS_OPTIMIZED', 'BIND_HTTP_TO_LOCALHOST']
+            'USING_EBS', 'EBS_VOLUME_SIZE', 'EBS_OPTIMIZED',
+            'ENABLE_WEB_ADMIN', 'BIND_HTTP_TO_LOCALHOST']
 
 
 class SettingsTypeError(TypeError):
@@ -103,6 +104,9 @@ if not isinstance(EBS_VOLUME_SIZE, int):
 
 if not isinstance(EBS_OPTIMIZED, bool):
     raise SettingsTypeError('EBS_OPTIMIZED should be a boolean (True or False)')
+
+if not isinstance(ENABLE_WEB_ADMIN, bool):
+    raise SettingsTypeError('ENABLE_WEB_ADMIN should be a boolean (True or False)')
 
 if not isinstance(BIND_HTTP_TO_LOCALHOST, bool):
     raise SettingsTypeError('BIND_HTTP_TO_LOCALHOST should be a boolean '

--- a/docs/server/source/clusters-feds/aws-testing-cluster.md
+++ b/docs/server/source/clusters-feds/aws-testing-cluster.md
@@ -132,6 +132,7 @@ SECURITY_GROUP="bigchaindb"
 USING_EBS=True
 EBS_VOLUME_SIZE=30
 EBS_OPTIMIZED=False
+ENABLE_WEB_ADMIN=True
 BIND_HTTP_TO_LOCALHOST=True
 ```
 
@@ -181,7 +182,7 @@ bigchaindb --help
 bigchaindb show-config
 ```
 
-You can also check out the RethinkDB web interface. The way to do that depends on how `BIND_HTTP_TO_LOCALHOST` was set in your AWS deployment configuration file:
+If you enabled the RethinkDB web interface (by setting `ENABLE_WEB_ADMIN=True` in your AWS configuration file), then you can also check that. The way to do that depends on how `BIND_HTTP_TO_LOCALHOST` was set (in your AWS deployment configuration file):
 
 * If it was set to `False`, then just go to your web browser and visit a web address like `http://ec2-52-29-197-211.eu-central-1.compute.amazonaws.com:8080/`. (Replace `ec2-...aws.com` with the hostname of one of your instances.)
 * If it was set to `True` (the default in the example config file), then follow the instructions in the "Via a SOCKS proxy" section of [the "Secure your cluster" page of the RethinkDB documentation](https://www.rethinkdb.com/docs/security/).


### PR DESCRIPTION
I added another configuration setting to the AWS deployment configuration file: `ENABLE_WEB_ADMIN`. It can be `True` or `False`. Setting it to `False` is a way to add security, because anyone with access to the web admin interface has full admin powers, and there's no (built-in) way to make it ask for login credentials.

This pull request resolves #843 
