### PR TITLE
Add flake8-quotes checker and cleanup double quotes

### DIFF
--- a/bigchaindb/backend/utils.py
+++ b/bigchaindb/backend/utils.py
@@ -12,9 +12,9 @@ def module_dispatch_registrar(module):
                 return dispatch_registrar.register(obj_type)(func)
             except AttributeError as ex:
                 raise ModuleDispatchRegistrationError(
-                    ("`{module}` does not contain a single-dispatchable "
-                     "function named `{func}`. The module being registered "
-                     "was not implemented correctly!").format(
+                    ('`{module}` does not contain a single-dispatchable '
+                     'function named `{func}`. The module being registered '
+                     'was not implemented correctly!').format(
                          func=func_name, module=module.__name__)) from ex
         return wrapper
     return dispatch_wrapper

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -118,7 +118,7 @@ class Input(object):
             fulfillment = Fulfillment.from_uri(data['fulfillment'])
         except ValueError:
             # TODO FOR CC: Throw an `InvalidSignature` error in this case.
-            raise InvalidSignature('Fulfillment URI couldn\'t been parsed')
+            raise InvalidSignature("Fulfillment URI couldn't been parsed")
         except TypeError:
             # NOTE: See comment about this special case in
             #       `Input.to_dict`

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -1039,7 +1039,7 @@ class Transaction(object):
 
         if tx_body.get('operation') == Transaction.CREATE:
             if proposed_tx_id != tx_body['asset'].get('id'):
-                raise InvalidHash("CREATE tx has wrong asset_id")
+                raise InvalidHash('CREATE tx has wrong asset_id')
 
     @classmethod
     def from_dict(cls, tx):

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -118,7 +118,7 @@ class Input(object):
             fulfillment = Fulfillment.from_uri(data['fulfillment'])
         except ValueError:
             # TODO FOR CC: Throw an `InvalidSignature` error in this case.
-            raise InvalidSignature("Fulfillment URI couldn't been parsed")
+            raise InvalidSignature('Fulfillment URI couldn\'t been parsed')
         except TypeError:
             # NOTE: See comment about this special case in
             #       `Input.to_dict`

--- a/bigchaindb/consensus.py
+++ b/bigchaindb/consensus.py
@@ -39,6 +39,6 @@ class BaseConsensusRules():
             except SchemaValidationError as exc:
                 logger.warning(exc)
         else:
-            logger.warning("Vote failed signature verification: "
-                           "%s with voters: %s", signed_vote, voters)
+            logger.warning('Vote failed signature verification: '
+                           '%s with voters: %s', signed_vote, voters)
         return False

--- a/bigchaindb/web/views/info.py
+++ b/bigchaindb/web/views/info.py
@@ -36,10 +36,10 @@ class ApiV1Index(Resource):
             '/drivers-clients/http-client-server-api.html',
         ]
         return {
-            "_links": {
-                "docs": ''.join(docs_url),
-                "self": api_root,
-                "statuses": api_root + "statuses/",
-                "transactions": api_root + "transactions/",
+            '_links': {
+                'docs': ''.join(docs_url),
+                'self': api_root,
+                'statuses': api_root + 'statuses/',
+                'transactions': api_root + 'transactions/',
             },
         }

--- a/bigchaindb/web/views/statuses.py
+++ b/bigchaindb/web/views/statuses.py
@@ -28,7 +28,7 @@ class StatusApi(Resource):
 
         # logical xor - exactly one query argument required
         if bool(tx_id) == bool(block_id):
-            return make_error(400, "Provide exactly one query parameter. Choices are: block_id, tx_id")
+            return make_error(400, 'Provide exactly one query parameter. Choices are: block_id, tx_id')
 
         pool = current_app.config['bigchain_pool']
         status, links = None, None
@@ -37,7 +37,7 @@ class StatusApi(Resource):
             if tx_id:
                 status = bigchain.get_status(tx_id)
                 links = {
-                    "tx": "/transactions/{}".format(tx_id)
+                    'tx': '/transactions/{}'.format(tx_id)
                 }
 
             elif block_id:
@@ -56,7 +56,7 @@ class StatusApi(Resource):
 
         if links:
             response.update({
-                "_links": links
+                '_links': links
             })
 
         return response

--- a/docs/server/generate_schema_documentation.py
+++ b/docs/server/generate_schema_documentation.py
@@ -189,7 +189,7 @@ def render_section(section_name, obj):
                 'type': property_type(prop),
             }]
         except Exception as exc:
