### PR TITLE
Fix docstring of `recipient` argument to be a list of tuples

### DIFF
--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -483,8 +483,8 @@ class Transaction(object):
             Args:
                 tx_signers (:obj:`list` of :obj:`str`): A list of keys that
                     represent the signers of the CREATE Transaction.
-                recipients (:obj:`list` of :obj:`str`): A list of keys that
-                    represent the recipients of the outputs of this
+                recipients (:obj:`list` of :obj:`tuple`): A list of
+                    ([keys],amount) that represent the recipients of this
                     Transaction.
                 metadata (dict): The metadata to be stored along with the
                     Transaction.
@@ -550,7 +550,7 @@ class Transaction(object):
                 inputs (:obj:`list` of :class:`~bigchaindb.common.transaction.
                     Input`): Converted `Output`s, intended to
                     be used as inputs in the transfer to generate.
-                recipients (:obj:`list` of :obj:`str`): A list of
+                recipients (:obj:`list` of :obj:`tuple`): A list of
                     ([keys],amount) that represent the recipients of this
                     Transaction.
                 asset_id (str): The asset ID of the asset to be transferred in


### PR DESCRIPTION
Small fix for incorrect docstrings for the `recipient` argument after divisible assets.

Not sure if I should put what the tuple is of (in this case, list of strings and int)? Maybe you know @sbellem?