### PR TITLE
duplicate tx.id into tx.asset.id in CREATE transactions

### DIFF
--- a/bigchaindb/backend/mongodb/query.py
+++ b/bigchaindb/backend/mongodb/query.py
@@ -1,7 +1,6 @@
 """Query implementation for MongoDB"""
 
 from time import time
-from itertools import chain
 
 from pymongo import ReturnDocument
 from pymongo import errors

--- a/bigchaindb/backend/mongodb/query.py
+++ b/bigchaindb/backend/mongodb/query.py
@@ -85,22 +85,6 @@ def get_blocks_status_from_transaction(conn, transaction_id):
 
 @register_query(MongoDBConnection)
 def get_txids_by_asset_id(conn, asset_id):
-    # get the txid of the create transaction for asset_id
-    cursor = conn.db['bigchain'].aggregate([
-        {'$match': {
-            'block.transactions.id': asset_id,
-            'block.transactions.operation': 'CREATE'
-        }},
-        {'$unwind': '$block.transactions'},
-        {'$match': {
-            'block.transactions.id': asset_id,
-            'block.transactions.operation': 'CREATE'
-        }},
-        {'$project': {'block.transactions.id': True}}
-    ])
-    create_tx_txids = (elem['block']['transactions']['id'] for elem in cursor)
-
-    # get txids of transfer transaction with asset_id
     cursor = conn.db['bigchain'].aggregate([
         {'$match': {
             'block.transactions.asset.id': asset_id
@@ -111,9 +95,7 @@ def get_txids_by_asset_id(conn, asset_id):
         }},
         {'$project': {'block.transactions.id': True}}
     ])
-    transfer_tx_ids = (elem['block']['transactions']['id'] for elem in cursor)
-
-    return chain(create_tx_txids, transfer_tx_ids)
+    return (elem['block']['transactions']['id'] for elem in cursor)
 
 
 @register_query(MongoDBConnection)

--- a/bigchaindb/backend/rethinkdb/query.py
+++ b/bigchaindb/backend/rethinkdb/query.py
@@ -1,4 +1,3 @@
-from itertools import chain
 from time import time
 
 import rethinkdb as r
@@ -77,19 +76,15 @@ def get_txids_by_asset_id(connection, asset_id):
     # here we only want to return the transaction ids since later on when
     # we are going to retrieve the transaction with status validation
 
-    # First find the asset's CREATE transaction
-    create_tx_cursor = connection.run(
-        _get_asset_create_tx_query(asset_id).get_field('id'))
-
     # Then find any TRANSFER transactions related to the asset
-    transfer_tx_cursor = connection.run(
+    tx_cursor = connection.run(
         r.table('bigchain')
          .get_all(asset_id, index='asset_id')
          .concat_map(lambda block: block['block']['transactions'])
          .filter(lambda transaction: transaction['asset']['id'] == asset_id)
          .get_field('id'))
 
-    return chain(create_tx_cursor, transfer_tx_cursor)
+    return tx_cursor
 
 
 @register_query(RethinkDBConnection)

--- a/bigchaindb/common/schema/transaction.yaml
+++ b/bigchaindb/common/schema/transaction.yaml
@@ -104,7 +104,7 @@ definitions:
         Description of the asset being transacted. In the case of a ``TRANSFER``
         transaction, this field contains only the ID of asset. In the case
         of a ``CREATE`` transaction, this field contains the user-defined
-        payload and may contain the asset ID (duplicated from the Transaction ID).
+        payload and the asset ID (duplicated from the Transaction ID).
     additionalProperties: false
     properties:
       id:

--- a/bigchaindb/common/schema/transaction.yaml
+++ b/bigchaindb/common/schema/transaction.yaml
@@ -103,8 +103,8 @@ definitions:
     description: |
         Description of the asset being transacted. In the case of a ``TRANSFER``
         transaction, this field contains only the ID of asset. In the case
-        of a ``CREATE`` transaction, this field contains only the user-defined
-        payload.
+        of a ``CREATE`` transaction, this field contains the user-defined
+        payload and may contain the asset ID (duplicated from the Transaction ID).
     additionalProperties: false
     properties:
       id:

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -444,6 +444,7 @@ class Transaction(object):
                 asset is not None and not (isinstance(asset, dict) and 'data' in asset)):
             raise TypeError(('`asset` must be None or a dict holding a `data` '
                              " property instance for '{}' Transactions".format(operation)))