-            raise ValueError("Error rendering property: %s" % name, exc)
+            raise ValueError('Error rendering property: %s' % name, exc)
     return '\n\n'.join(out + [''])
 
 
@@ -201,7 +201,7 @@ def property_description(prop):
         return property_description(resolve_ref(prop['$ref']))
     if 'anyOf' in prop:
         return property_description(prop['anyOf'][0])
-    raise KeyError("description")
+    raise KeyError('description')
 
 
 def property_type(prop):
@@ -214,7 +214,7 @@ def property_type(prop):
         return ' or '.join(property_type(p) for p in prop['anyOf'])
     if '$ref' in prop:
         return property_type(resolve_ref(prop['$ref']))
-    raise ValueError("Could not resolve property type")
+    raise ValueError('Could not resolve property type')
 
 
 DEFINITION_BASE_PATH = '#/definitions/'

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ tests_require = [
     'coverage',
     'pep8',
     'flake8',
+    'flake8-quotes==0.8.1',
     'pylint',
     'pytest>=3.0.0',
     'pytest-catchlog>=1.2.2',

--- a/tests/backend/rethinkdb/test_admin.py
+++ b/tests/backend/rethinkdb/test_admin.py
@@ -57,8 +57,8 @@ def test_set_shards_dry_run(rdb_conn, db_name, db_conn):
 @pytest.mark.bdb
 @pytest.mark.skipif(
     _count_rethinkdb_servers() < 2,
-    reason=("Requires at least two servers. It's impossible to have"
-            "more replicas of the data than there are servers.")
+    reason=('Requires at least two servers. It\'s impossible to have'
+            'more replicas of the data than there are servers.')
 )
 def test_set_replicas(rdb_conn, db_name, db_conn):
     from bigchaindb.backend.schema import TABLES
@@ -85,8 +85,8 @@ def test_set_replicas(rdb_conn, db_name, db_conn):
 @pytest.mark.bdb
 @pytest.mark.skipif(
     _count_rethinkdb_servers() < 2,
-    reason=("Requires at least two servers. It's impossible to have"
-            "more replicas of the data than there are servers.")
+    reason=('Requires at least two servers. It\'s impossible to have'
+            'more replicas of the data than there are servers.')
 )
 def test_set_replicas_dry_run(rdb_conn, db_name, db_conn):
     from bigchaindb.backend.schema import TABLES
@@ -109,8 +109,8 @@ def test_set_replicas_dry_run(rdb_conn, db_name, db_conn):
 @pytest.mark.bdb
 @pytest.mark.skipif(
     _count_rethinkdb_servers() < 2,
-    reason=("Requires at least two servers. It's impossible to have"
-            "more replicas of the data than there are servers.")
+    reason=('Requires at least two servers. It\'s impossible to have'
+            'more replicas of the data than there are servers.')
 )
 def test_reconfigure(rdb_conn, db_name, db_conn):
     from bigchaindb.backend.rethinkdb.admin import reconfigure

--- a/tests/common/schema/test_schema.py
+++ b/tests/common/schema/test_schema.py
@@ -13,7 +13,7 @@ def _test_additionalproperties(node, path=''):
     if isinstance(node, dict):
         if node.get('type') == 'object':
             assert 'additionalProperties' in node, \
-                ("additionalProperties not set at path:" + path)
+                ('additionalProperties not set at path:' + path)
         for name, val in node.items():
             _test_additionalproperties(val, path + name + '.')
 
@@ -47,7 +47,7 @@ def test_drop_descriptions():
         },
         'definitions': {
             'wat': {
-                'description': "go"
+                'description': 'go'
             }
         }
     }

