### PR TITLE
introduce BigchainDBCritical exception

### DIFF
--- a/bigchaindb/backend/exceptions.py
+++ b/bigchaindb/backend/exceptions.py
@@ -15,3 +15,7 @@ class OperationError(BackendError):
 
 class DuplicateKeyError(OperationError):
     """Exception raised when an insert fails because the key is not unique"""
+
+
+class BigchainDBCritical(Exception):
+    """Unhandleable error that requires attention"""

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -11,6 +11,7 @@ from bigchaindb.common.transaction import TransactionLink
 import bigchaindb
 
 from bigchaindb import backend, config_utils, utils
+from bigchaindb.backend import exceptions as backend_exceptions
 from bigchaindb.consensus import BaseConsensusRules
 from bigchaindb.models import Block, Transaction
 
@@ -308,11 +309,10 @@ class Bigchain(object):
             if list(validity.values()).count(Bigchain.BLOCK_VALID) > 1:
                 block_ids = str([block for block in validity
                                  if validity[block] == Bigchain.BLOCK_VALID])
-                raise exceptions.DoubleSpend('Transaction {tx} is present in '
-                                             'multiple valid blocks: '
-                                             '{block_ids}'
-                                             .format(tx=txid,
-                                                     block_ids=block_ids))
+                raise backend_exceptions.BigchainDBCritical(
+                    'Transaction {tx} is present in '
+                    'multiple valid blocks: {block_ids}'
+                    .format(tx=txid, block_ids=block_ids))
 
             return validity
 

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -90,8 +90,8 @@ class TestBigchainApi(object):
         assert b.has_previous_vote(block.id, block.voters) is True
 
     @pytest.mark.genesis
-    def test_get_spent_with_double_spend(self, b, monkeypatch):
-        from bigchaindb.common.exceptions import DoubleSpend
+    def test_get_spent_with_double_inclusion_detected(self, b, monkeypatch):
+        from bigchaindb.backend.exceptions import BigchainDBCritical
         from bigchaindb.models import Transaction
 
         tx = Transaction.create([b.me], [([b.me], 1)])
@@ -115,18 +115,18 @@ class TestBigchainApi(object):
         block3 = b.create_block([transfer_tx2])
         b.write_block(block3)
 
-        # Vote both block2 and block3 valid to provoke a double spend
+        # Vote both block2 and block3 valid
         vote = b.vote(block2.id, b.get_last_voted_block().id, True)
         b.write_vote(vote)
         vote = b.vote(block3.id, b.get_last_voted_block().id, True)
         b.write_vote(vote)
 
-        with pytest.raises(DoubleSpend):
+        with pytest.raises(BigchainDBCritical):
             b.get_spent(tx.id, 0)
 
     @pytest.mark.genesis
-    def test_get_block_status_for_tx_with_double_spend(self, b, monkeypatch):
-        from bigchaindb.common.exceptions import DoubleSpend
+    def test_get_block_status_for_tx_with_double_inclusion(self, b, monkeypatch):
+        from bigchaindb.backend.exceptions import BigchainDBCritical
         from bigchaindb.models import Transaction
 
         tx = Transaction.create([b.me], [([b.me], 1)])
@@ -146,7 +146,7 @@ class TestBigchainApi(object):
         vote = b.vote(block2.id, b.get_last_voted_block().id, True)
         b.write_vote(vote)
 
-        with pytest.raises(DoubleSpend):
+        with pytest.raises(BigchainDBCritical):
             b.get_blocks_status_containing_tx(tx.id)
 
     @pytest.mark.genesis


### PR DESCRIPTION
Fixes #1149

DoubleSpend was being raised when the same transaction was found in multiple valid blocks, this is the wrong exception, introduce `BigchainDBCritical` for this (and other unhandleable) cases.