### PR TITLE
Added replicaset name to bigchaindb config

### DIFF
--- a/.ci/travis-before-script.sh
+++ b/.ci/travis-before-script.sh
@@ -8,5 +8,5 @@ elif [[ "${BIGCHAINDB_DATABASE_BACKEND}" == mongodb ]]; then
     wget http://downloads.mongodb.org/linux/mongodb-linux-x86_64-3.4.1.tgz -O /tmp/mongodb.tgz
     tar -xvf /tmp/mongodb.tgz
     mkdir /tmp/mongodb-data
-    ${PWD}/mongodb-linux-x86_64-3.4.1/bin/mongod --dbpath=/tmp/mongodb-data --replSet=rs0 &> /dev/null &
+    ${PWD}/mongodb-linux-x86_64-3.4.1/bin/mongod --dbpath=/tmp/mongodb-data --replSet=bigchain-rs &> /dev/null &
 fi

--- a/.ci/travis-before-script.sh
+++ b/.ci/travis-before-script.sh
@@ -8,5 +8,5 @@ elif [[ "${BIGCHAINDB_DATABASE_BACKEND}" == mongodb ]]; then
     wget http://downloads.mongodb.org/linux/mongodb-linux-x86_64-3.4.1.tgz -O /tmp/mongodb.tgz
     tar -xvf /tmp/mongodb.tgz
     mkdir /tmp/mongodb-data
-    ${PWD}/mongodb-linux-x86_64-3.4.1/bin/mongod --dbpath=/tmp/mongodb-data --replSet=bigchain-rs &> /dev/null &
+    ${PWD}/mongodb-linux-x86_64-3.4.1/bin/mongod --dbpath=/tmp/mongodb-data --replSet=bigchain-rs &
 fi

--- a/.ci/travis-before-script.sh
+++ b/.ci/travis-before-script.sh
@@ -8,5 +8,5 @@ elif [[ "${BIGCHAINDB_DATABASE_BACKEND}" == mongodb ]]; then
     wget http://downloads.mongodb.org/linux/mongodb-linux-x86_64-3.4.1.tgz -O /tmp/mongodb.tgz
     tar -xvf /tmp/mongodb.tgz
     mkdir /tmp/mongodb-data
-    ${PWD}/mongodb-linux-x86_64-3.4.1/bin/mongod --dbpath=/tmp/mongodb-data --replSet=bigchain-rs &
+    ${PWD}/mongodb-linux-x86_64-3.4.1/bin/mongod --dbpath=/tmp/mongodb-data --replSet=bigchain-rs &> /dev/null &
 fi

