### PR TITLE
fix wrong logic in validate_block

### DIFF
--- a/bigchaindb/models.py
+++ b/bigchaindb/models.py
@@ -202,11 +202,6 @@ class Block(object):
             OperationError: If a non-federation node signed the Block.
             InvalidSignature: If a Block's signature is invalid.
         """
-
-        # First, make sure this node hasn't already voted on this block
-        if bigchain.has_previous_vote(self.id, self.voters):
-            return self
-
         # Check if the block was created by a federation node
         possible_voters = (bigchain.nodes_except_me + [bigchain.me])
         if self.node_pubkey not in possible_voters:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -163,16 +163,3 @@ class TestBlockModel(object):
 
         public_key = PublicKey(b.me)
         assert public_key.verify(expected_block_serialized, block.signature)
-
-    def test_validate_already_voted_on_block(self, b, monkeypatch):
-        from unittest.mock import Mock
-        from bigchaindb.models import Transaction
-
-        tx = Transaction.create([b.me], [([b.me], 1)])
-        block = b.create_block([tx])
-
-        has_previous_vote = Mock()
-        has_previous_vote.return_value = True
-        monkeypatch.setattr(b, 'has_previous_vote', has_previous_vote)
-        assert block == block.validate(b)
-        assert has_previous_vote.called is True


### PR DESCRIPTION
resolves #519 
resolves #660 

The line in question is in `models.Block.validate` https://github.com/bigchaindb/bigchaindb/blob/9762b4b96854cd5896f4b71c7fbfcc82d6f24f5c/bigchaindb/models.py#L207
```python
if bigchain.has_previous_vote(self.id, self.voters):
    return self
```
This pr removes this check and the associated test.

This is wrong for two reasons:
1. `Block.validate` should run the block validation logic regardless of the voting, the same way that `Transaction.validate` runs the transaction validation logic regardless of if the transaction already exists or not. It's up to the block creation pipeline to make sure that the transaction is unique https://github.com/bigchaindb/bigchaindb/blob/9762b4b96854cd5896f4b71c7fbfcc82d6f24f5c/bigchaindb/pipelines/block.py#L63, the same way that is up to the voting pipeline to make sure that the block was not already voted on https://github.com/bigchaindb/bigchaindb/blob/9762b4b96854cd5896f4b71c7fbfcc82d6f24f5c/bigchaindb/pipelines/vote.py#L52.
2. `Block.validate` returns `self` if the block is valid or raises an exception otherwise. With the line above it would return `self` if it had already been voted on regardless of whether the block had been voted valid or invalid.