### PR TITLE
Document how to run BigchainDB with MongoDB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: mongo:3.4.1
     ports:
       - "27017"
-    command: mongod --replSet=rs0
+    command: mongod --replSet=bigchain-rs
 
   rdb:
     image: rethinkdb

--- a/docs/server/source/dev-and-test/setup-run-node.md
+++ b/docs/server/source/dev-and-test/setup-run-node.md
@@ -44,7 +44,7 @@ $ bigchaindb -y configure mongodb
 
 Note: [The BigchainDB CLI](../server-reference/bigchaindb-cli.html) and the [BigchainDB Configuration Settings](../server-reference/configuration.html) are documented elsewhere. (Click the links.)
 
-Start MongoDB using:
+Start MongoDB __3.4+__ using:
 ```text
 $ mongod --replSet=bigchain-rs
 ```
@@ -122,7 +122,7 @@ docker-compose up -d mdb
 MongoDB should now be up and running. You can check the port binding for the
 MongoDB driver port using:
 ```bash
-$ docker-compose port rdb 27017
+$ docker-compose port mdb 27017
 ```
 
 Start a BigchainDB node:

--- a/docs/server/source/dev-and-test/setup-run-node.md
+++ b/docs/server/source/dev-and-test/setup-run-node.md
@@ -30,6 +30,11 @@ To run BigchainDB Server, do:
 $ bigchaindb start
 ```
 
+You can [run all the unit tests](running-unit-tests.html) to test your installation.
+
+The BigchainDB [CONTRIBUTING.md file](https://github.com/bigchaindb/bigchaindb/blob/master/CONTRIBUTING.md) has more details about how to contribute.
+
+
 ### With MongoDB
 
 Create a default BigchainDB config file (in `$HOME/.bigchaindb`):
@@ -58,7 +63,6 @@ $ bigchaindb start
 You can [run all the unit tests](running-unit-tests.html) to test your installation.
 
 The BigchainDB [CONTRIBUTING.md file](https://github.com/bigchaindb/bigchaindb/blob/master/CONTRIBUTING.md) has more details about how to contribute.
-
 
 
 ## Option B: Using a Local Dev Machine and Docker

--- a/docs/server/source/dev-and-test/setup-run-node.md
+++ b/docs/server/source/dev-and-test/setup-run-node.md
@@ -7,25 +7,52 @@ The BigchainDB core dev team develops BigchainDB on recent Ubuntu and Fedora dis
 
 ## Option A: Using a Local Dev Machine
 
-First, read through the BigchainDB [CONTRIBUTING.md file](https://github.com/bigchaindb/bigchaindb/blob/master/CONTRIBUTING.md). It outlines the steps to setup a machine for developing and testing BigchainDB.
+Read through the BigchainDB [CONTRIBUTING.md file](https://github.com/bigchaindb/bigchaindb/blob/master/CONTRIBUTING.md). It outlines the steps to setup a machine for developing and testing BigchainDB.
 
-Next, create a default BigchainDB config file (in `$HOME/.bigchaindb`):
+### With RethinkDB
+
+Create a default BigchainDB config file (in `$HOME/.bigchaindb`):
 ```text
-bigchaindb -y configure
+$ bigchaindb -y configure rethinkdb
 ```
 
 Note: [The BigchainDB CLI](../server-reference/bigchaindb-cli.html) and the [BigchainDB Configuration Settings](../server-reference/configuration.html) are documented elsewhere. (Click the links.)
 
 Start RethinkDB using:
 ```text
-rethinkdb
+$ rethinkdb
 ```
 
 You can verify that RethinkDB is running by opening the RethinkDB web interface in your web browser. It should be at [http://localhost:8080/](http://localhost:8080/).
 
 To run BigchainDB Server, do:
 ```text
