### PR TITLE
Parallel testing script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: mongo:3.4.1
     ports:
       - "27017"
-    command: mongod --replSet=rs0
+    command: mongod --replSet=bigchain-rs
 
   rdb:
     image: rethinkdb

--- a/scripts/floodtest.sh
+++ b/scripts/floodtest.sh
@@ -15,12 +15,12 @@ function runWorker () {
 		git clone bigchaindb $1
 	fi
 	cd $1
-        git pull
-        docker-compose -p flood-$1 up -d mdb
+	docker-compose -p flood-$1 up -d mdb
 	docker-compose -p flood-$1 run --rm bdb-mdb pytest -v -x -s
-        # Neccesary so that no root-owned files are left lying around, otherwise we can't clean up outside the container
-	# without `sudo`. 
-	docker-compose -p flood-$1 run -w/usr/src --rm bdb-mdb bash -c 'self=`stat -c %u app/bigchaindb`; chown -R $self:$self app'
+	# Neccesary so that no root-owned files are left lying around,
+	# otherwise we can't clean up outside the container without `sudo`. 
+	docker-compose -p flood-$1 run -w/usr/src --rm bdb-mdb bash -c \
+		'self=`stat -c %u app/bigchaindb`; chown -R $self:$self app'
 	docker-compose stop bdb-mdb
 	cd ..
 	rm -rf $1

--- a/scripts/floodtest.sh
+++ b/scripts/floodtest.sh
@@ -5,8 +5,22 @@
 # Run BigchainDB test suite repeatedly in parallel. For hunting race conditions.
 # 
 # Author: scott@bigchaindb.com
+#
+# Arguments:
+#     [int] Number of workers
+#
+# Environment variables:
+# $FLOOD_CMD - Test command to run, defaults to "pytest -v -s -x"
+#
+# In order to run this command repeatedly, try:
+#
+# while true; do path/to/floodtest.sh $x || break; done
+#
+
 
 set -e
+
+test_cmd=${FLOOD_CMD:-pytest -v -x -s}
 
 function runWorker () {
 	set -x
@@ -16,7 +30,7 @@ function runWorker () {
 	fi
 	cd $1
 	docker-compose -p flood-$1 up -d mdb
-	docker-compose -p flood-$1 run --rm bdb-mdb pytest -v -x -s
+	docker-compose -p flood-$1 run --rm bdb-mdb $test_cmd
 	# Neccesary so that no root-owned files are left lying around,
 	# otherwise we can't clean up outside the container without `sudo`. 
 	docker-compose -p flood-$1 run -w/usr/src --rm bdb-mdb bash -c \

--- a/scripts/floodtest.sh
+++ b/scripts/floodtest.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# testflood.sh
+#
+# Run BigchainDB test suite repeatedly in parallel. For hunting race conditions.
+# 
+# Author: scott@bigchaindb.com
+
+set -e
+
+function runWorker () {
+	set -x
+	if [ ! -d $1 ]
+	then
+		git clone bigchaindb $1
+	fi
+	cd $1
+        git pull
+        docker-compose -p flood-$1 up -d mdb
+	docker-compose -p flood-$1 run --rm bdb-mdb pytest -v -x -s
+        # Neccesary so that no root-owned files are left lying around, otherwise we can't clean up outside the container
+	# without `sudo`. 
+	docker-compose -p flood-$1 run -w/usr/src --rm bdb-mdb bash -c 'self=`stat -c %u app/bigchaindb`; chown -R $self:$self app'
+	docker-compose stop bdb-mdb
+	cd ..
+	rm -rf $1
+	set +x
+	echo "All done."
+}
+
+
+if [ "$1" -eq 0 -o "$1" -ne 0 ] >/dev/null 2>&1; then
+	processes=$1
+else
+	>&2 echo "Usage: $0 [number-of-workers]"
+	exit 1
+fi
+
+while true; do
+	FAIL=0
+	for i in $(seq 1 $processes); do
+                worker=`printf "worker_%02d\n" $i`
+		echo "Launching $worker"
+                runWorker $worker &> $worker.log &
+	done
+	echo "Waiting for workers to finish"
+	for job in `jobs -p`; do
+		wait $job || let "FAIL+=1"
+	done
+	if [ "$FAIL" != "0" ]; then
+		echo "Runners failed: $FAIL"
+		break
+	fi
+	echo "All workers completed successfully"
+	break
+done


### PR DESCRIPTION
Script to run test suite in many parallel processes.

Uses `docker-compose` and separate networks rather than the pytest-xdist method, because of the need for isolation in filehandles. 