+            asset.pop('id', None)  # Remove duplicated asset ID if there is one
         elif (operation == Transaction.TRANSFER and
                 not (isinstance(asset, dict) and 'id' in asset)):
             raise TypeError(('`asset` must be a dict holding an `id` property '
@@ -926,9 +927,11 @@ class Transaction(object):
 
         tx_no_signatures = Transaction._remove_signatures(tx)
         tx_serialized = Transaction._to_str(tx_no_signatures)
-        tx_id = Transaction._to_hash(tx_serialized)
-
-        tx['id'] = tx_id
+        tx['id'] = Transaction._to_hash(tx_serialized)
+        if self.operation == Transaction.CREATE:
+            # Duplicate asset into asset for consistency with TRANSFER
+            # transactions
+            tx['asset']['id'] = tx['id']
         return tx
 
     @staticmethod
@@ -952,6 +955,9 @@ class Transaction(object):
             #       case could yield incorrect signatures. This is why we only
             #       set it to `None` if it's set in the dict.
             input_['fulfillment'] = None
+        # Pop duplicated asset_id from CREATE tx
+        if tx_dict['operation'] == Transaction.CREATE:
+            tx_dict['asset'].pop('id', None)
         return tx_dict
 
     @staticmethod
@@ -1030,6 +1036,10 @@ class Transaction(object):
             err_msg = ("The transaction's id '{}' isn't equal to "
                        "the hash of its body, i.e. it's not valid.")
             raise InvalidHash(err_msg.format(proposed_tx_id))
+
+        if tx_body.get('operation') == Transaction.CREATE:
+            if proposed_tx_id != tx_body['asset'].get('id'):
+                raise InvalidHash("CREATE tx has wrong asset_id")
 
     @classmethod
     def from_dict(cls, tx):

--- a/docs/server/source/data-models/asset-model.md
+++ b/docs/server/source/data-models/asset-model.md
@@ -1,10 +1,11 @@
 # The Digital Asset Model
 
-To avoid redundant data in transactions, the digital asset model is different for `CREATE` and `TRANSFER` transactions.
+The asset ID is the same as the ID of the CREATE transaction that defined the asset.
 
-A digital asset's properties are defined in a `CREATE` transaction with the following model:
+In the case of a CREATE transaction, the transaction ID is duplicated into the asset object for clarity and consistency in the database. The CREATE transaction also contains a user definable payload to describe the asset:
 ```json
 {
+    "id": "<same as transaction ID (sha3-256 hash)>",
     "data": "<json document>"
 }
 ```

--- a/tests/assets/test_digital_assets.py
+++ b/tests/assets/test_digital_assets.py
@@ -118,11 +118,8 @@ def test_get_transactions_by_asset_id(b, user_pk, user_sk):
     txs = b.get_transactions_by_asset_id(asset_id)
 
     assert len(txs) == 2
-    assert tx_create.id in [t.id for t in txs]
-    assert tx_transfer.id in [t.id for t in txs]
-    # FIXME: can I rely on the ordering here?
-    assert asset_id == txs[0].id
-    assert asset_id == txs[1].asset['id']
+    assert {tx_create.id, tx_transfer.id} == set(tx.id for tx in txs)
+    assert {asset_id} == {Transaction.get_asset_id(txs)}
 
 
 @pytest.mark.bdb

--- a/tests/assets/test_digital_assets.py
+++ b/tests/assets/test_digital_assets.py
@@ -119,7 +119,7 @@ def test_get_transactions_by_asset_id(b, user_pk, user_sk):
 
     assert len(txs) == 2
     assert {tx_create.id, tx_transfer.id} == set(tx.id for tx in txs)
-    assert {asset_id} == {Transaction.get_asset_id(txs)}
+    assert asset_id == Transaction.get_asset_id(txs)
 
 
 @pytest.mark.bdb

--- a/tests/common/test_transaction.py
+++ b/tests/common/test_transaction.py
@@ -958,7 +958,6 @@ def test_cant_add_empty_output():
 
 
 def test_cant_add_empty_input():
-    import bigchaindb.version
     from bigchaindb.common.transaction import Transaction
     tx = Transaction(Transaction.CREATE, None)
 

--- a/tests/common/test_transaction.py
+++ b/tests/common/test_transaction.py
@@ -300,6 +300,7 @@ def test_transaction_serialization(user_input, user_output, data):
         'operation': Transaction.CREATE,
         'metadata': None,
         'asset': {
+            'id': tx_id,
             'data': data,
         }
     }
@@ -307,7 +308,7 @@ def test_transaction_serialization(user_input, user_output, data):
     tx = Transaction(Transaction.CREATE, {'data': data}, [user_input],
                      [user_output])
     tx_dict = tx.to_dict()
-    tx_dict['id'] = tx_id
+    tx_dict['id'] = tx_dict['asset']['id'] = tx_id
 
     assert tx_dict == expected
 
@@ -334,6 +335,7 @@ def test_transaction_deserialization(user_input, user_output, data):
     }
     tx_no_signatures = Transaction._remove_signatures(tx)
     tx['id'] = Transaction._to_hash(Transaction._to_str(tx_no_signatures))