--- a/bigchaindb/__init__.py
+++ b/bigchaindb/__init__.py
@@ -18,7 +18,8 @@ config = {
         'backend': os.environ.get('BIGCHAINDB_DATABASE_BACKEND', 'rethinkdb'),
         'host': os.environ.get('BIGCHAINDB_DATABASE_HOST', 'localhost'),
         'port': int(os.environ.get('BIGCHAINDB_DATABASE_PORT', 28015)),
-        'name': 'bigchain',
+        'name': os.environ.get('BIGCHAINDB_DATABASE_NAME', 'bigchain'),
+        'replicaset': os.environ.get('BIGCHAINDB_DATABASE_REPLICASET', 'bigchain-rs'),
     },
     'keypair': {
         'public': None,

--- a/bigchaindb/backend/connection.py
+++ b/bigchaindb/backend/connection.py
@@ -13,7 +13,7 @@ BACKENDS = {
 logger = logging.getLogger(__name__)
 
 
-def connect(backend=None, host=None, port=None, name=None):
+def connect(backend=None, host=None, port=None, name=None, replicaset=None):
     """Create a new connection to the database backend.
 
     All arguments default to the current configuration's values if not
@@ -24,6 +24,8 @@ def connect(backend=None, host=None, port=None, name=None):
         host (str): the host to connect to.
         port (int): the port to connect to.
         name (str): the name of the database to use.
+        replicaset (str): the name of the replica set (only relevant for
+                          MongoDB connections).
 
     Returns:
         An instance of :class:`~bigchaindb.backend.connection.Connection`

--- a/bigchaindb/backend/mongodb/connection.py
+++ b/bigchaindb/backend/mongodb/connection.py
@@ -6,6 +6,7 @@ from pymongo.errors import ConnectionFailure
 
 import bigchaindb
 from bigchaindb.backend.connection import Connection
+from bigchaindb.backend import mongodb
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,10 @@ class MongoDBConnection(Connection):
     def _connect(self):
         for i in range(self.max_tries):
             try:
+                # we should only return a connection if the replica set is
+                # initialized. initialize_replica_set will check if the
+                # replica set is initialized else it will initialize it.
+                mongodb.schema.initialize_replica_set()
                 self.connection = MongoClient(self.host, self.port,
                                               replicaset=self.replicaset)
             except ConnectionFailure as exc:

--- a/bigchaindb/backend/mongodb/connection.py
+++ b/bigchaindb/backend/mongodb/connection.py
@@ -2,11 +2,11 @@ import time
 import logging
 
 from pymongo import MongoClient
-from pymongo.errors import ConnectionFailure
+from pymongo import errors
 
 import bigchaindb
+from bigchaindb.common import exceptions
 from bigchaindb.backend.connection import Connection
-from bigchaindb.backend import mongodb
 
 logger = logging.getLogger(__name__)
 
@@ -49,11 +49,87 @@ class MongoDBConnection(Connection):
                 # we should only return a connection if the replica set is
                 # initialized. initialize_replica_set will check if the
                 # replica set is initialized else it will initialize it.
-                mongodb.schema.initialize_replica_set()
+                initialize_replica_set()
                 self.connection = MongoClient(self.host, self.port,
                                               replicaset=self.replicaset)
-            except ConnectionFailure as exc:
+            except errors.ConnectionFailure as exc:
                 if i + 1 == self.max_tries:
                     raise
                 else:
                     time.sleep(2**i)
+
+
+def initialize_replica_set():
+    """Initialize a replica set. If already initialized skip."""
+
+    # Setup a MongoDB connection
+    # The reason we do this instead of `backend.connect` is that
+    # `backend.connect` will connect you to a replica set but this fails if
+    # you try to connect to a replica set that is not yet initialized
+    conn = MongoClient(host=bigchaindb.config['database']['host'],
+                       port=bigchaindb.config['database']['port'])
+    _check_replica_set(conn)
+    config = {'_id': bigchaindb.config['database']['replicaset'],
+              'members': [{'_id': 0, 'host': 'localhost:27017'}]}
+
+    try:
+        conn.admin.command('replSetInitiate', config)
+    except errors.OperationFailure as exc_info:
+        if exc_info.details['codeName'] == 'AlreadyInitialized':
+            return
+        raise
+    else:
+        _wait_for_replica_set_initialization(conn)
+        logger.info('Initialized replica set')
+
+
+def _check_replica_set(conn):
+    """Checks if the replSet option was enabled either through the command
+       line option or config file and if it matches the one provided by
+       bigchaindb configuration.
+
+       Note:
+           The setting we are looking for will have a different name depending
+           if it was set by the config file (`replSetName`) or by command
+           line arguments (`replSet`).
+
+        Raise:
+            :exc:`~ConfigurationError`: If mongod was not started with the
+            replSet option.
+    """
+    options = conn.admin.command('getCmdLineOpts')
+    try:
+        repl_opts = options['parsed']['replication']
+        repl_set_name = repl_opts.get('replSetName', None) or repl_opts['replSet']
+    except KeyError:
+        raise exceptions.ConfigurationError('mongod was not started with'
+                                            ' the replSet option.')
+
+    bdb_repl_set_name = bigchaindb.config['database']['replicaset']
+    if repl_set_name != bdb_repl_set_name:
+        raise exceptions.ConfigurationError('The replicaset configuration of '
+                                            'bigchaindb (`{}`) needs to match '
+                                            'the replica set name from MongoDB'
+                                            ' (`{}`)'
+                                            .format(bdb_repl_set_name,
+                                                    repl_set_name))
+
+
+def _wait_for_replica_set_initialization(conn):
+    """Wait for a replica set to finish initialization.
+
+    If a replica set is being initialized for the first time it takes some
+    time. Nodes need to discover each other and an election needs to take
+    place. During this time the database is not writable so we need to wait
+    before continuing with the rest of the initialization
+    """
+
+    # I did not find a better way to do this for now.
+    # To check if the database is ready we will poll the mongodb logs until
+    # we find the line that says the database is ready
+    logger.info('Waiting for mongodb replica set initialization')
+    while True:
+        logs = conn.admin.command('getLog', 'rs')['log']
+        if any('database writes are now permitted' in line for line in logs):
+                return
+        time.sleep(0.1)

--- a/bigchaindb/backend/mongodb/connection.py
+++ b/bigchaindb/backend/mongodb/connection.py
@@ -12,7 +12,8 @@ logger = logging.getLogger(__name__)
 
 class MongoDBConnection(Connection):
 
-    def __init__(self, host=None, port=None, dbname=None, max_tries=3):
+    def __init__(self, host=None, port=None, dbname=None, max_tries=3,
+                 replicaset=None):
         """Create a new Connection instance.
 
         Args:
@@ -20,10 +21,13 @@ class MongoDBConnection(Connection):
             port (int, optional): the port to connect to.
             dbname (str, optional): the database to use.
             max_tries (int, optional): how many tries before giving up.
+            replicaset (str, optional): the name of the replica set to
+                                        connect to.
         """
 
         self.host = host or bigchaindb.config['database']['host']
         self.port = port or bigchaindb.config['database']['port']
+        self.replicaset = replicaset or bigchaindb.config['database']['replicaset']
         self.dbname = dbname or bigchaindb.config['database']['name']
         self.max_tries = max_tries
         self.connection = None
@@ -41,7 +45,8 @@ class MongoDBConnection(Connection):
     def _connect(self):
         for i in range(self.max_tries):
             try:
-                self.connection = MongoClient(self.host, self.port)
+                self.connection = MongoClient(self.host, self.port,
+                                              replicaset=self.replicaset)
             except ConnectionFailure as exc:
                 if i + 1 == self.max_tries:
                     raise

--- a/bigchaindb/backend/mongodb/schema.py
+++ b/bigchaindb/backend/mongodb/schema.py
@@ -147,6 +147,7 @@ def _check_replica_set(conn):
                                             .format(bdb_repl_set_name,
                                                     repl_set_name))
 
+
 def _wait_for_replica_set_initialization(conn):
     """Wait for a replica set to finish initialization.
 

--- a/bigchaindb/backend/mongodb/schema.py
+++ b/bigchaindb/backend/mongodb/schema.py
@@ -1,13 +1,9 @@
 """Utils to initialize and drop the database."""
 
-import time
 import logging
 
-from pymongo import MongoClient
 from pymongo import ASCENDING, DESCENDING
-from pymongo import errors
 
-import bigchaindb
 from bigchaindb import backend
 from bigchaindb.common import exceptions
 from bigchaindb.backend.utils import module_dispatch_registrar
@@ -94,79 +90,3 @@ def create_votes_secondary_index(conn, dbname):
                                              ('node_pubkey',
                                               ASCENDING)],
                                             name='block_and_voter')