-bigchaindb start
+$ bigchaindb start
+```
+
+### With MongoDB
+
+Create a default BigchainDB config file (in `$HOME/.bigchaindb`):
+```text
+$ bigchaindb -y configure mongodb
+```
+
+Note: [The BigchainDB CLI](../server-reference/bigchaindb-cli.html) and the [BigchainDB Configuration Settings](../server-reference/configuration.html) are documented elsewhere. (Click the links.)
+
+Start MongoDB using:
+```text
+$ mongod --replSet=bigchain-rs
+```
+
+You can verify that MongoDB is running correctly by checking the output of the
+previous command for the line:
+```text
+waiting for connections on port 27017
+```
+
+To run BigchainDB Server, do:
+```text
+$ bigchaindb start
 ```
 
 You can [run all the unit tests](running-unit-tests.html) to test your installation.
@@ -33,13 +60,8 @@ You can [run all the unit tests](running-unit-tests.html) to test your installat
 The BigchainDB [CONTRIBUTING.md file](https://github.com/bigchaindb/bigchaindb/blob/master/CONTRIBUTING.md) has more details about how to contribute.
 
 
-## Option B: Using a Dev Machine on Cloud9
 
-Ian Worrall of [Encrypted Labs](http://www.encryptedlabs.com/) wrote a document (PDF) explaining how to set up a BigchainDB (Server) dev machine on Cloud9:
-
-[Download that document from GitHub](https://raw.githubusercontent.com/bigchaindb/bigchaindb/master/docs/server/source/_static/cloud9.pdf)
-
-## Option C: Using a Local Dev Machine and Docker
+## Option B: Using a Local Dev Machine and Docker
 
 You need to have recent versions of [Docker Engine](https://docs.docker.com/engine/installation/)
 and (Docker) [Compose](https://docs.docker.com/compose/install/).
@@ -49,6 +71,8 @@ Build the images:
 ```bash
 docker-compose build
 ```
+
+### Docker with RethinkDB
 
 **Note**: If you're upgrading BigchainDB and have previously already built the images, you may need
 to rebuild them after the upgrade to install any new dependencies.
@@ -62,7 +86,7 @@ docker-compose up -d rdb
 The RethinkDB web interface should be accessible at <http://localhost:58080/>.
 Depending on which platform, and/or how you are running docker, you may need
 to change `localhost` for the `ip` of the machine that is running docker. As a
-dummy example, if the `ip` of that machine was `0.0.0.0`, you would accees the
+dummy example, if the `ip` of that machine was `0.0.0.0`, you would access the
 web interface at: <http://0.0.0.0:58080/>.
 
 Start a BigchainDB node:
@@ -82,6 +106,40 @@ If you wish to run the tests:
 ```bash
 docker-compose run --rm bdb py.test -v -n auto
 ```
+
+### Docker with MongoDB
+
+Start MongoDB:
+
+```bash
+docker-compose up -d mdb
+```
+
+MongoDB should now be up and running. You can check the port binding for the
+MongoDB driver port using:
+```bash
+$ docker-compose port rdb 27017
+```
+
+Start a BigchainDB node:
+
+```bash
+docker-compose up -d bdb-mdb
+```
+
+You can monitor the logs:
+
+```bash
+docker-compose logs -f bdb-mdb
+```
+
+If you wish to run the tests:
+
+```bash
+docker-compose run --rm bdb-mdb py.test -v --database-backend=mongodb
+```
+
+### Accessing the HTTP API
 
 A quick check to make sure that the BigchainDB server API is operational:
 
@@ -123,3 +181,9 @@ root:
 ```bash
 curl 0.0.0.0:32772
 ```
+
+## Option C: Using a Dev Machine on Cloud9
+
+Ian Worrall of [Encrypted Labs](http://www.encryptedlabs.com/) wrote a document (PDF) explaining how to set up a BigchainDB (Server) dev machine on Cloud9:
+
+[Download that document from GitHub](https://raw.githubusercontent.com/bigchaindb/bigchaindb/master/docs/server/source/_static/cloud9.pdf)

--- a/docs/server/source/quickstart.md
+++ b/docs/server/source/quickstart.md
@@ -5,7 +5,7 @@ This page has instructions to set up a single stand-alone BigchainDB node for le
 A. Install the database backend. 
 
 [Install RethinkDB Server](https://rethinkdb.com/docs/install/ubuntu/) or
-[Install MongoDB Server](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/)
+[Install MongoDB Server 3.4+](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/)
 
 B. Run the database backend. Open a Terminal and run the command:
 
@@ -14,7 +14,7 @@ with RethinkDB
 $ rethinkdb
 ```
 
-with MongoDB
+with MongoDB __3.4+__
 ```text
 $ mongod --replSet=bigchain-rs
 ```

--- a/docs/server/source/quickstart.md
+++ b/docs/server/source/quickstart.md
@@ -2,34 +2,55 @@
 
 This page has instructions to set up a single stand-alone BigchainDB node for learning or experimenting. Instructions for other cases are [elsewhere](introduction.html). We will assume you're using Ubuntu 16.04 or similar. If you're not using Linux, then you might try [running BigchainDB with Docker](appendices/run-with-docker.html).
 