+    tx['asset']['id'] = tx['id']
     tx = Transaction.from_dict(tx)
 
     assert tx == expected
@@ -680,6 +682,7 @@ def test_create_create_transaction_single_io(user_output, user_pub, data):
     tx_dict = tx.to_dict()
     tx_dict['inputs'][0]['fulfillment'] = None
     tx_dict.pop('id')
+    tx_dict['asset'].pop('id')
 
     assert tx_dict == expected
 
@@ -763,6 +766,7 @@ def test_create_create_transaction_threshold(user_pub, user2_pub, user3_pub,
                             metadata=data, asset=data)
     tx_dict = tx.to_dict()
     tx_dict.pop('id')
+    tx_dict['asset'].pop('id')
     tx_dict['inputs'][0]['fulfillment'] = None
 
     assert tx_dict == expected
@@ -975,3 +979,25 @@ def test_validate_version(utx):
     utx.version = '1.0.0'
     with raises(SchemaValidationError):
         validate_transaction_model(utx)
+
+
+def test_create_tx_has_asset_id(tx):
+    tx = tx.to_dict()
+    assert tx['id'] == tx['asset']['id']
+
+
+def test_create_tx_validates_asset_id(tx):
+    from bigchaindb.common.transaction import Transaction
+    from bigchaindb.common.exceptions import InvalidHash
+
+    tx = tx.to_dict()
+
+    # Test fails with wrong asset_id
+    tx['asset']['id'] = tx['asset']['id'][::-1]
+    with raises(InvalidHash):
+        Transaction.from_dict(tx)
+
+    # Test fails with no asset_id
+    tx['asset'].pop('id')
+    with raises(InvalidHash):
+        Transaction.from_dict(tx)


### PR DESCRIPTION
Fixes #1033 

All CREATE transactions must have `id` duplicated into `asset.id`.

```json
{
  "asset": {
    "data": null,
    "id": "7a21b877db0b1e3cbf7cd8967be8f990be1d6ebb09e2967f15577b4b23c8e3b8"
  },
  "id": "7a21b877db0b1e3cbf7cd8967be8f990be1d6ebb09e2967f15577b4b23c8e3b8",
```

@ttmc 
![screenshot from 2017-01-16 15-21-51](https://cloud.githubusercontent.com/assets/125019/21986509/fb2df1d0-dbff-11e6-96f0-003f43a455f9.png)
