### PR TITLE
Removed base_url()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ ntools/one-m/ansible/ansible.cfg
 # Just in time documentation
 docs/server/source/schema
 docs/server/source/drivers-clients/samples
+
+#ignore .idea
+.idea/

--- a/bigchaindb/web/views/base.py
+++ b/bigchaindb/web/views/base.py
@@ -3,7 +3,7 @@ Common classes and methods for API handlers
 """
 import logging
 
-from flask import jsonify, request
+from flask import jsonify
 
 logger = logging.getLogger(__name__)
 
@@ -16,8 +16,3 @@ def make_error(status_code, message=None):
     response = jsonify(response_content)
     response.status_code = status_code
     return response
-
-
-def base_url():
-    return '%s://%s/' % (request.environ['wsgi.url_scheme'],
-                         request.environ['HTTP_HOST'])

--- a/bigchaindb/web/views/info.py
+++ b/bigchaindb/web/views/info.py
@@ -4,7 +4,6 @@ import flask
 from flask_restful import Resource
 
 import bigchaindb
-from bigchaindb.web.views.base import base_url
 from bigchaindb import version
 
 
@@ -14,7 +13,7 @@ class RootIndex(Resource):
             'https://docs.bigchaindb.com/projects/server/en/',
             version.__short_version__ + '/'
         ]
-        api_v1_url = base_url() + 'api/v1/'
+        api_v1_url = '/api/v1/'
         return flask.jsonify({
             '_links': {
                 'docs': ''.join(docs_url),
@@ -29,7 +28,7 @@ class RootIndex(Resource):
 
 class ApiV1Index(Resource):
     def get(self):
-        api_root = base_url() + 'api/v1/'
+        api_root = '/api/v1/'
         docs_url = [
             'https://docs.bigchaindb.com/projects/server/en/',
             version.__short_version__,

--- a/tests/web/test_info.py
+++ b/tests/web/test_info.py
@@ -9,7 +9,7 @@ def test_api_root_endpoint(client):
     assert res.json == {
         '_links': {
             'docs': 'https://docs.bigchaindb.com/projects/server/en/tst/',
-            'api_v1': 'http://localhost/api/v1/',
+            'api_v1': '/api/v1/',
         },
         'version': 'tsttst',
         'keyring': ['abc'],
@@ -28,8 +28,8 @@ def test_api_v1_endpoint(client):
     assert res.json == {
         '_links': {
             'docs': ''.join(docs_url),
-            'self': 'http://localhost/api/v1/',
-            'statuses': 'http://localhost/api/v1/statuses/',
-            'transactions': 'http://localhost/api/v1/transactions/',
+            'self': '/api/v1/',
+            'statuses': '/api/v1/statuses/',
+            'transactions': '/api/v1/transactions/',
         }
     }


### PR DESCRIPTION
- This will ensure we do not show protocol://host:port when someone hits
the root URL or root_url/api/v1

Solves #1141 