### PR TITLE
Return 202 on successful transaction POST

### DIFF
--- a/bigchaindb/web/views/transactions.py
+++ b/bigchaindb/web/views/transactions.py
@@ -113,4 +113,4 @@ class TransactionListApi(Resource):
                 with monitor.timer('write_transaction', rate=rate):
                     bigchain.write_transaction(tx_obj)
 
-        return tx
+        return tx, 202

--- a/tests/web/test_transactions.py
+++ b/tests/web/test_transactions.py
@@ -38,6 +38,9 @@ def test_post_create_transaction_endpoint(b, client):
     tx = tx.sign([user_priv])
 
     res = client.post(TX_ENDPOINT, data=json.dumps(tx.to_dict()))
+
+    assert res.status_code == 202
+
     assert res.json['inputs'][0]['owners_before'][0] == user_pub
     assert res.json['outputs'][0]['public_keys'][0] == user_pub
 
@@ -156,6 +159,8 @@ def test_post_transfer_transaction_endpoint(b, client, user_pk, user_sk):
     transfer_tx = transfer_tx.sign([user_sk])
 
     res = client.post(TX_ENDPOINT, data=json.dumps(transfer_tx.to_dict()))
+
+    assert res.status_code == 202
 
     assert res.json['inputs'][0]['owners_before'][0] == user_pk
     assert res.json['outputs'][0]['public_keys'][0] == user_pub


### PR DESCRIPTION
This brings implementation into line with docs that specify 202 response code on TX POST.

https://github.com/bigchaindb/bigchaindb/blob/master/docs/server/generate_http_server_api_documentation.py#L70