### PR TITLE
Default Dockerfile-dev to configure BigchainDB for RethinkDB

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -10,4 +10,4 @@ RUN pip install --upgrade pip
 COPY . /usr/src/app/
 
 RUN pip install --no-cache-dir -e .[dev]
-RUN bigchaindb -y configure
+RUN bigchaindb -y configure rethinkdb


### PR DESCRIPTION
@r-marques I guess we must've missed this in the configuration PR?