### PR TITLE
Adding a VOLUME statement in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ WORKDIR /usr/src/app
 
 RUN pip3 install --no-cache-dir -e .
 
+VOLUME ["/data"]
+
 WORKDIR /data
 
 ENV BIGCHAINDB_CONFIG_PATH /data/.bigchaindb


### PR DESCRIPTION
- MacOS does not allow users to mount folders from the host unless it is
specified during build time.
- This is needed as the container on Mac needs to access the .bigchaindb
conf file residing on the host.