--- a/tests/web/test_blocks.py
+++ b/tests/web/test_blocks.py
@@ -41,7 +41,7 @@ def test_get_blocks_by_txid_endpoint(b, client):
     block_invalid = b.create_block([tx])
     b.write_block(block_invalid)
 
-    res = client.get(BLOCKS_ENDPOINT + "?tx_id=" + tx.id)
+    res = client.get(BLOCKS_ENDPOINT + '?tx_id=' + tx.id)
     # test if block is retrieved as undecided
     assert res.status_code == 200
     assert block_invalid.id in res.json
@@ -51,7 +51,7 @@ def test_get_blocks_by_txid_endpoint(b, client):
     vote = b.vote(block_invalid.id, b.get_last_voted_block().id, False)
     b.write_vote(vote)
 
-    res = client.get(BLOCKS_ENDPOINT + "?tx_id=" + tx.id)
+    res = client.get(BLOCKS_ENDPOINT + '?tx_id=' + tx.id)
     # test if block is retrieved as invalid
     assert res.status_code == 200
     assert block_invalid.id in res.json
@@ -61,7 +61,7 @@ def test_get_blocks_by_txid_endpoint(b, client):
     block_valid = b.create_block([tx, tx2])
     b.write_block(block_valid)
 
-    res = client.get(BLOCKS_ENDPOINT + "?tx_id=" + tx.id)
+    res = client.get(BLOCKS_ENDPOINT + '?tx_id=' + tx.id)
     # test if block is retrieved as undecided
     assert res.status_code == 200
     assert block_valid.id in res.json
@@ -71,7 +71,7 @@ def test_get_blocks_by_txid_endpoint(b, client):
     vote = b.vote(block_valid.id, block_invalid.id, True)
     b.write_vote(vote)
 
-    res = client.get(BLOCKS_ENDPOINT + "?tx_id=" + tx.id)
+    res = client.get(BLOCKS_ENDPOINT + '?tx_id=' + tx.id)
     # test if block is retrieved as valid
     assert res.status_code == 200
     assert block_valid.id in res.json
@@ -96,19 +96,19 @@ def test_get_blocks_by_txid_and_status_endpoint(b, client):
     block_valid = b.create_block([tx, tx2])
     b.write_block(block_valid)
 
-    res = client.get("{}?tx_id={}&status={}".format(BLOCKS_ENDPOINT, tx.id, Bigchain.BLOCK_INVALID))
+    res = client.get('{}?tx_id={}&status={}'.format(BLOCKS_ENDPOINT, tx.id, Bigchain.BLOCK_INVALID))
     # test if no blocks are retrieved as invalid
     assert res.status_code == 200
     assert len(res.json) == 0
 
-    res = client.get("{}?tx_id={}&status={}".format(BLOCKS_ENDPOINT, tx.id, Bigchain.BLOCK_UNDECIDED))
+    res = client.get('{}?tx_id={}&status={}'.format(BLOCKS_ENDPOINT, tx.id, Bigchain.BLOCK_UNDECIDED))
     # test if both blocks are retrieved as undecided
     assert res.status_code == 200
     assert block_valid.id in res.json
     assert block_invalid.id in res.json
     assert len(res.json) == 2
 
-    res = client.get("{}?tx_id={}&status={}".format(BLOCKS_ENDPOINT, tx.id, Bigchain.BLOCK_VALID))
+    res = client.get('{}?tx_id={}&status={}'.format(BLOCKS_ENDPOINT, tx.id, Bigchain.BLOCK_VALID))
     # test if no blocks are retrieved as valid
     assert res.status_code == 200
     assert len(res.json) == 0