-
-
-def initialize_replica_set():
-    """Initialize a replica set. If already initialized skip."""
-
-    # Setup a MongoDB connection
-    # The reason we do this instead of `backend.connect` is that
-    # `backend.connect` will connect you to a replica set but this fails if
-    # you try to connect to a replica set that is not yet initialized
-    conn = MongoClient(host=bigchaindb.config['database']['host'],
-                       port=bigchaindb.config['database']['port'])
-    _check_replica_set(conn)
-    config = {'_id': bigchaindb.config['database']['replicaset'],
-              'members': [{'_id': 0, 'host': 'localhost:27017'}]}
-
-    try:
-        conn.admin.command('replSetInitiate', config)
-    except errors.OperationFailure as exc_info:
-        if exc_info.details['codeName'] == 'AlreadyInitialized':
-            return
-        raise
-    else:
-        _wait_for_replica_set_initialization(conn)
-        logger.info('Initialized replica set')
-
-
-def _check_replica_set(conn):
-    """Checks if the replSet option was enabled either through the command
-       line option or config file and if it matches the one provided by
-       bigchaindb configuration.
-
-       Note:
-           The setting we are looking for will have a different name depending
-           if it was set by the config file (`replSetName`) or by command
-           line arguments (`replSet`).
-
-        Raise:
-            :exc:`~ConfigurationError`: If mongod was not started with the
-            replSet option.
-    """
-    options = conn.admin.command('getCmdLineOpts')
-    try:
-        repl_opts = options['parsed']['replication']
-        repl_set_name = repl_opts.get('replSetName', None) or repl_opts['replSet']
-    except KeyError:
-        raise exceptions.ConfigurationError('mongod was not started with'
-                                            ' the replSet option.')
-
-    bdb_repl_set_name = bigchaindb.config['database']['replicaset']
-    if repl_set_name != bdb_repl_set_name:
-        raise exceptions.ConfigurationError('The replicaset configuration of '
-                                            'bigchaindb (`{}`) needs to match '
-                                            'the replica set name from MongoDB'
-                                            ' (`{}`)'
-                                            .format(bdb_repl_set_name,
-                                                    repl_set_name))
-
-
-def _wait_for_replica_set_initialization(conn):
-    """Wait for a replica set to finish initialization.
-
-    If a replica set is being initialized for the first time it takes some
-    time. Nodes need to discover each other and an election needs to take
-    place. During this time the database is not writable so we need to wait
-    before continuing with the rest of the initialization
-    """
-
-    # I did not find a better way to do this for now.
-    # To check if the database is ready we will poll the mongodb logs until
-    # we find the line that says the database is ready
-    logger.info('Waiting for mongodb replica set initialization')
-    while True:
-        logs = conn.admin.command('getLog', 'rs')['log']
-        if any('database writes are now permitted' in line for line in logs):
-                return
-        time.sleep(0.1)

