### PR TITLE
Fix bigchaindb configure commands

### DIFF
--- a/docs/server/source/cloud-deployment-starter-templates/azure-quickstart-template.md
+++ b/docs/server/source/cloud-deployment-starter-templates/azure-quickstart-template.md
@@ -24,7 +24,7 @@ One can deploy a BigchainDB node on Azure using the template in the `bigchaindb-
 
 1. Configure BigchainDB Server by doing:
 ```text
-bigchaindb configure
+bigchaindb configure rethinkdb
 ```
 It will ask you several questions. You can press `Enter` (or `Return`) to accept the default for all of them *except for one*. When it asks **API Server bind? (default \`localhost:9984\`):**, you should answer:
 ```text

--- a/docs/server/source/nodes/setup-run-node.md
+++ b/docs/server/source/nodes/setup-run-node.md
@@ -144,7 +144,7 @@ python setup.py install
 
 Start by creating a default BigchainDB config file:
 ```text
-bigchaindb -y configure
+bigchaindb -y configure rethinkdb
 ```
 
 (There's documentation for the `bigchaindb` command is in the section on [the BigchainDB Command Line Interface (CLI)](bigchaindb-cli.html).)

--- a/docs/server/source/server-reference/configuration.md
+++ b/docs/server/source/server-reference/configuration.md
@@ -28,7 +28,7 @@ Note that the `-c` command line option will always take precedence if both the `
 
 You can read the current default values in the file [bigchaindb/\_\_init\_\_.py](https://github.com/bigchaindb/bigchaindb/blob/master/bigchaindb/__init__.py). (The link is to the latest version.)
 
-Running `bigchaindb -y configure` will generate a local config file in `$HOME/.bigchaindb` with all the default values, with two exceptions: It will generate a valid private/public keypair, rather than using the default keypair (`None` and `None`).
+Running `bigchaindb -y configure rethinkdb` will generate a local config file in `$HOME/.bigchaindb` with all the default values, with two exceptions: It will generate a valid private/public keypair, rather than using the default keypair (`None` and `None`).
 
 
 ## keypair.public & keypair.private
@@ -49,7 +49,7 @@ export BIGCHAINDB_KEYPAIR_PRIVATE=5C5Cknco7YxBRP9AgB1cbUVTL4FAcooxErLygw1DeG2D
 }
 ```
 
-Internally (i.e. in the Python code), both keys have a default value of `None`, but that's not a valid key. Therefore you can't rely on the defaults for the keypair. If you want to run BigchainDB, you must provide a valid keypair, either in the environment variables or in the local config file. You can generate a local config file with a valid keypair (and default everything else) using `bigchaindb -y configure`.
+Internally (i.e. in the Python code), both keys have a default value of `None`, but that's not a valid key. Therefore you can't rely on the defaults for the keypair. If you want to run BigchainDB, you must provide a valid keypair, either in the environment variables or in the local config file. You can generate a local config file with a valid keypair (and default everything else) using `bigchaindb -y configure rethinkdb`.
 
 
 ## keyring

--- a/ntools/one-m/ansible/roles/bigchaindb/tasks/main.yml
+++ b/ntools/one-m/ansible/roles/bigchaindb/tasks/main.yml
@@ -37,7 +37,7 @@
   register: home_bigchaindb_config_file
 
 - name: If ~/.bigchaindb doesn't exist, generate a default BigchainDB config file there
-  shell: bigchaindb -y configure
+  shell: bigchaindb -y configure rethinkdb
   when: not home_bigchaindb_config_file.stat.exists
 
 - name: Look up all processes with 'bigchaindb' in their name


### PR DESCRIPTION
Appended `rethinkdb` to the end of `bigchaindb configure` or `bigchaindb -y configure` in various places.