### PR TITLE
Identify voters + Voting class

### DIFF
--- a/bigchaindb/voting.py
+++ b/bigchaindb/voting.py
@@ -70,7 +70,7 @@ class Voting:
         * Votes must agree on previous block, otherwise they become invalid.
 
         note:
-            The sum of votes returned by this function does not neccesarily
+            The sum of votes returned by this function does not necessarily
             equal the length of the list of votes fed in. It may differ for
             example if there are found to be multiple votes submitted by a
             single voter.

--- a/bigchaindb/voting.py
+++ b/bigchaindb/voting.py
@@ -7,6 +7,11 @@ to test.
 import collections
 
 
+VALID = 'valid'
+INVALID = 'invalid'
+UNDECIDED = 'undecided'
+
+
 def partition_eligible_votes(votes, eligible_voters, verify_vote_signature):
     """
     Filter votes from unknown nodes or nodes that are not listed on
@@ -92,8 +97,3 @@ def decide_votes(n_voters, n_valid, n_invalid, n_agree_prev_block):
             return VALID
         return INVALID
     return UNDECIDED
-
-
-INVALID = 'invalid'
-VALID = TX_VALID = 'valid'
-UNDECIDED = TX_UNDECIDED = 'undecided'

--- a/bigchaindb/voting.py
+++ b/bigchaindb/voting.py
@@ -1,10 +1,7 @@
-"""
-Everything to do with creating and checking votes.
-All functions in this module should be referentially transparent, that is,
-they always give the same output for a given input. This makes it easier
-to test.
-"""
 import collections
+from bigchaindb.common.schema import SchemaValidationError, validate_vote_schema
+from bigchaindb.common.utils import serialize
+from bigchaindb.common.crypto import PublicKey
 
 
 VALID = 'valid'
@@ -12,88 +9,159 @@ INVALID = 'invalid'
 UNDECIDED = 'undecided'
 
 
-def partition_eligible_votes(votes, eligible_voters, verify_vote_signature):
+class Voting:
     """