@@ -121,18 +121,18 @@ def test_get_blocks_by_txid_and_status_endpoint(b, client):
     vote = b.vote(block_valid.id, block_invalid.id, True)
     b.write_vote(vote)
 
-    res = client.get("{}?tx_id={}&status={}".format(BLOCKS_ENDPOINT, tx.id, Bigchain.BLOCK_INVALID))
+    res = client.get('{}?tx_id={}&status={}'.format(BLOCKS_ENDPOINT, tx.id, Bigchain.BLOCK_INVALID))
     # test if the invalid block is retrieved as invalid
     assert res.status_code == 200
     assert block_invalid.id in res.json
     assert len(res.json) == 1
 
-    res = client.get("{}?tx_id={}&status={}".format(BLOCKS_ENDPOINT, tx.id, Bigchain.BLOCK_UNDECIDED))
+    res = client.get('{}?tx_id={}&status={}'.format(BLOCKS_ENDPOINT, tx.id, Bigchain.BLOCK_UNDECIDED))
     # test if no blocks are retrieved as undecided
     assert res.status_code == 200
     assert len(res.json) == 0
 
-    res = client.get("{}?tx_id={}&status={}".format(BLOCKS_ENDPOINT, tx.id, Bigchain.BLOCK_VALID))
+    res = client.get('{}?tx_id={}&status={}'.format(BLOCKS_ENDPOINT, tx.id, Bigchain.BLOCK_VALID))
     # test if the valid block is retrieved as valid
     assert res.status_code == 200
     assert block_valid.id in res.json
@@ -141,11 +141,11 @@ def test_get_blocks_by_txid_and_status_endpoint(b, client):
 
 @pytest.mark.bdb
 def test_get_blocks_by_txid_endpoint_returns_empty_list_not_found(client):
-    res = client.get(BLOCKS_ENDPOINT + "?tx_id=")
+    res = client.get(BLOCKS_ENDPOINT + '?tx_id=')
     assert res.status_code == 200
     assert len(res.json) == 0
 
-    res = client.get(BLOCKS_ENDPOINT + "?tx_id=123")
+    res = client.get(BLOCKS_ENDPOINT + '?tx_id=123')
     assert res.status_code == 200
     assert len(res.json) == 0
 
@@ -155,7 +155,7 @@ def test_get_blocks_by_txid_endpoint_returns_400_bad_query_params(client):
     res = client.get(BLOCKS_ENDPOINT)
     assert res.status_code == 400
 
-    res = client.get(BLOCKS_ENDPOINT + "?ts_id=123")
+    res = client.get(BLOCKS_ENDPOINT + '?ts_id=123')
     assert res.status_code == 400
     assert res.json == {
         'message': {
@@ -163,13 +163,13 @@ def test_get_blocks_by_txid_endpoint_returns_400_bad_query_params(client):
         }
     }
 
-    res = client.get(BLOCKS_ENDPOINT + "?tx_id=123&foo=123")
+    res = client.get(BLOCKS_ENDPOINT + '?tx_id=123&foo=123')
     assert res.status_code == 400
     assert res.json == {
         'message': 'Unknown arguments: foo'
     }
 
