### PR TITLE
Http api statuses tx 1039

### DIFF
--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -267,15 +267,26 @@ class Bigchain(object):
             return response
 
     def get_transaction_status(self, txid):
-        """Retrieve the status of a transaction with `txid` from bigchain.
+        """Retrieves the status of the transaction having the given
+        ``txid``.
 
         Args:
-            txid (str): transaction id of the transaction to query
+            txid (str): Transaction id of the transaction to query the
+                status for.
 
         Returns:
-            (string): transaction status ('valid', 'undecided',
-            or 'backlog'). If no transaction with that `txid` was found it
-            returns `None`
+            str: The transaction status (``'valid'``, ``'undecided'``,
+            ``'backlog'``, or ``'invalid'``). If no transaction with
+            the given ``txid`` was found it returns ``None``.
+
+        Note:
+            A transaction's lifecycle is such that it may go through the
+            ``backlog``, ``undecided``, and ``invalid`` states a few
+            times before being ``valid``. Consequently, if a transaction
+            lands in an ``invalid`` block, but goes through an
+            additional round, it may be reported as being in the
+            ``backlog`` or in an ``undecided`` block, or eventually in
+            a ``valid`` block.
         """
         try:
             statuses = self.get_blocks_status_containing_tx(txid).values()

--- a/bigchaindb/web/server.py
+++ b/bigchaindb/web/server.py
@@ -6,7 +6,7 @@ The application is implemented in Flask and runs using Gunicorn.
 import copy
 import multiprocessing
 
-from flask import Flask
+from flask import Flask, got_request_exception
 import gunicorn.app.base
 
 from bigchaindb import utils
@@ -14,6 +14,17 @@ from bigchaindb import Bigchain
 from bigchaindb.web.routes import add_routes
 
 from bigchaindb.monitor import Monitor
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def log_exception(sender, exception, **extra):
+    """ Log an exception to our logging framework """
+    # TODO log via the sneder object instead:
+    # sender.logger.warning('Got exception during processing: %s', exception)
+    logger.warning('Got exception during processing: %s', exception)
 
 
 # TODO: Figure out if we do we need all this boilerplate.
@@ -68,6 +79,7 @@ def create_app(*, debug=False, threads=4):
     app.config['monitor'] = Monitor()
 
     add_routes(app)
+    got_request_exception.connect(log_exception, app)
 
     return app
 

--- a/bigchaindb/web/views/statuses.py
+++ b/bigchaindb/web/views/statuses.py
@@ -35,7 +35,7 @@ class StatusApi(Resource):
 
         with pool() as bigchain:
             if tx_id:
-                status = bigchain.get_status(tx_id)
+                status = bigchain.get_transaction_status(tx_id)
                 links = {
                     'tx': '/transactions/{}'.format(tx_id)
                 }

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ install_requires = [
     'multipipes~=0.1.0',
     'jsonschema~=2.5.1',
     'pyyaml~=3.12',
+    'blinker~=1.4',
 ]
 
 setup(

--- a/tests/web/test_statuses.py
+++ b/tests/web/test_statuses.py
@@ -1,7 +1,11 @@
+from functools import singledispatch
+
 import pytest
 from flask import url_for
 
 from bigchaindb.models import Transaction
+
+APPLICATION_ROOT = '/api/v1'
 
 
 @pytest.mark.bdb
@@ -15,8 +19,114 @@ def test_get_transaction_status_endpoint(b, client, user_pk):
     res = client.get(path=path)
     assert status == res.json['status']
     expected_tx_link = url_for(
-        TransactionApi.__name__.lower(), tx_id=input_tx.txid)[7:]
+        TransactionApi.__name__.lower(), tx_id=input_tx.txid
+    ).replace(APPLICATION_ROOT, '')
     assert res.json['_links']['tx'] == expected_tx_link
+    assert res.status_code == 200
+
+
+@pytest.mark.bdb
+def test_get_backlog_transaction_status(b, client, backlog_tx):
+    from bigchaindb import Bigchain
+    from bigchaindb.web.views.statuses import StatusApi
+    from bigchaindb.web.views.transactions import TransactionApi
+    path = url_for(StatusApi.__name__.lower(), tx_id=backlog_tx.id)
+    res = client.get(path=path)
+    assert res.json['status'] == Bigchain.TX_IN_BACKLOG
+    expected_tx_link = url_for(
+        TransactionApi.__name__.lower(), tx_id=backlog_tx.id
+    ).replace(APPLICATION_ROOT, '')
+    assert res.json['_links']['tx'] == expected_tx_link
+    assert res.status_code == 200
+
+
+@pytest.mark.bdb
+def test_get_undecided_transaction_status(b, client, undecided_tx):
+    from bigchaindb import Bigchain
+    from bigchaindb.web.views.statuses import StatusApi
+    from bigchaindb.web.views.transactions import TransactionApi
+    path = url_for(StatusApi.__name__.lower(), tx_id=undecided_tx.id)
+    res = client.get(path=path)
+    assert res.json['status'] == Bigchain.BLOCK_UNDECIDED
+    expected_tx_link = url_for(
+        TransactionApi.__name__.lower(), tx_id=undecided_tx.id
+    ).replace(APPLICATION_ROOT, '')
+    assert res.json['_links']['tx'] == expected_tx_link
+    assert res.status_code == 200
+
+
+@pytest.mark.bdb
+def test_get_valid_transaction_status(b, client, valid_tx):
+    from bigchaindb import Bigchain
+    from bigchaindb.web.views.statuses import StatusApi
+    from bigchaindb.web.views.transactions import TransactionApi
+    path = url_for(StatusApi.__name__.lower(), tx_id=valid_tx.id)
+    res = client.get(path=path)
+    assert res.json['status'] == Bigchain.BLOCK_VALID
+    expected_tx_link = url_for(
+        TransactionApi.__name__.lower(), tx_id=valid_tx.id
+    ).replace(APPLICATION_ROOT, '')
+    assert res.json['_links']['tx'] == expected_tx_link
+    assert res.status_code == 200
+
+
+@pytest.mark.bdb
+def test_get_invalid_transaction_status(b, client, invalid_tx):
+    from bigchaindb import Bigchain
+    from bigchaindb.web.views.statuses import StatusApi
+    from bigchaindb.web.views.transactions import TransactionApi
+    path = url_for(StatusApi.__name__.lower(), tx_id=invalid_tx.id)
+    res = client.get(path=path)
+    assert res.json['status'] == Bigchain.BLOCK_INVALID
+    expected_tx_link = url_for(
+        TransactionApi.__name__.lower(), tx_id=invalid_tx.id
+    ).replace(APPLICATION_ROOT, '')
+    assert res.json['_links']['tx'] == expected_tx_link
+    assert res.status_code == 200
+
+
+@pytest.mark.parametrize('statuses,in_backlog,status', (
+    (None, True, 'backlog'),
+    ({'block-001': 'valid'}, True, 'valid'),
+    ({'block-001': 'undecided'}, True, 'undecided'),
+    ({'block-001': 'invalid'}, True, 'backlog'),
+    ({'block-001': 'invalid'}, False, 'invalid'),
+    ({'block-001': 'valid', 'block-002': 'undecided'}, True, 'valid'),
+    ({'block-001': 'valid', 'block-002': 'invalid'}, True, 'valid'),
+    ({'block-002': 'undecided', 'block-003': 'invalid'}, True, 'undecided'),
+    ({'block-001': 'valid', 'block-002': 'undecided', 'block-003': 'invalid'},
+     True,
+     'valid'),
+))
+def test_get_transaction_status_mocked(client, statuses,
+                                       status, in_backlog, monkeypatch):
+    from bigchaindb.web.views.statuses import StatusApi
+    from bigchaindb.web.views.transactions import TransactionApi
+    from bigchaindb.backend.rethinkdb.connection import RethinkDBConnection
+    from bigchaindb.backend.mongodb.connection import MongoDBConnection
+
+    @singledispatch
+    def mocked_get_transaction_from_backlog(conn, txid):
+        return in_backlog
+
+    mocked_get_transaction_from_backlog.register(RethinkDBConnection,
+                                                 lambda x, y: in_backlog)
+    mocked_get_transaction_from_backlog.register(MongoDBConnection,
+                                                 lambda x, y: in_backlog)
+    monkeypatch.setattr(
+        'bigchaindb.backend.query.get_transaction_from_backlog',
+        mocked_get_transaction_from_backlog,
+    )
+    monkeypatch.setattr(
+        'bigchaindb.core.Bigchain.get_blocks_status_containing_tx',
+        lambda self, txid: statuses,
+    )
+    tx_id = 1
+    res = client.get(path=url_for(StatusApi.__name__.lower(), tx_id=tx_id))
+    assert res.json['status'] == status
+    assert res.json['_links']['tx'] == url_for(
+        TransactionApi.__name__.lower(), tx_id=tx_id
+    ).replace(APPLICATION_ROOT, '')
     assert res.status_code == 200
 
 

--- a/tests/web/test_statuses.py
+++ b/tests/web/test_statuses.py
@@ -1,29 +1,36 @@
 import pytest
+from flask import url_for
 
 from bigchaindb.models import Transaction
-
-STATUSES_ENDPOINT = '/api/v1/statuses'
 
 
 @pytest.mark.bdb
 @pytest.mark.usefixtures('inputs')
 def test_get_transaction_status_endpoint(b, client, user_pk):
+    from bigchaindb.web.views.statuses import StatusApi
+    from bigchaindb.web.views.transactions import TransactionApi
     input_tx = b.get_owned_ids(user_pk).pop()
     tx, status = b.get_transaction(input_tx.txid, include_status=True)
-    res = client.get(STATUSES_ENDPOINT + '?tx_id=' + input_tx.txid)
+    path = url_for(StatusApi.__name__.lower(), tx_id=input_tx.txid)
+    res = client.get(path=path)
     assert status == res.json['status']
-    assert res.json['_links']['tx'] == '/transactions/{}'.format(input_tx.txid)
+    expected_tx_link = url_for(
+        TransactionApi.__name__.lower(), tx_id=input_tx.txid)[7:]
+    assert res.json['_links']['tx'] == expected_tx_link
     assert res.status_code == 200
 
 
 @pytest.mark.bdb
 def test_get_transaction_status_endpoint_returns_404_if_not_found(client):
-    res = client.get(STATUSES_ENDPOINT + '?tx_id=123')
+    from bigchaindb.web.views.statuses import StatusApi
+    path = url_for(StatusApi.__name__.lower(), tx_id=123)
+    res = client.get(path=path)
     assert res.status_code == 404
 
 
 @pytest.mark.bdb
 def test_get_block_status_endpoint_undecided(b, client):
+    from bigchaindb.web.views.statuses import StatusApi
     tx = Transaction.create([b.me], [([b.me], 1)])
     tx = tx.sign([b.me_private])
 
@@ -32,7 +39,8 @@ def test_get_block_status_endpoint_undecided(b, client):
 
     status = b.block_election_status(block.id, block.voters)
 
-    res = client.get(STATUSES_ENDPOINT + '?block_id=' + block.id)
+    path = url_for(StatusApi.__name__.lower(), block_id=block.id)
+    res = client.get(path=path)
     assert status == res.json['status']
     assert '_links' not in res.json
     assert res.status_code == 200
@@ -41,6 +49,7 @@ def test_get_block_status_endpoint_undecided(b, client):
 @pytest.mark.bdb
 @pytest.mark.usefixtures('inputs')
 def test_get_block_status_endpoint_valid(b, client):
+    from bigchaindb.web.views.statuses import StatusApi
     tx = Transaction.create([b.me], [([b.me], 1)])
     tx = tx.sign([b.me_private])
 
@@ -53,7 +62,8 @@ def test_get_block_status_endpoint_valid(b, client):
 
     status = b.block_election_status(block.id, block.voters)
 
-    res = client.get(STATUSES_ENDPOINT + '?block_id=' + block.id)
+    path = url_for(StatusApi.__name__.lower(), block_id=block.id)
+    res = client.get(path=path)
     assert status == res.json['status']
     assert '_links' not in res.json
     assert res.status_code == 200
@@ -62,6 +72,7 @@ def test_get_block_status_endpoint_valid(b, client):
 @pytest.mark.bdb
 @pytest.mark.usefixtures('inputs')
 def test_get_block_status_endpoint_invalid(b, client):
+    from bigchaindb.web.views.statuses import StatusApi
     tx = Transaction.create([b.me], [([b.me], 1)])
     tx = tx.sign([b.me_private])
 
@@ -74,7 +85,8 @@ def test_get_block_status_endpoint_invalid(b, client):
 
     status = b.block_election_status(block.id, block.voters)
 
-    res = client.get(STATUSES_ENDPOINT + '?block_id=' + block.id)
+    path = url_for(StatusApi.__name__.lower(), block_id=block.id)
+    res = client.get(path=path)
     assert status == res.json['status']
     assert '_links' not in res.json
     assert res.status_code == 200
@@ -82,17 +94,19 @@ def test_get_block_status_endpoint_invalid(b, client):
 
 @pytest.mark.bdb
 def test_get_block_status_endpoint_returns_404_if_not_found(client):
-    res = client.get(STATUSES_ENDPOINT + '?block_id=123')
+    from bigchaindb.web.views.statuses import StatusApi
+    path = url_for(StatusApi.__name__.lower(), block_id=123)
+    res = client.get(path=path)
     assert res.status_code == 404
 
 
 @pytest.mark.bdb
-def test_get_status_endpoint_returns_400_bad_query_params(client):
-    res = client.get(STATUSES_ENDPOINT)
-    assert res.status_code == 400
-
-    res = client.get(STATUSES_ENDPOINT + '?ts_id=123')
-    assert res.status_code == 400
-
-    res = client.get(STATUSES_ENDPOINT + '?tx_id=123&block_id=123')
+@pytest.mark.parametrize('query_params', (
+    {}, {'ts_id': 123}, {'tx_id': 123, 'block_id': 123}
+))
+def test_get_status_endpoint_returns_400_bad_query_params(client,
+                                                          query_params):
+    from bigchaindb.web.views.statuses import StatusApi
+    path = url_for(StatusApi.__name__.lower(), **query_params)
+    res = client.get(path)
     assert res.status_code == 400


### PR DESCRIPTION
**note**: For those who wonder what `blinker` is for: it is for flask signals. In this case it is necessary for the call [`got_request_exception.connect(log_exception, app)`](https://github.com/bigchaindb/bigchaindb/pull/1067/commits/8c43aa6835cbec26c6fe6ea621971961d55ef61f#diff-9943b8877e792a45dc46b4e483e1c02eR82).