### PR TITLE
Closes #1038

### DIFF
--- a/bigchaindb/web/server.py
+++ b/bigchaindb/web/server.py
@@ -6,7 +6,7 @@ The application is implemented in Flask and runs using Gunicorn.
 import copy
 import multiprocessing
 
-from flask import Flask
+from flask import Flask, got_request_exception
 import gunicorn.app.base
 
 from bigchaindb import utils
@@ -14,6 +14,17 @@ from bigchaindb import Bigchain
 from bigchaindb.web.routes import add_routes
 
 from bigchaindb.monitor import Monitor
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def log_exception(sender, exception, **extra):
+    """ Log an exception to our logging framework """
+    # TODO log via the sneder object instead:
+    # sender.logger.warning('Got exception during processing: %s', exception)
+    logger.warning('Got exception during processing: %s', exception)
 
 
 # TODO: Figure out if we do we need all this boilerplate.
@@ -68,6 +79,7 @@ def create_app(*, debug=False, threads=4):
     app.config['monitor'] = Monitor()
 
     add_routes(app)
+    got_request_exception.connect(log_exception, app)
 
     return app
 

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ install_requires = [
     'multipipes~=0.1.0',
     'jsonschema~=2.5.1',
     'pyyaml~=3.12',
+    'blinker~=1.4',
 ]
 
 setup(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,11 +272,44 @@ def genesis_block(b):
 
 
 @pytest.fixture
+def backlog_tx(b, signed_create_tx):
+    b.write_transaction(signed_create_tx)
+    return signed_create_tx
+
+
+@pytest.fixture
+def undecided_block(b, signed_create_tx):
+    block = b.create_block([signed_create_tx])
+    b.write_block(block)
+    return block
+
+
+@pytest.fixture
+def undecided_block_2(b, signed_create_tx, signed_transfer_tx):
+    block = b.create_block([signed_create_tx, signed_transfer_tx])
+    b.write_block(block)
+    return block
+
+
+@pytest.fixture
+def undecided_tx(b, undecided_block):
+    return undecided_block.transactions[0]
+
+
+@pytest.fixture
+def valid_block(b, genesis_block, undecided_block):
+    vote = b.vote(undecided_block.id, genesis_block.id, True)
+    b.write_vote(vote)
+    return undecided_block
+
+
+@pytest.fixture
 def inputs(user_pk, b, genesis_block):
     from bigchaindb.models import Transaction
 
     # create blocks with transactions for `USER` to spend
     prev_block_id = genesis_block.id
+    blocks = []
     for block in range(4):
         transactions = [
             Transaction.create(
@@ -293,6 +326,8 @@ def inputs(user_pk, b, genesis_block):
         vote = b.vote(block.id, prev_block_id, True)
         prev_block_id = block.id
         b.write_vote(vote)
+        blocks.append(block)
+    return blocks
 
 
 @pytest.fixture


### PR DESCRIPTION
Following the spec commented on at https://github.com/bigchaindb/bigchaindb/pull/830#pullrequestreview-17058946

Known limitation:

- No filter to combine statuses, e.g.: `status=backlog,undecided` -- Needs to be clarified in the spec.