-    res = client.get(BLOCKS_ENDPOINT + "?tx_id=123&status=123")
+    res = client.get(BLOCKS_ENDPOINT + '?tx_id=123&status=123')
     assert res.status_code == 400
     assert res.json == {
         'message': {

--- a/tests/web/test_statuses.py
+++ b/tests/web/test_statuses.py
@@ -10,15 +10,15 @@ STATUSES_ENDPOINT = '/api/v1/statuses'
 def test_get_transaction_status_endpoint(b, client, user_pk):
     input_tx = b.get_owned_ids(user_pk).pop()
     tx, status = b.get_transaction(input_tx.txid, include_status=True)
-    res = client.get(STATUSES_ENDPOINT + "?tx_id=" + input_tx.txid)
+    res = client.get(STATUSES_ENDPOINT + '?tx_id=' + input_tx.txid)
     assert status == res.json['status']
-    assert res.json['_links']['tx'] == "/transactions/{}".format(input_tx.txid)
+    assert res.json['_links']['tx'] == '/transactions/{}'.format(input_tx.txid)
     assert res.status_code == 200
 
 
 @pytest.mark.bdb
 def test_get_transaction_status_endpoint_returns_404_if_not_found(client):
-    res = client.get(STATUSES_ENDPOINT + "?tx_id=123")
+    res = client.get(STATUSES_ENDPOINT + '?tx_id=123')
     assert res.status_code == 404
 
 
@@ -32,7 +32,7 @@ def test_get_block_status_endpoint_undecided(b, client):
 
     status = b.block_election_status(block.id, block.voters)
 
-    res = client.get(STATUSES_ENDPOINT + "?block_id=" + block.id)
+    res = client.get(STATUSES_ENDPOINT + '?block_id=' + block.id)
     assert status == res.json['status']
     assert '_links' not in res.json
     assert res.status_code == 200
@@ -53,7 +53,7 @@ def test_get_block_status_endpoint_valid(b, client):
 
     status = b.block_election_status(block.id, block.voters)
 
-    res = client.get(STATUSES_ENDPOINT + "?block_id=" + block.id)
+    res = client.get(STATUSES_ENDPOINT + '?block_id=' + block.id)
     assert status == res.json['status']
     assert '_links' not in res.json
     assert res.status_code == 200
@@ -74,7 +74,7 @@ def test_get_block_status_endpoint_invalid(b, client):
 
     status = b.block_election_status(block.id, block.voters)
 
-    res = client.get(STATUSES_ENDPOINT + "?block_id=" + block.id)
+    res = client.get(STATUSES_ENDPOINT + '?block_id=' + block.id)
     assert status == res.json['status']
     assert '_links' not in res.json
     assert res.status_code == 200
@@ -82,7 +82,7 @@ def test_get_block_status_endpoint_invalid(b, client):
 
 @pytest.mark.bdb
 def test_get_block_status_endpoint_returns_404_if_not_found(client):
-    res = client.get(STATUSES_ENDPOINT + "?block_id=123")
+    res = client.get(STATUSES_ENDPOINT + '?block_id=123')
     assert res.status_code == 404
 
 
@@ -91,8 +91,8 @@ def test_get_status_endpoint_returns_400_bad_query_params(client):
     res = client.get(STATUSES_ENDPOINT)
     assert res.status_code == 400
 
-    res = client.get(STATUSES_ENDPOINT + "?ts_id=123")
+    res = client.get(STATUSES_ENDPOINT + '?ts_id=123')
     assert res.status_code == 400
 
-    res = client.get(STATUSES_ENDPOINT + "?tx_id=123&block_id=123")
+    res = client.get(STATUSES_ENDPOINT + '?tx_id=123&block_id=123')
     assert res.status_code == 400

--- a/tests/web/test_transactions.py
+++ b/tests/web/test_transactions.py
@@ -53,8 +53,8 @@ def test_post_create_transaction_with_invalid_id(b, client, caplog):
     res = client.post(TX_ENDPOINT, data=json.dumps(tx))
     expected_status_code = 400
     expected_error_message = (
-        "Invalid transaction ({}): The transaction's id '{}' isn't equal to "
-        "the hash of its body, i.e. it's not valid."
+        'Invalid transaction ({}): The transaction\'s id \'{}\' isn\'t equal to '
+        'the hash of its body, i.e. it\'s not valid.'
     ).format(InvalidHash.__name__, tx['id'])
     assert res.status_code == expected_status_code
     assert res.json['message'] == expected_error_message
@@ -74,8 +74,8 @@ def test_post_create_transaction_with_invalid_signature(b, client, caplog):
     res = client.post(TX_ENDPOINT, data=json.dumps(tx))
     expected_status_code = 400
     expected_error_message = (
-        "Invalid transaction ({}): Fulfillment URI "
-        "couldn't been parsed"
+        'Invalid transaction ({}): Fulfillment URI '
+        'couldn\'t been parsed'
     ).format(InvalidSignature.__name__)
     assert res.status_code == expected_status_code
     assert res.json['message'] == expected_error_message
@@ -97,7 +97,7 @@ def test_post_create_transaction_with_invalid_schema(client, caplog):
     res = client.post(TX_ENDPOINT, data=json.dumps(tx))
     expected_status_code = 400
     expected_error_message = (
-        "Invalid transaction schema: 'version' is a required property")
+        'Invalid transaction schema: \'version\' is a required property')
     assert res.status_code == expected_status_code
     assert res.json['message'] == expected_error_message
     assert caplog.records[0].args['status'] == expected_status_code

--- a/tests/web/test_transactions.py
+++ b/tests/web/test_transactions.py
@@ -97,7 +97,7 @@ def test_post_create_transaction_with_invalid_schema(client, caplog):
     res = client.post(TX_ENDPOINT, data=json.dumps(tx))
     expected_status_code = 400
     expected_error_message = (
-        'Invalid transaction schema: \'version\' is a required property')
+        "Invalid transaction schema: 'version' is a required property")
     assert res.status_code == expected_status_code
     assert res.json['message'] == expected_error_message
     assert caplog.records[0].args['status'] == expected_status_code

