### PR TITLE
Upgrade pysha3 to 1.0.2 to fix usage on Python 3.6 on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ install_requires = [
     # TODO Consider not installing the db drivers, or putting them in extras.
     'rethinkdb~=2.3',  # i.e. a version between 2.3 and 3.0
     'pymongo~=3.4',
-    'pysha3==1.0.0',
+    'pysha3~=1.0.2',
     'cryptoconditions>=0.5.0',
     'python-rapidjson>=0.0.8',
     'logstats>=0.2.1',


### PR DESCRIPTION
Fixes #1128.