### PR TITLE
Added terraform.tfstate* files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,8 @@ ntools/one-m/ansible/ansible.cfg
 # Just in time documentation
 docs/server/source/schema
 docs/server/source/drivers-clients/samples
+
+# Terraform state files
+# See https://stackoverflow.com/a/41482391
+terraform.tfstate
+terraform.tfstate.backup


### PR DESCRIPTION
See https://stackoverflow.com/a/41482391

I used to have these files in my local `.git/info/exclude` file, but it seems everyone's Git should be ignoring them.