--- a/bigchaindb/backend/mongodb/schema.py
+++ b/bigchaindb/backend/mongodb/schema.py
@@ -3,6 +3,7 @@
 import time
 import logging
 
+from pymongo import MongoClient
 from pymongo import ASCENDING, DESCENDING
 from pymongo import errors
 
@@ -26,9 +27,6 @@ def create_database(conn, dbname):
     logger.info('Create database `%s`.', dbname)
     # TODO: read and write concerns can be declared here
     conn.conn.get_database(dbname)
-
-    # initialize the replica set
-    initialize_replica_set(conn)
 
 
 @register_schema(MongoDBConnection)
@@ -98,17 +96,23 @@ def create_votes_secondary_index(conn, dbname):
                                             name='block_and_voter')
 
 
-def initialize_replica_set(conn):
+def initialize_replica_set():
     """Initialize a replica set. If already initialized skip."""
+
+    # Setup a MongoDB connection
+    # The reason we do this instead of `backend.connect` is that
+    # `backend.connect` will connect you to a replica set but this fails if
+    # you try to connect to a replica set that is not yet initialized
+    conn = MongoClient(host=bigchaindb.config['database']['host'],
+                       port=bigchaindb.config['database']['port'])
     _check_replica_set(conn)
     config = {'_id': bigchaindb.config['database']['replicaset'],
               'members': [{'_id': 0, 'host': 'localhost:27017'}]}
 
     try:
-        conn.conn.admin.command('replSetInitiate', config)
+        conn.admin.command('replSetInitiate', config)
     except errors.OperationFailure as exc_info:
         if exc_info.details['codeName'] == 'AlreadyInitialized':
-            logger.info('Replica set already initialized')
             return
         raise
     else:
