### PR TITLE
Bug/1132/vote pipeline validates transactions twice

### DIFF
--- a/bigchaindb/pipelines/vote.py
+++ b/bigchaindb/pipelines/vote.py
@@ -53,7 +53,7 @@ class Vote:
                                                block['block']['voters']):
             try:
                 block = Block.from_dict(block)
-            except (exceptions.InvalidHash, exceptions.InvalidSignature):
+            except (exceptions.InvalidHash):
                 # XXX: if a block is invalid we should skip the `validate_tx`
                 # step, but since we are in a pipeline we cannot just jump to
                 # another function. Hackish solution: generate an invalid
@@ -61,10 +61,8 @@ class Vote:
                 # pipeline.
                 return block['id'], [self.invalid_dummy_tx]
             try:
-                self.consensus.validate_block(self.bigchain, block)
-            except (exceptions.InvalidHash,
-                    exceptions.OperationError,
-                    exceptions.InvalidSignature):
+                block._validate_block(self.bigchain)
+            except (exceptions.OperationError, exceptions.InvalidSignature):
                 # XXX: if a block is invalid we should skip the `validate_tx`
                 # step, but since we are in a pipeline we cannot just jump to
                 # another function. Hackish solution: generate an invalid

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -107,7 +107,7 @@ class TestBlockModel(object):
         with raises(InvalidHash):
             Block.from_dict(block)
 
-    def test_block_invalid_signature_deserialization(self, b):
+    def test_block_invalid_signature(self, b):
         from bigchaindb.common.crypto import hash_data
         from bigchaindb.common.exceptions import InvalidSignature
         from bigchaindb.common.utils import gen_timestamp, serialize
@@ -131,7 +131,7 @@ class TestBlockModel(object):
         }
 
         with raises(InvalidSignature):
-            Block.from_dict(block_body)
+            Block.from_dict(block_body).validate(b)
 
     def test_compare_blocks(self, b):
         from bigchaindb.models import Block, Transaction


### PR DESCRIPTION
resolves #1132 
resolves #1133 

Initially this pr was supposed to address the duplicate validation of transactions in the votes pipeline.
The pipeline was calling `Block.validate` (which also validates the transactions) and then `validate_tx` which validates the transactions again.
Now we want to use `validate_tx` because it parallelizes the validation of transactions.

I solved this by subdividing `Block.validate` into `Block._validate_block` and `Block._validate_block_transactions`.
This way the votes pipeline can simply call `Block._validate_block` and then validate the transactions separately.

While refactoring the `Block.validate` method I found another problem and I non-intentionally addressed #1133 in this pr.

Here the problem is that we had duplicated code for the validation of the signature.
When calling `Block.from_dict(); Block.validate()` which we usually want to do we were validating the signature twice.

So there were two solutions to remove the duplication:
1. Validate the signature in `from_dict`
2. Validate the signature in `validate`

The first approach is tricky. Before `from_dict` would work if the document did not have a signature. This is because we separate the creation of the document from the signing. If we were to do validation of the signature only on `from_dict` we would need to enforce that the signature is present always, meaning that we would no longer be able to do `from_dict` in an unsigned block.

The second approach works similar to the transaction model. `from_dict` does not validate the signature but it does include it in the model if a signature is provided.
And then the validation of the signature happens only when calling `Block.validate`