-    Filter votes from unknown nodes or nodes that are not listed on
-    block. This is the primary Sybill protection.
-    """
-    eligible, ineligible = ([], [])
+    Everything to do with creating and checking votes.
 
-    for vote in votes:
-        voter_eligible = vote['node_pubkey'] in eligible_voters
-        if voter_eligible and verify_vote_signature(vote):
-            eligible.append(vote)
-        else:
-            ineligible.append(vote)
+    All functions in this class should be referentially transparent, that is,
+    they always give the same output for a given input. This makes it easier
+    to test. This also means no logging!
 
-    return eligible, ineligible
-
-
-def count_votes(eligible_votes):
-    """
-    Given a list of eligible votes, (votes from known nodes that are listed
-    as voters), count the votes to produce three quantities:
-
-        Number of votes that say valid
-        Number of votes that say invalid
-        Highest agreement on previous block ID
-
-    Also, detect if there are multiple votes from a single node and return them
-    in a separate "cheat" dictionary.
-    """
-    by_voter = collections.defaultdict(list)
-    for vote in eligible_votes:
-        by_voter[vote['node_pubkey']].append(vote)
-
-    n_valid = 0
-    n_invalid = 0
-    prev_blocks = collections.Counter()
-    cheat = {}
-
-    for pubkey, votes in by_voter.items():
-        if len(votes) > 1:
-            cheat[pubkey] = votes
-            n_invalid += 1
-            continue
-
-        vote = votes[0]
-        prev_blocks[vote['vote']['previous_block']] += 1
-        if vote['vote']['is_block_valid']:
-            n_valid += 1
-        else:
-            n_invalid += 1
-
-    return {
-        'n_valid': n_valid,
-        'n_invalid': n_invalid,
-        'n_agree_prev_block': prev_blocks.most_common()[0][1]
-    }, cheat
-
-
-def decide_votes(n_voters, n_valid, n_invalid, n_agree_prev_block):
-    """
-    Decide on votes.
-
-    To return VALID there must be a clear majority that say VALID
-    and also agree on the previous block. This is achieved using the > operator.
-
-    A tie on an even number of votes counts as INVALID so the >= operator is
-    used.
+    Assumptions regarding data:
+        * Vote is a dictionary, but it is not assumed that any properties are.
+        * Everything else is assumed to be structurally correct, otherwise errors
+        may be thrown.
     """
 
-    # Check insane cases. This is basic, not exhaustive.
-    if n_valid + n_invalid > n_voters or n_agree_prev_block > n_voters:
-        raise ValueError('Arguments not sane: %s' % {
-            'n_voters': n_voters,
-            'n_valid': n_valid,
-            'n_invalid': n_invalid,
-            'n_agree_prev_block': n_agree_prev_block,
-        })
+    @classmethod
+    def block_election(cls, block, votes, keyring):
+        """
+        Calculate the election status of a block.
+        """
+        eligible_voters = set(block['voters']) & set(keyring)
+        eligible_votes, ineligible_votes = \
+            cls.partition_eligible_votes(votes, eligible_voters)
+        results = cls.count_votes(eligible_votes)
+        results['status'] = decide_votes(results['counts'])
+        results['ineligible'] = ineligible_votes
+        return results
 
-    if n_invalid * 2 >= n_voters:
-        return INVALID
-    if n_valid * 2 > n_voters:
-        if n_agree_prev_block * 2 > n_voters:
-            return VALID
-        return INVALID
-    return UNDECIDED
+    @classmethod
+    def partition_eligible_votes(cls, votes, eligible_voters):
+        """
+        Filter votes from unknown nodes or nodes that are not listed on
+        block. This is the primary Sybill protection.
+        """
+        eligible, ineligible = ([], [])
+
+        for vote in votes:
+            voter_eligible = vote.get('node_pubkey') in eligible_voters
+            if voter_eligible and cls.verify_vote_signature(vote):
+                eligible.append(vote)
+            else:
+                ineligible.append(vote)
+
+        return eligible, ineligible
+
+    @classmethod
+    def count_votes(cls, eligible_votes):
+        """
+        Given a list of eligible votes, (votes from known nodes that are listed
+        as voters), count the votes to produce three quantities:
+
+            Number of votes that say valid
+            Number of votes that say invalid
+            Highest agreement on previous block ID
+
+        Also, detect if there are multiple votes from a single node and return them
+        in a separate "cheat" dictionary.
+        """
+        by_voter = collections.defaultdict(list)
+        for vote in eligible_votes:
+            by_voter[vote['node_pubkey']].append(vote)
+
+        n_valid = 0
+        n_invalid = 0
+        prev_blocks = collections.Counter()
+        cheat = []
+        malformed = []
+
+        for pubkey, votes in by_voter.items():
+            if len(votes) > 1:
+                cheat.append(votes)
+                n_invalid += 1
+                continue
+
+            vote = votes[0]
+
+            if not cls.verify_vote_schema(vote):
+                malformed.append(vote)
+                n_invalid += 1
+                continue
+
+            prev_blocks[vote['vote']['previous_block']] += 1
+            if vote['vote']['is_block_valid']:
+                n_valid += 1
+            else:
+                n_invalid += 1
+
+        return {
+            'counts': {
+                'n_valid': n_valid,
+                'n_invalid': n_invalid,
+                'n_agree_prev_block': prev_blocks.most_common()[0][1],
+            },
+            'cheat': cheat,
+            'malformed': malformed,
+        }
+
+    @classmethod
+    def decide_votes(cls, n_voters, n_valid, n_invalid, n_agree_prev_block):
+        """
+        Decide on votes.
+
+        To return VALID there must be a clear majority that say VALID
+        and also agree on the previous block. This is achieved using the > operator.
+
+        A tie on an even number of votes counts as INVALID so the >= operator is
+        used.
+        """
+
+        # Check insane cases. This is basic, not exhaustive.
+        if n_valid + n_invalid > n_voters or n_agree_prev_block > n_voters:
+            raise ValueError('Arguments not sane: %s' % {
+                'n_voters': n_voters,
+                'n_valid': n_valid,
+                'n_invalid': n_invalid,
+                'n_agree_prev_block': n_agree_prev_block,
+            })
+
+        if n_invalid * 2 >= n_voters:
+            return INVALID
+        if n_valid * 2 > n_voters:
+            if n_agree_prev_block * 2 > n_voters:
+                return VALID
+            return INVALID
+        return UNDECIDED
+
+    @classmethod
+    def verify_vote_signature(cls, vote):
+        """Verify the signature of a vote
+
+        A valid vote should have been signed by a voter's private key.
+
+        Args:
+            vote (list): voters of the block that is under election
+
+        Returns:
+            bool: True if the signature is correct, False otherwise.
+        """
+        signature = vote.get('signature')
+        pk_base58 = vote.get('node_pubkey')
+
+        if not (type(signature) == str and type(pk_base58) == str):
+            raise ValueError("Malformed vote: %s" % vote)
+
+        public_key = PublicKey(pk_base58)
+        body = serialize(signed_vote['vote']).encode()
+        return public_key.verify(body, signature)
+
+    @classmethod
+    def verify_vote_schema(cls, vote):
+        # I'm not sure this is the correct approach. Maybe we should allow
+        # duck typing w/r/t votes.
+        try:
+            validate_vote_schema(vote)
+            return True
+        except SchemaValidationError:
+            return False

--- a/bigchaindb/voting.py
+++ b/bigchaindb/voting.py
@@ -69,12 +69,9 @@ class Voting:
           in a separate "cheat" dictionary.
         * Votes must agree on previous block, otherwise they become invalid.
         """