-A. [Install RethinkDB Server](https://rethinkdb.com/docs/install/ubuntu/)
+A. Install the database backend. 
 
-B. Open a Terminal and run RethinkDB Server with the command:
+[Install RethinkDB Server](https://rethinkdb.com/docs/install/ubuntu/) or
+[Install MongoDB Server](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/)
+
+B. Run the database backend. Open a Terminal and run the command:
+
+with RethinkDB
 ```text
-rethinkdb
+$ rethinkdb
+```
+
+with MongoDB
+```text
+$ mongod --replSet=bigchain-rs
 ```
 
 C. Ubuntu 16.04 already has Python 3.5, so you don't need to install it, but you do need to install some other things:
 ```text
-sudo apt-get update
-sudo apt-get install g++ python3-dev libffi-dev
+$ sudo apt-get update
+$ sudo apt-get install g++ python3-dev libffi-dev
 ```
 
 D. Get the latest version of pip and setuptools:
 ```text
-sudo apt-get install python3-pip
-sudo pip3 install --upgrade pip setuptools
+$ sudo apt-get install python3-pip
+$ sudo pip3 install --upgrade pip setuptools
 ```
 
 E. Install the `bigchaindb` Python package from PyPI:
 ```text
-sudo pip3 install bigchaindb
+$ sudo pip3 install bigchaindb
 ```
 
-F. Configure and run BigchainDB Server:
+F. Configure the BigchainDB Server: and run BigchainDB Server:
+
+with RethinkDB
 ```text
-bigchaindb -y configure
-bigchaindb start
+$ bigchaindb -y configure rethinkdb
+```
+
+with MongoDB
+```text
+$ bigchaindb -y configure mongodb
+```
+
+G. Run the BigchainDB Server:
+```text
+$ bigchaindb start
 ```
 
 That's it!

--- a/docs/server/source/server-reference/bigchaindb-cli.md
+++ b/docs/server/source/server-reference/bigchaindb-cli.md
@@ -19,7 +19,7 @@ Generate a local configuration file (which can be used to set some or all [Bigch
 
 Since BigchainDB supports multiple databases you need to always specify the
 database backend that you want to use. At this point only two database backends
-are support, `rethinkdb` and `mongodb`.
+are supported: `rethinkdb` and `mongodb`.
 
 If you use the `-c` command-line option, it will generate the file at the specified path:
 ```text

--- a/docs/server/source/server-reference/bigchaindb-cli.md
+++ b/docs/server/source/server-reference/bigchaindb-cli.md
@@ -15,18 +15,22 @@ Show the version number. `bigchaindb -v` does the same thing.
 
 ## bigchaindb configure
 
-Generate a local config file (which can be used to set some or all [BigchainDB node configuration settings](configuration.html)). It will auto-generate a public-private keypair and then ask you for the values of other configuration settings. If you press Enter for a value, it will use the default value.
+Generate a local configuration file (which can be used to set some or all [BigchainDB node configuration settings](configuration.html)). It will auto-generate a public-private keypair and then ask you for the values of other configuration settings. If you press Enter for a value, it will use the default value.
+
+Since BigchainDB supports multiple databases you need to always specify the
+database backend that you want to use. At this point only two database backends
+are support, `rethinkdb` and `mongodb`.
 
 If you use the `-c` command-line option, it will generate the file at the specified path:
 ```text
-bigchaindb -c path/to/new_config.json configure
+bigchaindb -c path/to/new_config.json configure rethinkdb
 ```
 
 If you don't use the `-c` command-line option, the file will be written to `$HOME/.bigchaindb` (the default location where BigchainDB looks for a config file, if one isn't specified).
 
 If you use the `-y` command-line option, then there won't be any interactive prompts: it will just generate a keypair and use the default values for all the other configuration settings.
 ```text
-bigchaindb -y configure
+bigchaindb -y configure rethinkdb
 ```
 
 
@@ -82,4 +86,26 @@ $ bigchaindb set-shards 4
 Set the number of replicas (of each shard) in the underlying datastore. For example, the following command will set the number of replicas to three (i.e. it will set the replication factor to three):
 ```text
 $ bigchaindb set-replicas 3
+```
+
+## bigchaindb add-replicas
+
+This command is specific to MongoDB so it will only run if BigchainDB is
+configured with `mongodb` as the backend.
+
+This command is used to add nodes to a BigchainDB cluster. It accepts a list of
+space separated hosts in the form _hostname:port_:
+```text
+$ bigchaindb add-replicas server1.com:27017 server2.com:27017 server3.com:27017
+```
+
+## bigchaindb remove-replicas
+
+This command is specific to MongoDB so it will only run if BigchainDB is
+configured with `mongodb` as the backend.
+
+This command is used to remove nodes from a BigchainDB cluster. It accepts a
+list of space separated hosts in the form _hostname:port_:
+```text
+$ bigchaindb remove-replicas server1.com:27017 server2.com:27017 server3.com:27017
 ```


### PR DESCRIPTION
- Documented changes in the `configure` command.
- Documented the new `add-replicas remove-replicas` commands.
- Updated quickstart with instructions to run with mongodb
- Updated how to run a dev/test node with mongodb (with and without docker)