### PR TITLE
Various modifications to the Release_Process.md

### DIFF
--- a/Release_Process.md
+++ b/Release_Process.md
@@ -41,11 +41,12 @@ These steps are common between minor and patch releases:
 1. Fill in the details:
    - Tag version: version number preceeded by 'v', e.g. "v0.9.1"
    - Target: the release branch that was just pushed
-   - Title: Same as tag name
-   - Description: The body of the changelog entry (Added, Changed etc)
-1. Publish the release on GitHub
-1. (Optional) Do a `make clean` in the repository root directory (`bigchaindb/`)
-1. Generate the release tarball with `python setup.py sdist`. Upload the release to PyPI, e.g. `twine upload dist/BigchainDB-0.9.0.tar.gz` (requires you to have a `~/.pypirc` file)
+   - Title: Same as tag name above, e.g "v0.9.1"
+   - Description: The body of the changelog entry (Added, Changed, etc.)
+1. Click "Publish release" to publish the release on GitHub
+1. Make sure your local Git is in the same state as the release: e.g. `git fetch <remote-name>` and `git checkout v0.9.1`
+1. Make sure you have a `~/.pypirc` file containing credentials for PyPI
+1. Do a `make release` to build and publish the new `bigchaindb` package on PyPI
 1. Login to readthedocs.org as a maintainer of the BigchainDB Server docs.
    Go to Admin --> Versions and under **Choose Active Versions**, make sure that the new version's tag is
    "Active" and "Public", and make sure the new version's branch

--- a/Release_Process.md
+++ b/Release_Process.md
@@ -10,11 +10,11 @@ that [major version 0.x does not export a stable API](http://semver.org/#spec-it
 A minor release is preceeded by a feature freeze and created from the 'master' branch. This is a summary of the steps we go through to release a new minor version of BigchainDB Server.
 
 1. Update the `CHANGELOG.md` file in master
-1. Create and checkout a new branch for the release, named after the minor version, without a preceeding 'v', e.g. `git checkout -b 0.9.4`
+1. Create and checkout a new branch for the minor release, named after the minor version, without a preceeding 'v', e.g. `git checkout -b 0.9` (*not* 0.9.0, this new branch will be for e.g. 0.9.0, 0.9.1, 0.9.2, etc. each of which will be identified by a tagged commit)
 1. In `bigchaindb/version.py`, update `__version__` and `__short_version__`, e.g. to `0.9` and `0.9.0` (with no `.dev` on the end)
-1. Commit changes, push new branch to Github, and merge it into master
+1. Commit that change, and push the new branch to GitHub
 1. Follow steps outlined in [Common Steps](#common-steps)
-1. In 'master' branch, Edit `bigchaindb/version.py`, increment the minor version to the next planned release, e.g. `0.10.0.dev'.
+1. In 'master' branch, Edit `bigchaindb/version.py`, increment the minor version to the next planned release, e.g. `0.10.0.dev'
 This is so people reading the latest docs will know that they're for the latest (master branch)
 version of BigchainDB Server, not the docs at the time of the most recent release (which are also
 available).
@@ -25,11 +25,12 @@ Congratulations, you have released BigchainDB!
 
 A patch release is similar to a minor release, but piggybacks on an existing minor release branch:
 
-1. Check out the minor release branch
-1. Apply the changes you want, ie using `git cherry-pick`.
+1. Check out the minor release branch, e.g. `0.9`
+1. Apply the changes you want, e.g. using `git cherry-pick`.
 1. Update the `CHANGELOG.md` file
 1. Increment the patch version in `bigchaindb/version.py`, e.g. "0.9.1"
 1. Follow steps outlined in [Common Steps](#common-steps)
+1. Cherry-pick the `CHANGELOG.md` update commit (made above) to the `master` branch
 
 ## Common steps
 
@@ -42,7 +43,8 @@ These steps are common between minor and patch releases:
    - Target: the release branch that was just pushed
    - Title: Same as tag name
    - Description: The body of the changelog entry (Added, Changed etc)
-1. Publish the release on Github
+1. Publish the release on GitHub
+1. (Optional) Do a `make clean` in the repository root directory (`bigchaindb/`)
 1. Generate the release tarball with `python setup.py sdist`. Upload the release to PyPI, e.g. `twine upload dist/BigchainDB-0.9.0.tar.gz` (requires you to have a `~/.pypirc` file)
 1. Login to readthedocs.org as a maintainer of the BigchainDB Server docs.
    Go to Admin --> Versions and under **Choose Active Versions**, make sure that the new version's tag is


### PR DESCRIPTION
* Clarify that the 0.X branch is for all 0.X.Y releases (tags), including 0.X.0, 0.X.1, 0.X.2, etc.
* Don't merge the 0.X.0 release into the `master` branch. The CHANGELOG.md file was already updated before branching off the master branch.
* In the patch release process, added a step to cherry-pick the commit to update the CHANGELOG.md file.
* In the common steps, added an optional `make clean` step before the PyPI steps.

Any comments or suggestions?