-        n_valid = 0
-        n_invalid = 0
         prev_blocks = collections.Counter()
         cheat = []
         malformed = []
-        prev_block = None
 
         # Group by pubkey to detect duplicate voting
         by_voter = collections.defaultdict(list)
@@ -84,35 +81,28 @@ class Voting:
         for pubkey, votes in by_voter.items():
             if len(votes) > 1:
                 cheat.append(votes)
-                n_invalid += 1
                 continue
 
             vote = votes[0]
 
             if not cls.verify_vote_schema(vote):
                 malformed.append(vote)
-                n_invalid += 1
                 continue
 
-            if vote['vote']['is_block_valid']:
+            if vote['vote']['is_block_valid'] is True:
                 prev_blocks[vote['vote']['previous_block']] += 1
-                n_valid += 1
-            else:
-                n_invalid += 1
 
-        # Neutralise difference between valid block and previous block,
-        # so that nodes must agree on previous block
-        if n_valid:
-            prev_block, n_prev = prev_blocks.most_common()[0]
+        n_valid = 0
+        prev_block = None
+        # Valid votes must agree on previous block
+        if prev_blocks:
+            prev_block, n_valid = prev_blocks.most_common()[0]
             del prev_blocks[prev_block]
-            diff = n_valid - n_prev
-            n_valid -= diff
-            n_invalid += diff
 
         return {
             'counts': {
                 'n_valid': n_valid,
-                'n_invalid': n_invalid,
+                'n_invalid': len(by_voter) - n_valid,
             },
             'cheat': cheat,
             'malformed': malformed,
@@ -126,10 +116,9 @@ class Voting:
         Decide on votes.
 
         To return VALID there must be a clear majority that say VALID
-        and also agree on the previous block. This is achieved using the > operator.
+        and also agree on the previous block.
 
-        A tie on an even number of votes counts as INVALID so the >= operator is
-        used.
+        A tie on an even number of votes counts as INVALID.
         """
         if n_invalid * 2 >= n_voters:
             return INVALID
@@ -139,15 +128,8 @@ class Voting:
 
     @classmethod
     def verify_vote_signature(cls, vote):
-        """Verify the signature of a vote
-
-        A valid vote should have been signed by a voter's private key.
-
-        Args:
-            vote (list): voters of the block that is under election
-
-        Returns:
-            bool: True if the signature is correct, False otherwise.
+        """
+        Verify the signature of a vote
         """
         signature = vote.get('signature')
         pk_base58 = vote.get('node_pubkey')

--- a/bigchaindb/voting.py
+++ b/bigchaindb/voting.py
@@ -1,5 +1,5 @@
 import collections
-from bigchaindb.backend.exceptions import BigchainDBCritical
+
 from bigchaindb.common.schema import SchemaValidationError, validate_vote_schema
 from bigchaindb.common.utils import serialize
 from bigchaindb.common.crypto import PublicKey
@@ -56,31 +56,30 @@ class Voting:
                 except ValueError:
                     pass
             ineligible.append(vote)
-
         return eligible, ineligible
 
     @classmethod
     def count_votes(cls, eligible_votes):
         """
         Given a list of eligible votes, (votes from known nodes that are listed
-        as voters), count the votes to produce three quantities:
+        as voters), produce the number that say valid and the number that say
+        invalid.
 
-            Number of votes that say valid
-            Number of votes that say invalid
-            Highest agreement on previous block ID
-
-        Also, detect if there are multiple votes from a single node and return them
-        in a separate "cheat" dictionary.
+        * Detect if there are multiple votes from a single node and return them
+          in a separate "cheat" dictionary.
+        * Votes must agree on previous block, otherwise they become invalid.
         """
-        by_voter = collections.defaultdict(list)
-        for vote in eligible_votes:
-            by_voter[vote['node_pubkey']].append(vote)
-
         n_valid = 0
         n_invalid = 0
         prev_blocks = collections.Counter()
         cheat = []
         malformed = []
+        prev_block = None
+
+        # Group by pubkey to detect duplicate voting
+        by_voter = collections.defaultdict(list)
+        for vote in eligible_votes:
+            by_voter[vote['node_pubkey']].append(vote)
 
         for pubkey, votes in by_voter.items():
             if len(votes) > 1:
@@ -101,20 +100,28 @@ class Voting:
             else:
                 n_invalid += 1
 
-        n_prev = prev_blocks.most_common()[0][1] if prev_blocks else 0
+        # Neutralise difference between valid block and previous block,
+        # so that nodes must agree on previous block
+        if n_valid:
+            prev_block, n_prev = prev_blocks.most_common()[0]
+            del prev_blocks[prev_block]
+            diff = n_valid - n_prev
+            n_valid -= diff
+            n_invalid += diff
 
         return {
             'counts': {
                 'n_valid': n_valid,
                 'n_invalid': n_invalid,
-                'n_agree_prev_block': n_prev,
             },
             'cheat': cheat,
             'malformed': malformed,
+            'previous_block': prev_block,
+            'other_previous_block': dict(prev_blocks),
         }
 
     @classmethod
-    def decide_votes(cls, n_voters, n_valid, n_invalid, n_agree_prev_block):
+    def decide_votes(cls, n_voters, n_valid, n_invalid):
         """
         Decide on votes.
 
@@ -124,22 +131,10 @@ class Voting:
         A tie on an even number of votes counts as INVALID so the >= operator is
         used.
         """
-
-        # Check insane cases. This is basic, not exhaustive.
-        if n_valid + n_invalid > n_voters or n_agree_prev_block > n_voters:
-            raise BigchainDBCritical('Arguments not sane: %s' % {
-                'n_voters': n_voters,
-                'n_valid': n_valid,
-                'n_invalid': n_invalid,
-                'n_agree_prev_block': n_agree_prev_block,
-            })
-
         if n_invalid * 2 >= n_voters:
             return INVALID
         if n_valid * 2 > n_voters:
-            if n_agree_prev_block * 2 > n_voters:
-                return VALID
-            return INVALID
+            return VALID
         return UNDECIDED
 
     @classmethod

--- a/bigchaindb/voting.py
+++ b/bigchaindb/voting.py
@@ -68,6 +68,12 @@ class Voting:
         * Detect if there are multiple votes from a single node and return them
           in a separate "cheat" dictionary.
         * Votes must agree on previous block, otherwise they become invalid.
+
+        note:
+            The sum of votes returned by this function does not neccesarily
+            equal the length of the list of votes fed in. It may differ for
+            example if there are found to be multiple votes submitted by a
+            single voter.
         """
         prev_blocks = collections.Counter()
         cheat = []

--- a/bigchaindb/voting.py
+++ b/bigchaindb/voting.py
@@ -1,25 +1,41 @@
+"""
+Everything to do with creating and checking votes.
+All functions in this module should be referentially transparent, that is,
+they always give the same output for a given input. This makes it easier
+to test.
+"""
 import collections
 
 
-def filter_eligible_votes(votes, block_voters, keyring, check_signature):
+def partition_eligible_votes(votes, eligible_voters, verify_vote_signature):
     """
     Filter votes from unknown nodes or nodes that are not listed on
-    block. Here is our sybill protection.
+    block. This is the primary Sybill protection.
     """
-    eligible_voters = set(keyring) & set(block_voters)
-    eligible_votes = []
+    eligible, ineligible = ([], [])
 
     for vote in votes:
-        pubkey = vote['node_pubkey']
-        voter_eligible = pubkey in eligible_voters
-        sig_legit = sig_is_legit(vote)
-        if voter_eligible and sig_legit:
-            eligible_votes[pubkey].append(vote)
+        voter_eligible = vote['node_pubkey'] in eligible_voters
+        if voter_eligible and verify_vote_signature(vote):
+            eligible.append(vote)
+        else:
+            ineligible.append(vote)
 
-    return eligible_votes
+    return eligible, ineligible
 
 
-def count_votes(eligible_votes, check_schema):
+def count_votes(eligible_votes):
+    """
+    Given a list of eligible votes, (votes from known nodes that are listed
+    as voters), count the votes to produce three quantities:
+
+        Number of votes that say valid
+        Number of votes that say invalid
+        Highest agreement on previous block ID
+
+    Also, detect if there are multiple votes from a single node and return them
+    in a separate "cheat" dictionary.
+    """
     by_voter = collections.defaultdict(list)
     for vote in eligible_votes:
         by_voter[vote['node_pubkey']].append(vote)
@@ -27,9 +43,11 @@ def count_votes(eligible_votes, check_schema):
     n_valid = 0
     n_invalid = 0
     prev_blocks = collections.Counter()
+    cheat = {}
 
     for pubkey, votes in by_voter.items():
-        if len(votes) > 1 or not schema_is_correct(votes[0]):
+        if len(votes) > 1:
+            cheat[pubkey] = votes
             n_invalid += 1
             continue
 
@@ -41,7 +59,41 @@ def count_votes(eligible_votes, check_schema):
             n_invalid += 1
 
     return {
-        'valid': n_valid,
-        'invalid': n_invalid,
-        'prev_block': prev_blocks.most_common()[0]
-    }
+        'n_valid': n_valid,
+        'n_invalid': n_invalid,
+        'n_agree_prev_block': prev_blocks.most_common()[0][1]
+    }, cheat
+
+
+def decide_votes(n_voters, n_valid, n_invalid, n_agree_prev_block):
+    """
+    Decide on votes.
+
+    To return VALID there must be a clear majority that say VALID
+    and also agree on the previous block. This is achieved using the > operator.
+
+    A tie on an even number of votes counts as INVALID so the >= operator is
+    used.
+    """
+
+    # Check insane cases. This is basic, not exhaustive.
+    if n_valid + n_invalid > n_voters or n_agree_prev_block > n_voters:
+        raise ValueError('Arguments not sane: %s' % {
+            'n_voters': n_voters,
+            'n_valid': n_valid,
+            'n_invalid': n_invalid,
+            'n_agree_prev_block': n_agree_prev_block,
+        })
+
+    if n_invalid * 2 >= n_voters:
+        return INVALID
+    if n_valid * 2 > n_voters:
+        if n_agree_prev_block * 2 > n_voters:
+            return VALID
+        return INVALID
+    return UNDECIDED
+
+
+INVALID = 'invalid'
+VALID = TX_VALID = 'valid'
+UNDECIDED = TX_UNDECIDED = 'undecided'

--- a/bigchaindb/voting.py
+++ b/bigchaindb/voting.py
@@ -1,0 +1,47 @@
+import collections
+
+
+def filter_eligible_votes(votes, block_voters, keyring, check_signature):
+    """
+    Filter votes from unknown nodes or nodes that are not listed on
+    block. Here is our sybill protection.
+    """
+    eligible_voters = set(keyring) & set(block_voters)
+    eligible_votes = []
+
+    for vote in votes:
+        pubkey = vote['node_pubkey']
+        voter_eligible = pubkey in eligible_voters
+        sig_legit = sig_is_legit(vote)
+        if voter_eligible and sig_legit:
+            eligible_votes[pubkey].append(vote)
+
+    return eligible_votes
+
+
+def count_votes(eligible_votes, check_schema):
+    by_voter = collections.defaultdict(list)
+    for vote in eligible_votes:
+        by_voter[vote['node_pubkey']].append(vote)
+
+    n_valid = 0
+    n_invalid = 0
+    prev_blocks = collections.Counter()
+
+    for pubkey, votes in by_voter.items():
+        if len(votes) > 1 or not schema_is_correct(votes[0]):
+            n_invalid += 1
+            continue
+
+        vote = votes[0]
+        prev_blocks[vote['vote']['previous_block']] += 1
+        if vote['vote']['is_block_valid']:
+            n_valid += 1
+        else:
+            n_invalid += 1
+
+    return {
+        'valid': n_valid,
+        'invalid': n_invalid,
+        'prev_block': prev_blocks.most_common()[0]
+    }

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -130,3 +130,35 @@ def test_verify_vote_schema(b):
     assert Voting.verify_vote_schema(vote)
     vote = b.vote('b', 'a', True)
     assert not Voting.verify_vote_schema(vote)
+
+
+################################################################################
+# block_election tests
+# A more thorough test will follow  as part of #1217
+
+
+def test_block_election(b):
+
+    class TestVoting(Voting):
+        @classmethod
+        def verify_vote_signature(cls, vote):
+            return True
+
+        @classmethod
+        def verify_vote_schema(cls, vote):
+            return True
+
+    keyring = 'abc'
+    block = {'block': {'voters': 'ab'}}
+    votes = [{
+        'node_pubkey': c,
+        'vote': {'is_block_valid': True, 'previous_block': 'a'}
+    } for c in 'abc']
+
+    assert TestVoting.block_election(block, votes, keyring) == {
+        'status': VALID,
+        'counts': {'n_agree_prev_block': 2, 'n_valid': 2, 'n_invalid': 0},
+        'ineligible': [votes[-1]],
+        'cheat': [],
+        'malformed': [],
+    }

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -49,6 +49,9 @@ def test_count_votes():
         'counts': {
             'n_valid': 9,    # 9 kosher votes
             'n_invalid': 4,  # 1 cheat, 1 invalid, 1 malformed, 1 rogue prev block
+            # One of the cheat votes counts towards n_invalid, the other is
+            # not counted here.
+            # len(cheat) + n_valid + n_invalid == len(votes)
         },
         'cheat': [votes[:2]],
         'malformed': [votes[3]],
@@ -83,18 +86,15 @@ def test_must_agree_prev_block():
 # Tests for vote decision making
 
 
-DECISION_TESTS = [dict(
-    zip(['n_voters', 'n_valid', 'n_invalid'], t))
-    for t in [
-         (1,          1,         1),
-         (2,          2,         1),
-         (3,          2,         2),
-         (4,          3,         2),
-         (5,          3,         3),
-         (6,          4,         3),
-         (7,          4,         4),
-         (8,          5,         4),
-    ]
+DECISION_TESTS = [
+    {'n_voters': 1, 'n_valid': 1, 'n_invalid': 1},
+    {'n_voters': 2, 'n_valid': 2, 'n_invalid': 1},
+    {'n_voters': 3, 'n_valid': 2, 'n_invalid': 2},
+    {'n_voters': 4, 'n_valid': 3, 'n_invalid': 2},
+    {'n_voters': 5, 'n_valid': 3, 'n_invalid': 3},
+    {'n_voters': 6, 'n_valid': 4, 'n_invalid': 3},
+    {'n_voters': 7, 'n_valid': 4, 'n_invalid': 4},
+    {'n_voters': 8, 'n_valid': 5, 'n_invalid': 4}
 ]
 
 

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -1,0 +1,61 @@
+import pytest
+
+from bigchaindb.core import Bigchain
+from bigchaindb.voting import (count_votes, partition_eligible_votes,
+                               decide_votes, INVALID, VALID, UNDECIDED)
+
+
+def test_partition_eligible_votes():
+    nodes = list(map(Bigchain, 'abc'))
+    votes = [n.vote('block', 'a', True) for n in nodes]
+
+    el, inel = partition_eligible_votes(votes, 'abc', lambda _: True)
+
+    assert el == votes
+    assert inel == []
+
+
+def test_count_votes():
+    nodes = list(map(Bigchain, 'abc'))
+    votes = [n.vote('block', 'a', True) for n in nodes]
+
+    assert count_votes(votes) == ({
+        'n_valid': 3,
+        'n_invalid': 0,
+        'n_agree_prev_block': 3
+    }, {})
+
+
+DECISION_TESTS = [dict(
+    zip(['n_voters', 'n_valid', 'n_invalid', 'n_agree_prev_block'], t))
+    for t in [
+         (1,          1,         1,           1),
+         (2,          2,         1,           2),
+         (3,          2,         2,           2),
+         (4,          3,         2,           3),
+         (5,          3,         3,           3),
+         (6,          4,         3,           4),
+         (7,          4,         4,           4),
+         (8,          5,         4,           5),
+    ]
+]
+
+
+@pytest.mark.parametrize('kwargs', DECISION_TESTS)
+def test_decide_votes_valid(kwargs):
+    kwargs = kwargs.copy()
+    kwargs['n_invalid'] = 0
+    assert decide_votes(**kwargs) == VALID
+    kwargs['n_agree_prev_block'] -= 1
+    assert decide_votes(**kwargs) == INVALID
+    kwargs['n_valid'] -= 1
+    assert decide_votes(**kwargs) == UNDECIDED
+
+
+@pytest.mark.parametrize('kwargs', DECISION_TESTS)
+def test_decide_votes_invalid(kwargs):
+    kwargs = kwargs.copy()
+    kwargs['n_valid'] = 0
+    assert decide_votes(**kwargs) == INVALID
+    kwargs['n_invalid'] -= 1
+    assert decide_votes(**kwargs) == UNDECIDED

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -1,33 +1,36 @@
 import pytest
+from unittest.mock import patch
 
 from bigchaindb.core import Bigchain
-from bigchaindb.voting import (count_votes, partition_eligible_votes,
-                               decide_votes, INVALID, VALID, UNDECIDED)
+from bigchaindb.voting import Voting, INVALID, VALID, UNDECIDED
 
 
 ################################################################################
 # Tests for checking vote eligibility
 
 
-def test_partition_eligible_votes():
+@patch('bigchaindb.voting.Voting.verify_vote_signature')
+def test_partition_eligible_votes(_):
     nodes = list(map(Bigchain, 'abc'))
     votes = [n.vote('block', 'a', True) for n in nodes]
 
-    el, inel = partition_eligible_votes(votes, 'abc', lambda _: True)
+    el, inel = Voting.partition_eligible_votes(votes, 'abc')
 
     assert el == votes
     assert inel == []
 
 
-def test_count_votes():
+@patch('bigchaindb.voting.Voting.verify_vote_schema')
+def test_count_votes(_):
     nodes = list(map(Bigchain, 'abc'))
+
     votes = [n.vote('block', 'a', True) for n in nodes]
 
-    assert count_votes(votes) == ({
+    assert Voting.count_votes(votes)['counts'] == {
         'n_valid': 3,
         'n_invalid': 0,
         'n_agree_prev_block': 3
-    }, {})
+    }
 
 
 ################################################################################
@@ -53,26 +56,29 @@ DECISION_TESTS = [dict(
 def test_decide_votes_valid(kwargs):
     kwargs = kwargs.copy()
     kwargs['n_invalid'] = 0
-    assert decide_votes(**kwargs) == VALID
+    assert Voting.decide_votes(**kwargs) == VALID
     kwargs['n_agree_prev_block'] -= 1
-    assert decide_votes(**kwargs) == INVALID
+    assert Voting.decide_votes(**kwargs) == INVALID
     kwargs['n_valid'] -= 1
-    assert decide_votes(**kwargs) == UNDECIDED
+    assert Voting.decide_votes(**kwargs) == UNDECIDED
 
 
 @pytest.mark.parametrize('kwargs', DECISION_TESTS)
 def test_decide_votes_invalid(kwargs):
     kwargs = kwargs.copy()
     kwargs['n_valid'] = 0
-    assert decide_votes(**kwargs) == INVALID
+    assert Voting.decide_votes(**kwargs) == INVALID
     kwargs['n_invalid'] -= 1
-    assert decide_votes(**kwargs) == UNDECIDED
+    assert Voting.decide_votes(**kwargs) == UNDECIDED
 
 
 def test_decide_votes_checks_arguments():
     with pytest.raises(ValueError):
-        decide_votes(n_voters=1, n_valid=2, n_invalid=0, n_agree_prev_block=0)
+        Voting.decide_votes(n_voters=1, n_valid=2, n_invalid=0,
+                            n_agree_prev_block=0)
     with pytest.raises(ValueError):
-        decide_votes(n_voters=1, n_valid=0, n_invalid=2, n_agree_prev_block=0)
+        Voting.decide_votes(n_voters=1, n_valid=0, n_invalid=2,
+                            n_agree_prev_block=0)
     with pytest.raises(ValueError):
-        decide_votes(n_voters=1, n_valid=0, n_invalid=0, n_agree_prev_block=2)
+        Voting.decide_votes(n_voters=1, n_valid=0, n_invalid=0,
+                            n_agree_prev_block=2)

--- a/tests/test_voting.py
+++ b/tests/test_voting.py
@@ -5,6 +5,10 @@ from bigchaindb.voting import (count_votes, partition_eligible_votes,
                                decide_votes, INVALID, VALID, UNDECIDED)
 
 
+################################################################################
+# Tests for checking vote eligibility
+
+
 def test_partition_eligible_votes():
     nodes = list(map(Bigchain, 'abc'))
     votes = [n.vote('block', 'a', True) for n in nodes]
@@ -24,6 +28,10 @@ def test_count_votes():
         'n_invalid': 0,
         'n_agree_prev_block': 3
     }, {})
+
+
+################################################################################
+# Tests for vote decision making
 
 
 DECISION_TESTS = [dict(
@@ -59,3 +67,12 @@ def test_decide_votes_invalid(kwargs):
     assert decide_votes(**kwargs) == INVALID
     kwargs['n_invalid'] -= 1
     assert decide_votes(**kwargs) == UNDECIDED
+
+
+def test_decide_votes_checks_arguments():
+    with pytest.raises(ValueError):
+        decide_votes(n_voters=1, n_valid=2, n_invalid=0, n_agree_prev_block=0)
+    with pytest.raises(ValueError):
+        decide_votes(n_voters=1, n_valid=0, n_invalid=2, n_agree_prev_block=0)
+    with pytest.raises(ValueError):
+        decide_votes(n_voters=1, n_valid=0, n_invalid=0, n_agree_prev_block=2)


### PR DESCRIPTION
The integration of this feature (to replace `Bigchain.block_election_status`) is being done in another PR: #1215, it is split in two to make it easier to review.

In order to fix some bugs* and make the voting logic more robust and testable, a new module is introduced `bigchaindb.voting`. The module is being created with the goals of correctness, testability and readability.

Scope:

- [x] Create module `bigchaindb.voting` with pure functions for vote counting
- [x] Implement test for vote counting that uses hardcoded table of thresholds
- [x] Votes with incorrect schema are considered eligible, as long as signature is correct.
- [x] Eligible voters are part of block voter list AND node keyring
- [x] Contains all functions for vote verification
- [x] Fix #1217 
- [x] Implement test for voting that checks state transitions