### PR TITLE
Add param 'rethinkdb' in docs for configure cmd.

### DIFF
--- a/docs/server/source/appendices/run-with-docker.md
+++ b/docs/server/source/appendices/run-with-docker.md
@@ -21,7 +21,7 @@ be stored in a file on your host machine at `~/bigchaindb_docker/.bigchaindb`:
 
 ```text
 docker run --rm -v "$HOME/bigchaindb_docker:/data" -ti \
-  bigchaindb/bigchaindb -y configure
+  bigchaindb/bigchaindb -y configure rethinkdb
 Generating keypair
 Configuration written to /data/.bigchaindb
 Ready to go!


### PR DESCRIPTION
With support for both mongo and rethink now, the original command for configuration of bigchaindb:
```
docker run --rm -v "$HOME/bigchaindb_docker:/data" -ti   bigchaindb/bigchaindb -y configure
```
needs to be updated to
```
docker run --rm -v "$HOME/bigchaindb_docker:/data" -ti   bigchaindb/bigchaindb -y configure rethinkdb
```
for docker to work without breaking.