--- a/tests/web/test_votes.py
+++ b/tests/web/test_votes.py
@@ -18,7 +18,7 @@ def test_get_votes_endpoint(b, client):
     vote = b.vote(block.id, b.get_last_voted_block().id, True)
     b.write_vote(vote)
 
-    res = client.get(VOTES_ENDPOINT + "?block_id=" + block.id)
+    res = client.get(VOTES_ENDPOINT + '?block_id=' + block.id)
     assert vote == res.json[0]
     assert len(res.json) == 1
     assert res.status_code == 200
@@ -41,18 +41,18 @@ def test_get_votes_endpoint_multiple_votes(b, client):
     vote_invalid = b.vote(block.id, last_block, False)
     b.write_vote(vote_invalid)
 
-    res = client.get(VOTES_ENDPOINT + "?block_id=" + block.id)
+    res = client.get(VOTES_ENDPOINT + '?block_id=' + block.id)
     assert len(res.json) == 2
     assert res.status_code == 200
 
 
 @pytest.mark.bdb
 def test_get_votes_endpoint_returns_empty_list_not_found(client):
-    res = client.get(VOTES_ENDPOINT + "?block_id=")
+    res = client.get(VOTES_ENDPOINT + '?block_id=')
     assert [] == res.json
     assert res.status_code == 200
 
-    res = client.get(VOTES_ENDPOINT + "?block_id=123")
+    res = client.get(VOTES_ENDPOINT + '?block_id=123')
     assert [] == res.json
     assert res.status_code == 200
 
@@ -62,8 +62,8 @@ def test_get_votes_endpoint_returns_400_bad_query_params(client):
     res = client.get(VOTES_ENDPOINT)
     assert res.status_code == 400
 
-    res = client.get(VOTES_ENDPOINT + "?ts_id=123")
+    res = client.get(VOTES_ENDPOINT + '?ts_id=123')
     assert res.status_code == 400
 
-    res = client.get(VOTES_ENDPOINT + "?tx_id=123&block_id=123")
+    res = client.get(VOTES_ENDPOINT + '?tx_id=123&block_id=123')
     assert res.status_code == 400


### PR DESCRIPTION
This is a flake8 extension to check for double quotes mis(?)use, and cleanup of the instances where we use double quotes instead of single quotes for inline string literals.