### PR TITLE
Refactor commands

### DIFF
--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -287,16 +287,6 @@ def create_parser():
         description='Control your BigchainDB node.',
         parents=[utils.base_parser])
 
-    parser.add_argument('--dev-start-rethinkdb',
-                        dest='start_rethinkdb',
-                        action='store_true',
-                        help='Run RethinkDB on start')
-
-    parser.add_argument('--dev-allow-temp-keypair',
-                        dest='allow_temp_keypair',
-                        action='store_true',
-                        help='Generate a random keypair on start')
-
     # all the commands are contained in the subparsers object,
     # the command selected by the user will be stored in `args.command`
     # that is used by the `main` function to select which other
@@ -328,8 +318,18 @@ def create_parser():
                           help='Drop the database')
 
     # parser for starting BigchainDB
-    subparsers.add_parser('start',
-                          help='Start BigchainDB')
+    start_parser = subparsers.add_parser('start',
+                                         help='Start BigchainDB')
+
+    start_parser.add_argument('--dev-allow-temp-keypair',
+                              dest='allow_temp_keypair',
+                              action='store_true',
+                              help='Generate a random keypair on start')
+
+    start_parser.add_argument('--dev-start-rethinkdb',
+                              dest='start_rethinkdb',
+                              action='store_true',
+                              help='Run RethinkDB on start')
 
     # parser for configuring the number of shards
     sharding_parser = subparsers.add_parser('set-shards',

--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -16,7 +16,6 @@ from bigchaindb.common.exceptions import (StartupError,
                                           DatabaseAlreadyExists,
                                           KeypairNotFoundException)
 import bigchaindb
-import bigchaindb.config_utils
 from bigchaindb.models import Transaction
 from bigchaindb.utils import ProcessGroup
 from bigchaindb import backend, processes
@@ -29,7 +28,7 @@ from bigchaindb.commands.messages import (
     CANNOT_START_KEYPAIR_NOT_FOUND,
     RETHINKDB_STARTUP_ERROR,
 )
-from bigchaindb.commands.utils import input_on_stderr
+from bigchaindb.commands.utils import configure_bigchaindb, input_on_stderr
 
 
 logging.basicConfig(level=logging.INFO)
@@ -42,12 +41,12 @@ logger = logging.getLogger(__name__)
 #   should be printed to stderr.
 
 
+@configure_bigchaindb
 def run_show_config(args):
     """Show the current configuration"""
     # TODO Proposal: remove the "hidden" configuration. Only show config. If
     # the system needs to be configured, then display information on how to
     # configure the system.
-    bigchaindb.config_utils.autoconfigure(filename=args.config, force=True)
     config = copy.deepcopy(bigchaindb.config)
     del config['CONFIGURED']
     private_key = config['keypair']['private']
@@ -120,10 +119,10 @@ def run_configure(args, skip_if_exists=False):
     print('Ready to go!', file=sys.stderr)
 
 
+@configure_bigchaindb
 def run_export_my_pubkey(args):
     """Export this node's public key to standard output
     """
-    bigchaindb.config_utils.autoconfigure(filename=args.config, force=True)
     pubkey = bigchaindb.config['keypair']['public']
     if pubkey is not None:
         print(pubkey)
@@ -145,9 +144,9 @@ def _run_init():
     logger.info('Genesis block created.')
 
 
+@configure_bigchaindb
 def run_init(args):
     """Initialize the database"""
-    bigchaindb.config_utils.autoconfigure(filename=args.config, force=True)
     # TODO Provide mechanism to:
     # 1. prompt the user to inquire whether they wish to drop the db
     # 2. force the init, (e.g., via -f flag)
@@ -158,9 +157,9 @@ def run_init(args):
         print('If you wish to re-initialize it, first drop it.', file=sys.stderr)
 
 
+@configure_bigchaindb
 def run_drop(args):
     """Drop the database"""
-    bigchaindb.config_utils.autoconfigure(filename=args.config, force=True)
     dbname = bigchaindb.config['database']['name']
 
     if not args.yes:
@@ -173,10 +172,10 @@ def run_drop(args):
     schema.drop_database(conn, dbname)
 
 
+@configure_bigchaindb
 def run_start(args):
     """Start the processes to run the node"""
     logger.info('BigchainDB Version %s', bigchaindb.__version__)
-    bigchaindb.config_utils.autoconfigure(filename=args.config, force=True)
 
     if args.allow_temp_keypair:
         if not (bigchaindb.config['keypair']['private'] or
@@ -224,8 +223,8 @@ def _run_load(tx_left, stats):
                 break
 
 
+@configure_bigchaindb
 def run_load(args):
-    bigchaindb.config_utils.autoconfigure(filename=args.config, force=True)
     logger.info('Starting %s processes', args.multiprocess)
     stats = logstats.Logstats()
     logstats.thread.start(stats)
@@ -240,6 +239,7 @@ def run_load(args):
     workers.start()
 
 
+@configure_bigchaindb
 def run_set_shards(args):
     conn = backend.connect()
     try:
@@ -248,6 +248,7 @@ def run_set_shards(args):
         sys.exit(str(e))
 
 
+@configure_bigchaindb
 def run_set_replicas(args):
     conn = backend.connect()
     try:
@@ -256,9 +257,9 @@ def run_set_replicas(args):
         sys.exit(str(e))
 
 
+@configure_bigchaindb
 def run_add_replicas(args):
     # Note: This command is specific to MongoDB
-    bigchaindb.config_utils.autoconfigure(filename=args.config, force=True)
     conn = backend.connect()
 
     try:
@@ -269,9 +270,9 @@ def run_add_replicas(args):
         print('Added {} to the replicaset.'.format(args.replicas))
 
 
+@configure_bigchaindb
 def run_remove_replicas(args):
     # Note: This command is specific to MongoDB
-    bigchaindb.config_utils.autoconfigure(filename=args.config, force=True)
     conn = backend.connect()
 
     try:

--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -3,12 +3,11 @@ the command-line interface (CLI) for BigchainDB Server.
 """
 
 import os
-import sys
 import logging
 import argparse
 import copy
 import json
-import builtins
+import sys
 
 import logstats
 
@@ -20,7 +19,7 @@ import bigchaindb
 import bigchaindb.config_utils
 from bigchaindb.models import Transaction
 from bigchaindb.utils import ProcessGroup
-from bigchaindb import backend
+from bigchaindb import backend, processes
 from bigchaindb.backend import schema
 from bigchaindb.backend.admin import (set_replicas, set_shards, add_replicas,
                                       remove_replicas)
@@ -30,19 +29,11 @@ from bigchaindb.commands.messages import (
     CANNOT_START_KEYPAIR_NOT_FOUND,
     RETHINKDB_STARTUP_ERROR,
 )
-from bigchaindb import processes
+from bigchaindb.commands.utils import input_on_stderr
 
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-
-# We need this because `input` always prints on stdout, while it should print
-# to stderr. It's a very old bug, check it out here:
-# - https://bugs.python.org/issue1927
-def input_on_stderr(prompt=''):
-    print(prompt, end='', file=sys.stderr)
-    return builtins.input()
 
 
 def run_show_config(args):

--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -36,6 +36,12 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+# Note about printing:
+#   We try to print to stdout for results of a command that may be useful to
+#   someone (or another program). Strictly informational text, or errors,
+#   should be printed to stderr.
+
+
 def run_show_config(args):
     """Show the current configuration"""
     # TODO Proposal: remove the "hidden" configuration. Only show config. If
@@ -84,7 +90,7 @@ def run_configure(args, skip_if_exists=False):
 
     # select the correct config defaults based on the backend
     print('Generating default configuration for backend {}'
-          .format(args.backend))
+          .format(args.backend), file=sys.stderr)
     conf['database'] = bigchaindb._database_map[args.backend]
 
     if not args.yes:

--- a/bigchaindb/commands/utils.py
+++ b/bigchaindb/commands/utils.py
@@ -4,6 +4,7 @@ for ``argparse.ArgumentParser``.
 
 import argparse
 import builtins
+import functools
 import multiprocessing as mp
 import subprocess
 import sys
@@ -12,9 +13,19 @@ import rethinkdb as r
 from pymongo import uri_parser
 
 import bigchaindb
+import bigchaindb.config_utils
 from bigchaindb import backend
 from bigchaindb.common.exceptions import StartupError
 from bigchaindb.version import __version__
+
+
+def configure_bigchaindb(command):
+    @functools.wraps(command)
+    def configure(args):
+        bigchaindb.config_utils.autoconfigure(filename=args.config, force=True)
+        command(args)
+
+    return configure
 
 
 # We need this because `input` always prints on stdout, while it should print

--- a/bigchaindb/commands/utils.py
+++ b/bigchaindb/commands/utils.py
@@ -3,8 +3,10 @@ for ``argparse.ArgumentParser``.
 """
 
 import argparse
+import builtins
 import multiprocessing as mp
 import subprocess
+import sys
 
 import rethinkdb as r
 from pymongo import uri_parser
@@ -13,6 +15,14 @@ import bigchaindb
 from bigchaindb import backend
 from bigchaindb.common.exceptions import StartupError
 from bigchaindb.version import __version__
+
+
+# We need this because `input` always prints on stdout, while it should print
+# to stderr. It's a very old bug, check it out here:
+# - https://bugs.python.org/issue1927
+def input_on_stderr(prompt=''):
+    print(prompt, end='', file=sys.stderr)
+    return builtins.input()
 
 
 def start_rethinkdb():

--- a/tests/commands/rethinkdb/test_commands.py
+++ b/tests/commands/rethinkdb/test_commands.py
@@ -45,7 +45,7 @@ def test_set_shards(mock_reconfigure, monkeypatch, b):
         return {'shards': [{'replicas': [1]}]}
 
     monkeypatch.setattr(rethinkdb.RqlQuery, 'run', mockreturn_one_replica)
-    args = Namespace(num_shards=3)
+    args = Namespace(num_shards=3, config=None)
     run_set_shards(args)
     mock_reconfigure.assert_called_with(replicas=1, shards=3, dry_run=False)
 
@@ -72,7 +72,7 @@ def test_set_shards_raises_exception(monkeypatch, b):
     monkeypatch.setattr(rethinkdb.RqlQuery, 'run', mockreturn_one_replica)
     monkeypatch.setattr(rethinkdb.ast.Table, 'reconfigure', mock_raise)
 
-    args = Namespace(num_shards=3)
+    args = Namespace(num_shards=3, config=None)
     with pytest.raises(SystemExit) as exc:
         run_set_shards(args)
     assert exc.value.args == ('Failed to reconfigure tables.',)
@@ -88,7 +88,7 @@ def test_set_replicas(mock_reconfigure, monkeypatch, b):
         return {'shards': [1, 2]}
 
     monkeypatch.setattr(rethinkdb.RqlQuery, 'run', mockreturn_two_shards)
-    args = Namespace(num_replicas=2)
+    args = Namespace(num_replicas=2, config=None)
     run_set_replicas(args)
     mock_reconfigure.assert_called_with(replicas=2, shards=2, dry_run=False)
 
@@ -115,7 +115,7 @@ def test_set_replicas_raises_exception(monkeypatch, b):
     monkeypatch.setattr(rethinkdb.RqlQuery, 'run', mockreturn_two_shards)
     monkeypatch.setattr(rethinkdb.ast.Table, 'reconfigure', mock_raise)
 
-    args = Namespace(num_replicas=2)
+    args = Namespace(num_replicas=2, config=None)
     with pytest.raises(SystemExit) as exc:
         run_set_replicas(args)
     assert exc.value.args == ('Failed to reconfigure tables.',)

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -1,6 +1,6 @@
 import json
 from unittest.mock import Mock, patch
-from argparse import Namespace, ArgumentTypeError
+from argparse import Namespace
 import copy
 
 import pytest
@@ -24,42 +24,6 @@ def test_make_sure_we_dont_remove_any_command():
     assert parser.parse_args(['load']).command
     assert parser.parse_args(['add-replicas', 'localhost:27017']).command
     assert parser.parse_args(['remove-replicas', 'localhost:27017']).command
-
-
-def test_start_raises_if_command_not_implemented():
-    from bigchaindb.commands.bigchain import utils
-    from bigchaindb.commands.bigchain import create_parser
-
-    parser = create_parser()
-
-    with pytest.raises(NotImplementedError):
-        # Will raise because `scope`, the third parameter,
-        # doesn't contain the function `run_start`
-        utils.start(parser, ['start'], {})
-
-
-def test_start_raises_if_no_arguments_given():
-    from bigchaindb.commands.bigchain import utils
-    from bigchaindb.commands.bigchain import create_parser
-
-    parser = create_parser()
-
-    with pytest.raises(SystemExit):
-        utils.start(parser, [], {})
-
-
-@patch('multiprocessing.cpu_count', return_value=42)
-def test_start_sets_multiprocess_var_based_on_cli_args(mock_cpu_count):
-    from bigchaindb.commands.bigchain import utils
-    from bigchaindb.commands.bigchain import create_parser
-
-    def run_load(args):
-        return args
-
-    parser = create_parser()
-
-    assert utils.start(parser, ['load'], {'run_load': run_load}).multiprocess == 1
-    assert utils.start(parser, ['load', '--multiprocess'], {'run_load': run_load}).multiprocess == 42
 
 
 @patch('bigchaindb.commands.utils.start')
@@ -504,19 +468,3 @@ def test_run_remove_replicas(mock_remove_replicas):
     assert exc.value.args == ('err',)
     assert mock_remove_replicas.call_count == 1
     mock_remove_replicas.reset_mock()
-
-
-def test_mongodb_host_type():
-    from bigchaindb.commands.utils import mongodb_host
-
-    # bad port provided
-    with pytest.raises(ArgumentTypeError):
-        mongodb_host('localhost:11111111111')
-
-    # no port information provided
-    with pytest.raises(ArgumentTypeError):
-        mongodb_host('localhost')
-
-    # bad host provided
-    with pytest.raises(ArgumentTypeError):
-        mongodb_host(':27017')

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -95,12 +95,10 @@ def test_bigchain_export_my_pubkey_when_pubkey_set(capsys, monkeypatch):
     monkeypatch.setitem(config['keypair'], 'public', 'Charlie_Bucket')
     _, _ = capsys.readouterr()  # has the effect of clearing capsys
     run_export_my_pubkey(args)
-    out, err = capsys.readouterr()
+    out, _ = capsys.readouterr()
     lines = out.splitlines()
-    err_lines = err.splitlines()
     assert config['keypair']['public'] in lines
     assert 'Charlie_Bucket' in lines
-    assert 'bigchaindb args = {}'.format(args) in err_lines
 
 
 def test_bigchain_export_my_pubkey_when_pubkey_not_set(monkeypatch):

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -381,11 +381,6 @@ def test_calling_main(start_mock, base_parser_mock, parse_args_mock,
     main()
 
     assert argparser_mock.called is True
-    assert parser.add_argument.called is True
-    parser.add_argument.assert_any_call('--dev-start-rethinkdb',
-                                        dest='start_rethinkdb',
-                                        action='store_true',
-                                        help='Run RethinkDB on start')
     parser.add_subparsers.assert_called_with(title='Commands',
                                              dest='command')
     subparsers.add_parser.assert_any_call('configure',
@@ -399,11 +394,19 @@ def test_calling_main(start_mock, base_parser_mock, parse_args_mock,
                                          'key')
     subparsers.add_parser.assert_any_call('init', help='Init the database')
     subparsers.add_parser.assert_any_call('drop', help='Drop the database')
+
     subparsers.add_parser.assert_any_call('start', help='Start BigchainDB')
+    subsubparsers.add_argument.assert_any_call('--dev-start-rethinkdb',
+                                               dest='start_rethinkdb',
+                                               action='store_true',
+                                               help='Run RethinkDB on start')
+    subsubparsers.add_argument.assert_any_call('--dev-allow-temp-keypair',
+                                               dest='allow_temp_keypair',
+                                               action='store_true',
+                                               help='Generate a random keypair on start')
 
     subparsers.add_parser.assert_any_call('set-shards',
                                           help='Configure number of shards')
-
     subsubparsers.add_argument.assert_any_call('num_shards',
                                                metavar='num_shards',
                                                type=int, default=1,

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -133,8 +133,10 @@ def test_bigchain_export_my_pubkey_when_pubkey_set(capsys, monkeypatch):
     run_export_my_pubkey(args)
     out, err = capsys.readouterr()
     lines = out.splitlines()
+    err_lines = err.splitlines()
     assert config['keypair']['public'] in lines
     assert 'Charlie_Bucket' in lines
+    assert 'bigchaindb args = {}'.format(args) in err_lines
 
 
 def test_bigchain_export_my_pubkey_when_pubkey_not_set(monkeypatch):

--- a/tests/commands/test_utils.py
+++ b/tests/commands/test_utils.py
@@ -1,0 +1,63 @@
+import argparse
+import pytest
+
+from unittest.mock import patch
+
+
+def test_start_raises_if_command_not_implemented():
+    from bigchaindb.commands import utils
+    from bigchaindb.commands.bigchain import create_parser
+
+    parser = create_parser()
+
+    with pytest.raises(NotImplementedError):
+        # Will raise because `scope`, the third parameter,
+        # doesn't contain the function `run_start`
+        utils.start(parser, ['start'], {})
+
+
+def test_start_raises_if_no_arguments_given():
+    from bigchaindb.commands import utils
+    from bigchaindb.commands.bigchain import create_parser
+
+    parser = create_parser()
+
+    with pytest.raises(SystemExit):
+        utils.start(parser, [], {})
+
+
+@patch('multiprocessing.cpu_count', return_value=42)
+def test_start_sets_multiprocess_var_based_on_cli_args(mock_cpu_count):
+    from bigchaindb.commands import utils
+
+    def run_mp_arg_test(args):
+        return args
+
+    parser = argparse.ArgumentParser()
+    subparser = parser.add_subparsers(title='Commands',
+                                      dest='command')
+    mp_arg_test_parser = subparser.add_parser('mp_arg_test')
+    mp_arg_test_parser.add_argument('-m', '--multiprocess',
+                                    nargs='?',
+                                    type=int,
+                                    default=False)
+
+    scope = {'run_mp_arg_test': run_mp_arg_test}
+    assert utils.start(parser, ['mp_arg_test'], scope).multiprocess == 1
+    assert utils.start(parser, ['mp_arg_test', '--multiprocess'], scope).multiprocess == 42
+
+
+def test_mongodb_host_type():
+    from bigchaindb.commands.utils import mongodb_host
+
+    # bad port provided
+    with pytest.raises(argparse.ArgumentTypeError):
+        mongodb_host('localhost:11111111111')
+
+    # no port information provided
+    with pytest.raises(argparse.ArgumentTypeError):
+        mongodb_host('localhost')
+
+    # bad host provided
+    with pytest.raises(argparse.ArgumentTypeError):
+        mongodb_host(':27017')


### PR DESCRIPTION
A few clean ups for `bigchaindb/commands`.

Builds on #1211.

Highlights:

* Moved `input_on_stderr()` to `commands/utils.py` (591b42c)
* Use `stderr` for informational messages (51720e9)
* Move `--dev-allow-temp-keypair` and `--dev-start-rethinkdb` to be only under `bigchaindb start` since it's only used there (e902c8c)
* Use a decorator to set up configuration before running each command (ccfb5c0)
* Move tests for `commands.utils.py` to `tests/commands/test_utils.py` (235c202)