### PR TITLE
short form 0.9, 0.10 etc tx version with no '.dev' suffix

### DIFF
--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -410,7 +410,7 @@ class Transaction(object):
     TRANSFER = 'TRANSFER'
     GENESIS = 'GENESIS'
     ALLOWED_OPERATIONS = (CREATE, TRANSFER, GENESIS)
-    VERSION = bigchaindb.version.__version__
+    VERSION = bigchaindb.version.__short_version__[:-4]  # 0.9, 0.10 etc
 
     def __init__(self, operation, asset, inputs=None, outputs=None,
                  metadata=None, version=None):

--- a/tests/common/test_transaction.py
+++ b/tests/common/test_transaction.py
@@ -966,11 +966,13 @@ def test_cant_add_empty_input():
 
 
 def test_validate_version(utx):
+    import re
     import bigchaindb.version
     from .utils import validate_transaction_model
     from bigchaindb.common.exceptions import SchemaValidationError
 
-    assert utx.version == bigchaindb.version.__version__
+    short_ver = bigchaindb.version.__short_version__
+    assert utx.version == re.match(r'^(.*\d)', short_ver).group(1)
 
     validate_transaction_model(utx)
 


### PR DESCRIPTION
As in title. The TX version moves lock-step with server version UNTIL 1.0, and does not include `.dev` suffix. 