### PR TITLE
Update configure command to support multiple backends

### DIFF
--- a/bigchaindb/__init__.py
+++ b/bigchaindb/__init__.py
@@ -5,6 +5,20 @@ import os
 # PORT_NUMBER = reduce(lambda x, y: x * y, map(ord, 'BigchainDB')) % 2**16
 # basically, the port number is 9984
 
+_database_rethinkdb = {
+    'backend': os.environ.get('BIGCHAINDB_DATABASE_BACKEND', 'rethinkdb'),
+    'host': os.environ.get('BIGCHAINDB_DATABASE_HOST', 'localhost'),
+    'port': int(os.environ.get('BIGCHAINDB_DATABASE_PORT', 28015)),
+    'name': os.environ.get('BIGCHAINDB_DATABASE_NAME', 'bigchain'),
+}
+
+_database_mongodb = {
+    'backend': os.environ.get('BIGCHAINDB_DATABASE_BACKEND', 'mongodb'),
+    'host': os.environ.get('BIGCHAINDB_DATABASE_HOST', 'localhost'),
+    'port': int(os.environ.get('BIGCHAINDB_DATABASE_PORT', 27017)),
+    'name': os.environ.get('BIGCHAINDB_DATABASE_NAME', 'bigchain'),
+    'replicaset': os.environ.get('BIGCHAINDB_DATABASE_REPLICASET', 'bigchain-rs'),
+}
 
 config = {
     'server': {
@@ -14,13 +28,7 @@ config = {
         'workers': None,  # if none, the value will be cpu_count * 2 + 1
         'threads': None,  # if none, the value will be cpu_count * 2 + 1
     },
-    'database': {
-        'backend': os.environ.get('BIGCHAINDB_DATABASE_BACKEND', 'rethinkdb'),
-        'host': os.environ.get('BIGCHAINDB_DATABASE_HOST', 'localhost'),
-        'port': int(os.environ.get('BIGCHAINDB_DATABASE_PORT', 28015)),
-        'name': os.environ.get('BIGCHAINDB_DATABASE_NAME', 'bigchain'),
-        'replicaset': os.environ.get('BIGCHAINDB_DATABASE_REPLICASET', 'bigchain-rs'),
-    },
+    'database': _database_rethinkdb,
     'keypair': {
         'public': None,
         'private': None,

--- a/bigchaindb/__init__.py
+++ b/bigchaindb/__init__.py
@@ -20,6 +20,11 @@ _database_mongodb = {
     'replicaset': os.environ.get('BIGCHAINDB_DATABASE_REPLICASET', 'bigchain-rs'),
 }
 
+_database_map = {
+    'mongodb': _database_mongodb,
+    'rethinkdb': _database_rethinkdb
+}
+
 config = {
     'server': {
         # Note: this section supports all the Gunicorn settings:
@@ -28,7 +33,9 @@ config = {
         'workers': None,  # if none, the value will be cpu_count * 2 + 1
         'threads': None,  # if none, the value will be cpu_count * 2 + 1
     },
-    'database': _database_rethinkdb,
+    'database': _database_map[
+        os.environ.get('BIGCHAINDB_DATABASE_BACKEND', 'rethinkdb')
+    ],
     'keypair': {
         'public': None,
         'private': None,

--- a/bigchaindb/backend/connection.py
+++ b/bigchaindb/backend/connection.py
@@ -40,6 +40,12 @@ def connect(backend=None, host=None, port=None, name=None, replicaset=None):
     host = host or bigchaindb.config['database']['host']
     port = port or bigchaindb.config['database']['port']
     dbname = name or bigchaindb.config['database']['name']
+    # Not sure how to handle this here. This setting is only relevant for
+    # mongodb.
+    # I added **kwargs for both RethinkDBConnection and MongoDBConnection
+    # to handle these these additional args. In case of RethinkDBConnection
+    # it just does not do anything with it.
+    replicaset = replicaset or bigchaindb.config['database'].get('replicaset')
 
     try:
         module_name, _, class_name = BACKENDS[backend].rpartition('.')
@@ -51,7 +57,7 @@ def connect(backend=None, host=None, port=None, name=None, replicaset=None):
         raise ConfigurationError('Error loading backend `{}`'.format(backend)) from exc
 
     logger.debug('Connection: {}'.format(Class))
-    return Class(host, port, dbname)
+    return Class(host, port, dbname, replicaset=replicaset)
 
 
 class Connection:

--- a/bigchaindb/backend/mongodb/connection.py
+++ b/bigchaindb/backend/mongodb/connection.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class MongoDBConnection(Connection):
 
     def __init__(self, host=None, port=None, dbname=None, max_tries=3,
-                 replicaset=None):
+                 replicaset=None, **kwargs):
         """Create a new Connection instance.
 
         Args:

--- a/bigchaindb/backend/rethinkdb/connection.py
+++ b/bigchaindb/backend/rethinkdb/connection.py
@@ -17,7 +17,7 @@ class RethinkDBConnection(Connection):
           more times to run the query or open a connection.
     """
 
-    def __init__(self, host, port, dbname, max_tries=3):
+    def __init__(self, host, port, dbname, max_tries=3, **kwargs):
         """Create a new :class:`~.RethinkDBConnection` instance.
 
         See :meth:`.Connection.__init__` for

--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -86,6 +86,16 @@ def run_configure(args, skip_if_exists=False):
     conf['keypair']['private'], conf['keypair']['public'] = \
         crypto.generate_key_pair()
 
+    # select the correct config defaults based on the backend
+    print('Generating default configuration for backend {}'
+          .format(args.backend))
+    database = {}
+    if args.backend == 'rethinkdb':
+        database = bigchaindb._database_rethinkdb
+    elif args.backend == 'mongodb':
+        database = bigchaindb._database_mongodb
+    conf['database'] = database
+
     if not args.yes:
         for key in ('bind', ):
             val = conf['server'][key]
@@ -282,9 +292,13 @@ def create_parser():
                                        dest='command')
 
     # parser for writing a config file
-    subparsers.add_parser('configure',
-                          help='Prepare the config file '
-                               'and create the node keypair')
+    config_parser = subparsers.add_parser('configure',
+                                          help='Prepare the config file '
+                                               'and create the node keypair')
+    config_parser.add_argument('backend',
+                               choices=['rethinkdb', 'mongodb'],
+                               help='The backend to use. It can be either '
+                                    'rethinkdb or mongodb.')
 
     # parsers for showing/exporting config values
     subparsers.add_parser('show-config',

--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -89,12 +89,7 @@ def run_configure(args, skip_if_exists=False):
     # select the correct config defaults based on the backend
     print('Generating default configuration for backend {}'
           .format(args.backend))
-    database = {}
-    if args.backend == 'rethinkdb':
-        database = bigchaindb._database_rethinkdb
-    elif args.backend == 'mongodb':
-        database = bigchaindb._database_mongodb
-    conf['database'] = database
+    conf['database'] = bigchaindb._database_map[args.backend]
 
     if not args.yes:
         for key in ('bind', ):

--- a/tests/backend/test_generics.py
+++ b/tests/backend/test_generics.py
@@ -68,33 +68,6 @@ def test_changefeed_class(changefeed_class_func_name, args_qty):
         changefeed_class_func(None, *range(args_qty))
 
 
-@patch('bigchaindb.backend.schema.create_indexes',
-       autospec=True, return_value=None)
-@patch('bigchaindb.backend.schema.create_tables',
-       autospec=True, return_value=None)
-@patch('bigchaindb.backend.schema.create_database',
-       autospec=True, return_value=None)
-def test_init_database(mock_create_database, mock_create_tables,
-                       mock_create_indexes):
-    from bigchaindb.backend.schema import init_database
-    from bigchaindb.backend.rethinkdb.connection import RethinkDBConnection
-    from bigchaindb.backend.mongodb.connection import MongoDBConnection
-
-    # rethinkdb
-    conn = RethinkDBConnection('host', 'port', 'dbname')
-    init_database(connection=conn, dbname='mickeymouse')
-    mock_create_database.assert_called_with(conn, 'mickeymouse')
-    mock_create_tables.assert_called_with(conn, 'mickeymouse')
-    mock_create_indexes.assert_called_with(conn, 'mickeymouse')
-
-    # mongodb
-    conn = MongoDBConnection('host', 'port', 'dbname', replicaset='rs')
-    init_database(connection=conn, dbname='mickeymouse')
-    mock_create_database.assert_called_with(conn, 'mickeymouse')
-    mock_create_tables.assert_called_with(conn, 'mickeymouse')
-    mock_create_indexes.assert_called_with(conn, 'mickeymouse')
-
-
 @mark.parametrize('admin_func_name,kwargs', (
     ('get_config', {'table': None}),
     ('reconfigure', {'table': None, 'shards': None, 'replicas': None}),

--- a/tests/backend/test_generics.py
+++ b/tests/backend/test_generics.py
@@ -1,4 +1,3 @@
-from importlib import import_module
 from unittest.mock import patch
 
 from pytest import mark, raises
@@ -69,10 +68,6 @@ def test_changefeed_class(changefeed_class_func_name, args_qty):
         changefeed_class_func(None, *range(args_qty))
 
 
-@mark.parametrize('db,conn_cls', (
-    ('mongodb', 'MongoDBConnection'),
-    ('rethinkdb', 'RethinkDBConnection'),
-))
 @patch('bigchaindb.backend.schema.create_indexes',
        autospec=True, return_value=None)
 @patch('bigchaindb.backend.schema.create_tables',
@@ -80,16 +75,24 @@ def test_changefeed_class(changefeed_class_func_name, args_qty):
 @patch('bigchaindb.backend.schema.create_database',
        autospec=True, return_value=None)
 def test_init_database(mock_create_database, mock_create_tables,
-                       mock_create_indexes, db, conn_cls):
+                       mock_create_indexes):
     from bigchaindb.backend.schema import init_database
-    conn = getattr(
-        import_module('bigchaindb.backend.{}.connection'.format(db)),
-        conn_cls,
-    )('host', 'port', 'dbname')
+    from bigchaindb.backend.rethinkdb.connection import RethinkDBConnection
+    from bigchaindb.backend.mongodb.connection import MongoDBConnection
+
+    # rethinkdb
+    conn = RethinkDBConnection('host', 'port', 'dbname')
     init_database(connection=conn, dbname='mickeymouse')
-    mock_create_database.assert_called_once_with(conn, 'mickeymouse')
-    mock_create_tables.assert_called_once_with(conn, 'mickeymouse')
-    mock_create_indexes.assert_called_once_with(conn, 'mickeymouse')
+    mock_create_database.assert_called_with(conn, 'mickeymouse')
+    mock_create_tables.assert_called_with(conn, 'mickeymouse')
+    mock_create_indexes.assert_called_with(conn, 'mickeymouse')
+
+    # mongodb
+    conn = MongoDBConnection('host', 'port', 'dbname', replicaset='rs')
+    init_database(connection=conn, dbname='mickeymouse')
+    mock_create_database.assert_called_with(conn, 'mickeymouse')
+    mock_create_tables.assert_called_with(conn, 'mickeymouse')
+    mock_create_indexes.assert_called_with(conn, 'mickeymouse')
 
 
 @mark.parametrize('admin_func_name,kwargs', (

--- a/tests/backend/test_generics.py
+++ b/tests/backend/test_generics.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 from pytest import mark, raises
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,26 +109,24 @@ def _restore_dbs(request):
 
 @pytest.fixture(scope='session')
 def _configure_bigchaindb(request):
+    import bigchaindb
     from bigchaindb import config_utils
     test_db_name = TEST_DB_NAME
     # Put a suffix like _gw0, _gw1 etc on xdist processes
     xdist_suffix = getattr(request.config, 'slaveinput', {}).get('slaveid')
     if xdist_suffix:
         test_db_name = '{}_{}'.format(TEST_DB_NAME, xdist_suffix)
+
+    backend = request.config.getoption('--database-backend')
+    backend_conf = getattr(bigchaindb, '_database_' + backend)
     config = {
-        'database': {
-            'name': test_db_name,
-            'backend': request.config.getoption('--database-backend'),
-        },
+        'database': backend_conf,
         'keypair': {
             'private': '31Lb1ZGKTyHnmVK3LUMrAUrPNfd4sE2YyBt3UA4A25aA',
             'public': '4XYfCbabAWVUCbjTmRTFEu2sc3dFEdkse4r6X498B1s8',
         }
     }
-    # FIXME
-    if config['database']['backend'] == 'mongodb':
-        # not a great way to do this
-        config['database']['port'] = 27017
+    config['database']['name'] = test_db_name
     config_utils.set_config(config)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,9 +118,8 @@ def _configure_bigchaindb(request):
         test_db_name = '{}_{}'.format(TEST_DB_NAME, xdist_suffix)
 
     backend = request.config.getoption('--database-backend')
-    backend_conf = getattr(bigchaindb, '_database_' + backend)
     config = {
-        'database': backend_conf,
+        'database': bigchaindb._database_map[backend],
         'keypair': {
             'private': '31Lb1ZGKTyHnmVK3LUMrAUrPNfd4sE2YyBt3UA4A25aA',
             'public': '4XYfCbabAWVUCbjTmRTFEu2sc3dFEdkse4r6X498B1s8',

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -130,7 +130,6 @@ def test_autoconfigure_read_both_from_file_and_env(monkeypatch, request):
             'host': 'test-host',
             'port': 4242,
             'name': 'test-dbname',
-            'replicaset': 'bigchain-rs'
         },
         'keypair': {
             'public': None,
@@ -215,7 +214,6 @@ def test_write_config():
     ('BIGCHAINDB_DATABASE_HOST', 'test-host', 'host'),
     ('BIGCHAINDB_DATABASE_PORT', 4242, 'port'),
     ('BIGCHAINDB_DATABASE_NAME', 'test-db', 'name'),
-    ('BIGCHAINDB_DATABASE_REPLICASET', 'test-replicaset', 'replicaset')
 ))
 def test_database_envs(env_name, env_value, config_key, monkeypatch):
     import bigchaindb
@@ -225,5 +223,20 @@ def test_database_envs(env_name, env_value, config_key, monkeypatch):
 
     expected_config = copy.deepcopy(bigchaindb.config)
     expected_config['database'][config_key] = env_value
+
+    assert bigchaindb.config == expected_config
+
+
+def test_database_envs_replicaset(monkeypatch):
+    # the replica set env is only used if the backend is mongodb
+    import bigchaindb
+
+    monkeypatch.setattr('os.environ', {'BIGCHAINDB_DATABASE_REPLICASET':
+                                       'test-replicaset'})
+    bigchaindb.config['database'] = bigchaindb._database_mongodb
+    bigchaindb.config_utils.autoconfigure()
+
+    expected_config = copy.deepcopy(bigchaindb.config)
+    expected_config['database']['replicaset'] = 'test-replicaset'
 
     assert bigchaindb.config == expected_config

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -23,11 +23,6 @@ def test_bigchain_instance_is_initialized_when_conf_provided(request):
 
     assert bigchaindb.config['CONFIGURED'] is True
 
-    # set the current backend so that Bigchain can create a connection
-    backend = request.config.getoption('--database-backend')
-    backend_conf = getattr(bigchaindb, '_database_' + backend)
-    bigchaindb.config['database'] = backend_conf
-
     b = bigchaindb.Bigchain()
 
     assert b.me
@@ -43,11 +38,6 @@ def test_bigchain_instance_raises_when_not_configured(request, monkeypatch):
     # We need to disable ``bigchaindb.config_utils.autoconfigure`` to avoid reading
     # from existing configurations
     monkeypatch.setattr(config_utils, 'autoconfigure', lambda: 0)
-
-    # set the current backend so that Bigchain can create a connection
-    backend = request.config.getoption('--database-backend')
-    backend_conf = getattr(bigchaindb, '_database_' + backend)
-    bigchaindb.config['database'] = backend_conf
 
     with pytest.raises(exceptions.KeypairNotFoundException):
         bigchaindb.Bigchain()

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -131,6 +131,27 @@ def test_autoconfigure_read_both_from_file_and_env(monkeypatch, request):
     from bigchaindb import config_utils
     config_utils.autoconfigure()
 
+    backend = request.config.getoption('--database-backend')
+    database_rethinkdb = {
+        'backend': 'rethinkdb',
+        'host': 'test-host',
+        'port': 4242,
+        'name': 'test-dbname',
+    }
+    database_mongodb = {
+        'backend': 'mongodb',
+        'host': 'test-host',
+        'port': 4242,
+        'name': 'test-dbname',
+        'replicaset': 'bigchain-rs',
+    }
+
+    database = {}
+    if backend == 'mongodb':
+        database = database_mongodb
+    elif backend == 'rethinkdb':
+        database = database_rethinkdb
+
     assert bigchaindb.config == {
         'CONFIGURED': True,
         'server': {
@@ -138,12 +159,7 @@ def test_autoconfigure_read_both_from_file_and_env(monkeypatch, request):
             'workers': None,
             'threads': None,
         },
-        'database': {
-            'backend': request.config.getoption('--database-backend'),
-            'host': 'test-host',
-            'port': 4242,
-            'name': 'test-dbname',
-        },
+        'database': database,
         'keypair': {
             'public': None,
             'private': None,


### PR DESCRIPTION
resolves #1057 

This pr changes the `bigchaindb configure` command to support multiple backends.
The main change to the command is that it now requires a positional argument `backend`:
```bash
$ bigchaindb configure -h
usage: bigchaindb configure [-h] {rethinkdb,mongodb}

positional arguments:
  {rethinkdb,mongodb}  The backend to use. It can be either rethinkdb or
                       mongodb.
```
When run in interactive mode it updates the defaults based on the backend.

Another thing to note is that depending on the backend it populates only the config options required by that backend. For instance if we chose `rethinkdb` as the backend it will not have the `replicaset` option on the generated config file:
```bash
$ bigchaindb -y configure rethinkdb && bigchaindb show-config
Generating keypair
Generating default configuration for backend rethinkdb
Configuration written to /home/rodmar/.bigchaindb
Ready to go!
INFO:bigchaindb.config_utils:Configuration loaded from `/home/rodmar/.bigchaindb`
{
    "backlog_reassign_delay": 120,
    "database": {
        "backend": "rethinkdb",
        "host": "localhost",
        "name": "bigchain",
        "port": 28015
    },
    "keypair": {
        "private": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
        "public": "6G2GV3ZTe6ZgCb1hXjcEJYCW5Cq7d8LhKUbJw7omcABh"
    },
    "keyring": [],
    "server": {
        "bind": "localhost:9984",
        "threads": null,
        "workers": null
    },
    "statsd": {
        "host": "localhost",
        "port": 8125,
        "rate": 0.01
    }
}

$ bigchaindb -y configure mongodb && bigchaindb show-config
Generating keypair
Generating default configuration for backend mongodb
Configuration written to /home/rodmar/.bigchaindb
Ready to go!
INFO:bigchaindb.config_utils:Configuration loaded from `/home/rodmar/.bigchaindb`
{
    "backlog_reassign_delay": 120,
    "database": {
        "backend": "mongodb",
        "host": "localhost",
        "name": "bigchain",
        "port": 27017,
        "replicaset": "bigchain-rs"
    },
    "keypair": {
        "private": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
        "public": "BhRLBQsi3XuDjk7D7jdseMQpPP4g1rDHML3nSXZYC1Ls"
    },
    "keyring": [],
    "server": {
        "bind": "localhost:9984",
        "threads": null,
        "workers": null
    },
    "statsd": {
        "host": "localhost",
        "port": 8125,
        "rate": 0.01
    }
}
```

#### Todo:
- [x] Update documentation if this is accepted.