@@ -130,7 +134,7 @@ def _check_replica_set(conn):
             :exc:`~ConfigurationError`: If mongod was not started with the
             replSet option.
     """
-    options = conn.conn.admin.command('getCmdLineOpts')
+    options = conn.admin.command('getCmdLineOpts')
     try:
         repl_opts = options['parsed']['replication']
         repl_set_name = repl_opts.get('replSetName', None) or repl_opts['replSet']
@@ -162,7 +166,7 @@ def _wait_for_replica_set_initialization(conn):
     # we find the line that says the database is ready
     logger.info('Waiting for mongodb replica set initialization')
     while True:
-        logs = conn.conn.admin.command('getLog', 'rs')['log']
+        logs = conn.admin.command('getLog', 'rs')['log']
         if any('database writes are now permitted' in line for line in logs):
                 return
         time.sleep(0.1)

--- a/docs/server/source/server-reference/configuration.md
+++ b/docs/server/source/server-reference/configuration.md
@@ -15,6 +15,7 @@ For convenience, here's a list of all the relevant environment variables (docume
 `BIGCHAINDB_DATABASE_HOST`<br>
 `BIGCHAINDB_DATABASE_PORT`<br>
 `BIGCHAINDB_DATABASE_NAME`<br>
+`BIGCHAINDB_DATABASE_REPLICASET`<br>
 `BIGCHAINDB_SERVER_BIND`<br>
 `BIGCHAINDB_SERVER_WORKERS`<br>
 `BIGCHAINDB_SERVER_THREADS`<br>
@@ -77,7 +78,7 @@ Note how the keys in the list are separated by colons.
 ```
 
 
-## database.backend, database.host, database.port & database.name
+## database.backend, database.host, database.port, database.name & database.replicaset
 
 The database backend to use (e.g. RethinkDB) and its hostname, port and name.
 
@@ -87,6 +88,7 @@ export BIGCHAINDB_DATABASE_BACKEND=rethinkdb
 export BIGCHAINDB_DATABASE_HOST=localhost
 export BIGCHAINDB_DATABASE_PORT=28015
 export BIGCHAINDB_DATABASE_NAME=bigchain
+export BIGCHAINDB_DATABASE_REPLICASET=bigchain-rs
 ```
 
 **Example config file snippet**
@@ -95,22 +97,25 @@ export BIGCHAINDB_DATABASE_NAME=bigchain
     "backend": "rethinkdb",
     "host": "localhost",
     "port": 28015,
-    "name": "bigchain"
+    "name": "bigchain",
+    "replicaset": "bigchain-rs"
 }
 ```
 
 **Default values (a snippet from `bigchaindb/__init__.py`)**
 ```python
 'database': {
-    "backend": "rethinkdb",
+    'backend': os.environ.get('BIGCHAINDB_DATABASE_BACKEND', 'rethinkdb'),
     'host': os.environ.get('BIGCHAINDB_DATABASE_HOST', 'localhost'),
-    'port': 28015,
-    'name': 'bigchain',
+    'port': int(os.environ.get('BIGCHAINDB_DATABASE_PORT', 28015)),
+    'name': os.environ.get('BIGCHAINDB_DATABASE_NAME', 'bigchain'),
+    'replicaset': os.environ.get('BIGCHAINDB_DATABASE_REPLICASET', 'bigchain-rs')
 }
 ```
 
-**Note**: As of now, only RethinkDB ("rethinkdb") is supported as a value for `database.backend`. In
-the future, other options (e.g. MongoDB) will be available.
+**Note**: We are currently adding support for MongoDB. The `replicaset` and
+`BIGCHAINDB_DATABASE_REPLICASET` option is only used if the `backend` or
+`BIGCHAINDB_DATABASE_BACKEND` is set to `"mongodb"`.
 
 
 ## server.bind, server.workers & server.threads

--- a/tests/backend/mongodb/test_connection.py
+++ b/tests/backend/mongodb/test_connection.py
@@ -1,7 +1,35 @@
 from unittest import mock
 
 import pytest
-from pymongo.errors import ConnectionFailure
+from pymongo import MongoClient
+from pymongo.database import Database
+from pymongo.errors import ConnectionFailure, OperationFailure
+
+
+pytestmark = pytest.mark.bdb
+
+
+@pytest.fixture
+def mock_cmd_line_opts():
+    return {'argv': ['mongod', '--dbpath=/data', '--replSet=bigchain-rs'],
+            'ok': 1.0,
+            'parsed': {'replication': {'replSet': 'bigchain-rs'},
+                       'storage': {'dbPath': '/data'}}}
+
+
+@pytest.fixture
+def mock_config_opts():
+    return {'argv': ['mongod', '--dbpath=/data', '--replSet=bigchain-rs'],
+            'ok': 1.0,
+            'parsed': {'replication': {'replSetName': 'bigchain-rs'},
+                       'storage': {'dbPath': '/data'}}}
+
+
+@pytest.fixture
+def mongodb_connection():
+    import bigchaindb
+    return MongoClient(host=bigchaindb.config['database']['host'],
+                       port=bigchaindb.config['database']['port'])
 
 
 def test_get_connection_returns_the_correct_instance():
@@ -38,3 +66,85 @@ def test_connection_error(mock_sleep, mock_client):
         conn.db
 
     assert mock_client.call_count == 3
+
+
+def test_check_replica_set_not_enabled(mongodb_connection):
+    from bigchaindb.backend.mongodb.connection import _check_replica_set
+    from bigchaindb.common.exceptions import ConfigurationError
+
+    # no replSet option set
+    cmd_line_opts = {'argv': ['mongod', '--dbpath=/data'],
+                     'ok': 1.0,
+                     'parsed': {'storage': {'dbPath': '/data'}}}
+    with mock.patch.object(Database, 'command', return_value=cmd_line_opts):
+        with pytest.raises(ConfigurationError):
+            _check_replica_set(mongodb_connection)
+
+
+def test_check_replica_set_command_line(mongodb_connection,
+                                        mock_cmd_line_opts):
+    from bigchaindb.backend.mongodb.connection import _check_replica_set
+
+    # replSet option set through the command line
+    with mock.patch.object(Database, 'command',
+                           return_value=mock_cmd_line_opts):
+        assert _check_replica_set(mongodb_connection) is None
+
+
+def test_check_replica_set_config_file(mongodb_connection, mock_config_opts):
+    from bigchaindb.backend.mongodb.connection import _check_replica_set
+
+    # replSet option set through the config file
+    with mock.patch.object(Database, 'command', return_value=mock_config_opts):
+        assert _check_replica_set(mongodb_connection) is None
+
+
+def test_check_replica_set_name_mismatch(mongodb_connection,
+                                         mock_cmd_line_opts):
+    from bigchaindb.backend.mongodb.connection import _check_replica_set
+    from bigchaindb.common.exceptions import ConfigurationError
+
+    # change the replica set name so it does not match the bigchaindb config
+    mock_cmd_line_opts['parsed']['replication']['replSet'] = 'rs0'
+
+    with mock.patch.object(Database, 'command',
+                           return_value=mock_cmd_line_opts):
+        with pytest.raises(ConfigurationError):
+            _check_replica_set(mongodb_connection)
+
+
+def test_wait_for_replica_set_initialization(mongodb_connection):
+    from bigchaindb.backend.mongodb.connection import _wait_for_replica_set_initialization  # noqa
+
+    with mock.patch.object(Database, 'command') as mock_command:
+        mock_command.side_effect = [
+            {'log': ['a line']},
+            {'log': ['database writes are now permitted']},
+        ]
+
+        # check that it returns
+        assert _wait_for_replica_set_initialization(mongodb_connection) is None
+
+
+def test_initialize_replica_set(mock_cmd_line_opts):
+    from bigchaindb.backend.mongodb.connection import initialize_replica_set
+
+    with mock.patch.object(Database, 'command') as mock_command:
+        mock_command.side_effect = [
+            mock_cmd_line_opts,
+            None,
+            {'log': ['database writes are now permitted']},
+        ]
+
+        # check that it returns
+        assert initialize_replica_set() is None
+
+    # test it raises OperationError if anything wrong
+    with mock.patch.object(Database, 'command') as mock_command:
+        mock_command.side_effect = [
+            mock_cmd_line_opts,
+            OperationFailure(None, details={'codeName': ''})
+        ]
+
+        with pytest.raises(OperationFailure):
+            initialize_replica_set()

--- a/tests/backend/mongodb/test_connection.py
+++ b/tests/backend/mongodb/test_connection.py
@@ -51,9 +51,10 @@ def test_get_connection_returns_the_correct_instance():
     assert conn.conn._topology_settings.replica_set_name == config['replicaset']
 
 
+@mock.patch('bigchaindb.backend.mongodb.connection.initialize_replica_set')
 @mock.patch('pymongo.MongoClient.__init__')
 @mock.patch('time.sleep')
-def test_connection_error(mock_sleep, mock_client):
+def test_connection_error(mock_sleep, mock_client, mock_init_repl_set):
     from bigchaindb.backend import connect
 
     # force the driver to trow ConnectionFailure

--- a/tests/backend/mongodb/test_connection.py
+++ b/tests/backend/mongodb/test_connection.py
@@ -13,12 +13,14 @@ def test_get_connection_returns_the_correct_instance():
         'backend': 'mongodb',
         'host': 'localhost',
         'port': 27017,
-        'name': 'test'
+        'name': 'test',
+        'replicaset': 'bigchain-rs'
     }
 
     conn = connect(**config)
     assert isinstance(conn, Connection)
     assert isinstance(conn, MongoDBConnection)
+    assert conn.conn._topology_settings.replica_set_name == config['replicaset']
 
 
 @mock.patch('pymongo.MongoClient.__init__')

--- a/tests/backend/mongodb/test_schema.py
+++ b/tests/backend/mongodb/test_schema.py
@@ -1,35 +1,8 @@
-from unittest import mock
-
 import pytest
 from pymongo import MongoClient
-from pymongo.database import Database
-from pymongo.errors import OperationFailure
 
 
 pytestmark = pytest.mark.bdb
-
-
-@pytest.fixture
-def mock_cmd_line_opts():
-    return {'argv': ['mongod', '--dbpath=/data', '--replSet=bigchain-rs'],
-            'ok': 1.0,
-            'parsed': {'replication': {'replSet': 'bigchain-rs'},
-                       'storage': {'dbPath': '/data'}}}
-
-
-@pytest.fixture
-def mock_config_opts():
-    return {'argv': ['mongod', '--dbpath=/data', '--replSet=bigchain-rs'],
-            'ok': 1.0,
-            'parsed': {'replication': {'replSetName': 'bigchain-rs'},
-                       'storage': {'dbPath': '/data'}}}
-
-
-@pytest.fixture
-def mongodb_connection():
-    import bigchaindb
-    return MongoClient(host=bigchaindb.config['database']['host'],
-                       port=bigchaindb.config['database']['port'])
 
 
 def test_init_creates_db_tables_and_indexes():
@@ -130,85 +103,3 @@ def test_drop(dummy_db):
     assert dummy_db in conn.conn.database_names()
     schema.drop_database(conn, dummy_db)
     assert dummy_db not in conn.conn.database_names()
-
-
-def test_check_replica_set_not_enabled(mongodb_connection):
-    from bigchaindb.backend.mongodb.schema import _check_replica_set
-    from bigchaindb.common.exceptions import ConfigurationError
-
-    # no replSet option set
-    cmd_line_opts = {'argv': ['mongod', '--dbpath=/data'],
-                     'ok': 1.0,
-                     'parsed': {'storage': {'dbPath': '/data'}}}
-    with mock.patch.object(Database, 'command', return_value=cmd_line_opts):
-        with pytest.raises(ConfigurationError):
-            _check_replica_set(mongodb_connection)
-
-
-def test_check_replica_set_command_line(mongodb_connection,
-                                        mock_cmd_line_opts):
-    from bigchaindb.backend.mongodb.schema import _check_replica_set
-
-    # replSet option set through the command line
-    with mock.patch.object(Database, 'command',
-                           return_value=mock_cmd_line_opts):
-        assert _check_replica_set(mongodb_connection) is None
-
-
-def test_check_replica_set_config_file(mongodb_connection, mock_config_opts):
-    from bigchaindb.backend.mongodb.schema import _check_replica_set
-
-    # replSet option set through the config file
-    with mock.patch.object(Database, 'command', return_value=mock_config_opts):
-        assert _check_replica_set(mongodb_connection) is None
-
-
-def test_check_replica_set_name_mismatch(mongodb_connection,
-                                         mock_cmd_line_opts):
-    from bigchaindb.backend.mongodb.schema import _check_replica_set
-    from bigchaindb.common.exceptions import ConfigurationError
-
-    # change the replica set name so it does not match the bigchaindb config
-    mock_cmd_line_opts['parsed']['replication']['replSet'] = 'rs0'
-
-    with mock.patch.object(Database, 'command',
-                           return_value=mock_cmd_line_opts):
-        with pytest.raises(ConfigurationError):
-            _check_replica_set(mongodb_connection)
-
-
-def test_wait_for_replica_set_initialization(mongodb_connection):
-    from bigchaindb.backend.mongodb.schema import _wait_for_replica_set_initialization  # noqa
-
-    with mock.patch.object(Database, 'command') as mock_command:
-        mock_command.side_effect = [
-            {'log': ['a line']},
-            {'log': ['database writes are now permitted']},
-        ]
-
-        # check that it returns
-        assert _wait_for_replica_set_initialization(mongodb_connection) is None
-
-
-def test_initialize_replica_set(mock_cmd_line_opts):
-    from bigchaindb.backend.mongodb.schema import initialize_replica_set
-
-    with mock.patch.object(Database, 'command') as mock_command:
-        mock_command.side_effect = [
-            mock_cmd_line_opts,
-            None,
-            {'log': ['database writes are now permitted']},
-        ]
-
-        # check that it returns
-        assert initialize_replica_set() is None
-
-    # test it raises OperationError if anything wrong
-    with mock.patch.object(Database, 'command') as mock_command:
-        mock_command.side_effect = [
-            mock_cmd_line_opts,
-            OperationFailure(None, details={'codeName': ''})
-        ]
-
-        with pytest.raises(OperationFailure):
-            initialize_replica_set()

--- a/tests/backend/mongodb/test_schema.py
+++ b/tests/backend/mongodb/test_schema.py
@@ -1,5 +1,4 @@
 import pytest
-from pymongo import MongoClient
 
 
 pytestmark = pytest.mark.bdb

--- a/tests/backend/mongodb/test_schema.py
+++ b/tests/backend/mongodb/test_schema.py
@@ -24,7 +24,6 @@ def mock_config_opts():
                        'storage': {'dbPath': '/data'}}}
 
 
-
 def test_init_creates_db_tables_and_indexes():
     import bigchaindb
     from bigchaindb import backend

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,17 +136,10 @@ def _configure_bigchaindb(request):
 def _setup_database(_configure_bigchaindb):
     from bigchaindb import config
     from bigchaindb.backend import connect, schema
-    from bigchaindb.backend.mongodb.schema import initialize_replica_set
     from bigchaindb.common.exceptions import DatabaseDoesNotExist
     print('Initializing test db')
     dbname = config['database']['name']
     conn = connect()
-
-    # if we are setting up mongodb for the first time we need to make sure
-    # that the replica set is initialized before doing any operation in the
-    # database
-    if config['database']['backend'] == 'mongodb':
-        initialize_replica_set(conn)
 
     try:
         schema.drop_database(conn, dbname)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,6 +9,7 @@ def config(request, monkeypatch):
             'host': 'host',
             'port': 28015,
             'name': 'bigchain',
+            'replicaset': 'bigchain-rs',
         },
         'keypair': {
             'public': 'pubkey',


### PR DESCRIPTION
resolves #1056 

This pr adds `replicaset` to `bigchaindb.config`.
Also updated the mongodb connection initialization to connect to a replica set, and moved the `initialize_replica_set` into `mongodb.connection`. The reason for this is that the replicaset needs to be initialized before we even try to setup a `MongoDBConnection`