### PR TITLE
Unify MongoDB and RethinkDB connection handling

### DIFF
--- a/bigchaindb/__init__.py
+++ b/bigchaindb/__init__.py
@@ -10,6 +10,8 @@ _database_rethinkdb = {
     'host': os.environ.get('BIGCHAINDB_DATABASE_HOST', 'localhost'),
     'port': int(os.environ.get('BIGCHAINDB_DATABASE_PORT', 28015)),
     'name': os.environ.get('BIGCHAINDB_DATABASE_NAME', 'bigchain'),
+    'connection_timeout': 5000,
+    'max_tries': 3,
 }
 
 _database_mongodb = {
@@ -18,6 +20,8 @@ _database_mongodb = {
     'port': int(os.environ.get('BIGCHAINDB_DATABASE_PORT', 27017)),
     'name': os.environ.get('BIGCHAINDB_DATABASE_NAME', 'bigchain'),
     'replicaset': os.environ.get('BIGCHAINDB_DATABASE_REPLICASET', 'bigchain-rs'),
+    'connection_timeout': 5000,
+    'max_tries': 3,
 }
 
 _database_map = {

--- a/bigchaindb/backend/connection.py
+++ b/bigchaindb/backend/connection.py
@@ -1,8 +1,10 @@
+from itertools import repeat
 from importlib import import_module
 import logging
 
 import bigchaindb
 from bigchaindb.common.exceptions import ConfigurationError
+from bigchaindb.backend.exceptions import ConnectionError
 
 
 BACKENDS = {
@@ -13,7 +15,8 @@ BACKENDS = {
 logger = logging.getLogger(__name__)
 
 
-def connect(backend=None, host=None, port=None, name=None, replicaset=None):
+def connect(backend=None, host=None, port=None, name=None, max_tries=None,
+            connection_timeout=None, replicaset=None):
     """Create a new connection to the database backend.
 
     All arguments default to the current configuration's values if not
@@ -58,7 +61,7 @@ def connect(backend=None, host=None, port=None, name=None, replicaset=None):
         raise ConfigurationError('Error loading backend `{}`'.format(backend)) from exc
 
     logger.debug('Connection: {}'.format(Class))
-    return Class(host, port, dbname, replicaset=replicaset)
+    return Class(host=host, port=port, dbname=dbname, replicaset=replicaset)
 
 
 class Connection:
@@ -68,16 +71,40 @@ class Connection:
     from and implements this class.
     """
 
-    def __init__(self, host=None, port=None, dbname=None, *args, **kwargs):
+    def __init__(self, host=None, port=None, dbname=None,
+                 connection_timeout=None, max_tries=None,
+                 **kwargs):
         """Create a new :class:`~.Connection` instance.
 
         Args:
             host (str): the host to connect to.
             port (int): the port to connect to.
             dbname (str): the name of the database to use.
+            connection_timeout (int, optional): the milliseconds to wait
+                until timing out the database connection attempt.
+                Defaults to 5000ms.
+            max_tries (int, optional): how many tries before giving up,
+                if 0 then try forever. Defaults to 3.
             **kwargs: arbitrary keyword arguments provided by the
                 configuration's ``database`` settings
         """
+
+        dbconf = bigchaindb.config['database']
+
+        self.host = host or dbconf['host']
+        self.port = port or dbconf['port']
+        self.dbname = dbname or dbconf['name']
+        self.connection_timeout = connection_timeout if connection_timeout is not None\
+            else dbconf['connection_timeout']
+        self.max_tries = max_tries if max_tries is not None else dbconf['max_tries']
+        self.max_tries_counter = range(self.max_tries) if self.max_tries != 0 else repeat(0)
+        self._conn = None
+
+    @property
+    def conn(self):
+        if self._conn is None:
+            self.connect()
+        return self._conn
 
     def run(self, query):
         """Run a query.
@@ -94,3 +121,24 @@ class Connection:
         """
 
         raise NotImplementedError()
+
+    def connect(self):
+        """Try to connect to the database.
+
+        Raises:
+            :exc:`~ConnectionError`: If the connection to the database
+                fails.
+        """
+
+        attempt = 0
+        for i in self.max_tries_counter:
+            attempt += 1
+            try:
+                self._conn = self._connect()
+            except ConnectionError as exc:
+                logger.warning('Attempt %s/%s. Connection to %s:%s failed after %sms.',
+                               attempt, self.max_tries if self.max_tries != 0 else '∞',
+                               self.host, self.port, self.connection_timeout)
+                if attempt == self.max_tries:
+                    logger.critical('Cannot connect to the Database. Giving up.')
+                    raise ConnectionError() from exc

--- a/bigchaindb/backend/connection.py
+++ b/bigchaindb/backend/connection.py
@@ -61,7 +61,9 @@ def connect(backend=None, host=None, port=None, name=None, max_tries=None,
         raise ConfigurationError('Error loading backend `{}`'.format(backend)) from exc
 
     logger.debug('Connection: {}'.format(Class))
-    return Class(host=host, port=port, dbname=dbname, replicaset=replicaset)
+    return Class(host=host, port=port, dbname=dbname,
+                 max_tries=max_tries, connection_timeout=connection_timeout,
+                 replicaset=replicaset)
 
 
 class Connection:
@@ -142,3 +144,5 @@ class Connection:
                 if attempt == self.max_tries:
                     logger.critical('Cannot connect to the Database. Giving up.')
                     raise ConnectionError() from exc
+            else:
+                break

--- a/bigchaindb/backend/rethinkdb/changefeed.py
+++ b/bigchaindb/backend/rethinkdb/changefeed.py
@@ -3,6 +3,7 @@ import logging
 import rethinkdb as r
 
 from bigchaindb import backend
+from bigchaindb.backend.exceptions import BackendError
 from bigchaindb.backend.changefeed import ChangeFeed
 from bigchaindb.backend.utils import module_dispatch_registrar
 from bigchaindb.backend.rethinkdb.connection import RethinkDBConnection
@@ -23,7 +24,7 @@ class RethinkDBChangeFeed(ChangeFeed):
             try:
                 self.run_changefeed()
                 break
-            except (r.ReqlDriverError, r.ReqlOpFailedError) as exc:
+            except BackendError as exc:
                 logger.exception(exc)
                 time.sleep(1)
 

--- a/bigchaindb/backend/rethinkdb/changefeed.py
+++ b/bigchaindb/backend/rethinkdb/changefeed.py
@@ -24,8 +24,8 @@ class RethinkDBChangeFeed(ChangeFeed):
             try:
                 self.run_changefeed()
                 break
-            except BackendError as exc:
-                logger.exception(exc)
+            except (BackendError, r.ReqlDriverError) as exc:
+                logger.exception('Error connecting to the database, retrying')
                 time.sleep(1)
 
     def run_changefeed(self):

--- a/bigchaindb/backend/rethinkdb/connection.py
+++ b/bigchaindb/backend/rethinkdb/connection.py
@@ -1,7 +1,7 @@
 import rethinkdb as r
 
 from bigchaindb.backend.connection import Connection
-from bigchaindb.backend.exceptions import ConnectionError
+from bigchaindb.backend.exceptions import ConnectionError, OperationError
 
 
 class RethinkDBConnection(Connection):
@@ -24,7 +24,10 @@ class RethinkDBConnection(Connection):
                 :attr:`~.RethinkDBConnection.max_tries`.
         """
 
-        return query.run(self.conn)
+        try:
+            return query.run(self.conn)
+        except r.ReqlDriverError as exc:
+            raise OperationError from exc
 
     def _connect(self):
         """Set a connection to RethinkDB.
@@ -39,4 +42,4 @@ class RethinkDBConnection(Connection):
         try:
             return r.connect(host=self.host, port=self.port, db=self.dbname)
         except r.ReqlDriverError as exc:
-            raise ConnectionError() from exc
+            raise ConnectionError from exc

--- a/bigchaindb/backend/rethinkdb/connection.py
+++ b/bigchaindb/backend/rethinkdb/connection.py
@@ -1,11 +1,7 @@
-import time
-import logging
-
 import rethinkdb as r
 
 from bigchaindb.backend.connection import Connection
-
-logger = logging.getLogger(__name__)
+from bigchaindb.backend.exceptions import ConnectionError
 
 
 class RethinkDBConnection(Connection):
@@ -16,23 +12,6 @@ class RethinkDBConnection(Connection):
         - resilient, because before raising exceptions it tries
           more times to run the query or open a connection.
     """
-
-    def __init__(self, host, port, dbname, max_tries=3, **kwargs):
-        """Create a new :class:`~.RethinkDBConnection` instance.
-
-        See :meth:`.Connection.__init__` for
-        :attr:`host`, :attr:`port`, and :attr:`dbname`.
-
-        Args:
-            max_tries (int, optional): how many tries before giving up.
-                Defaults to 3.
-        """
-
-        self.host = host
-        self.port = port
-        self.dbname = dbname
-        self.max_tries = max_tries
-        self.conn = None
 
     def run(self, query):
         """Run a RethinkDB query.
@@ -45,16 +24,7 @@ class RethinkDBConnection(Connection):
                 :attr:`~.RethinkDBConnection.max_tries`.
         """
 
-        if self.conn is None:
-            self._connect()
-
-        for i in range(self.max_tries):
-            try:
-                return query.run(self.conn)
-            except r.ReqlDriverError:
-                if i + 1 == self.max_tries:
-                    raise
-                self._connect()
+        return query.run(self.conn)
 
     def _connect(self):
         """Set a connection to RethinkDB.
@@ -66,16 +36,7 @@ class RethinkDBConnection(Connection):
                 :attr:`~.RethinkDBConnection.max_tries`.
         """
 
-        for i in range(1, self.max_tries + 1):
-            logging.debug('Connecting to database %s:%s/%s. (Attempt %s/%s)',
-                          self.host, self.port, self.dbname, i, self.max_tries)
-            try:
-                self.conn = r.connect(host=self.host, port=self.port, db=self.dbname)
-            except r.ReqlDriverError:
-                if i == self.max_tries:
-                    raise
-                wait_time = 2**i
-                logging.debug('Error connecting to database, waiting %ss', wait_time)
-                time.sleep(wait_time)
-            else:
-                break
+        try:
+            return r.connect(host=self.host, port=self.port, db=self.dbname)
+        except r.ReqlDriverError as exc:
+            raise ConnectionError() from exc

--- a/tests/backend/mongodb/test_admin.py
+++ b/tests/backend/mongodb/test_admin.py
@@ -40,7 +40,7 @@ def connection():
     # executed to make sure that the replica set is correctly initialized.
     # Here we force the the connection setup so that all required
     # `Database.command` are executed before we mock them it in the tests.
-    connection._connect()
+    connection.connect()
     return connection
 
 

--- a/tests/backend/rethinkdb/test_connection.py
+++ b/tests/backend/rethinkdb/test_connection.py
@@ -1,6 +1,7 @@
 import time
 import multiprocessing as mp
 from threading import Thread
+from unittest import mock
 from unittest.mock import patch
 
 import pytest
@@ -34,6 +35,7 @@ def test_run_a_simple_query():
 
 def test_raise_exception_when_max_tries():
     from bigchaindb.backend import connect
+    from bigchaindb.backend.exceptions import OperationError
 
     class MockQuery:
         def run(self, conn):
@@ -41,28 +43,41 @@ def test_raise_exception_when_max_tries():
 
     conn = connect()
 
-    with pytest.raises(r.ReqlDriverError):
+    with pytest.raises(OperationError):
         conn.run(MockQuery())
 
 
 def test_reconnect_when_connection_lost():
     from bigchaindb.backend import connect
 
-    def raise_exception(*args, **kwargs):
-        raise r.ReqlDriverError('mock')
-
-    conn = connect()
     original_connect = r.connect
-    r.connect = raise_exception
 
-    def delayed_start():
-        time.sleep(1)
-        r.connect = original_connect
+    with patch('rethinkdb.connect') as mock_connect:
+        mock_connect.side_effect = [
+            r.ReqlDriverError('mock'),
+            original_connect()
+        ]
 
-    thread = Thread(target=delayed_start)
-    query = r.expr('1')
-    thread.start()
-    assert conn.run(query) == '1'
+        conn = connect()
+        query = r.expr('1')
+        assert conn.run(query) == '1'
+
+
+def test_reconnect_when_connection_lost_tries_n_times():
+    from bigchaindb.backend import connect
+    from bigchaindb.backend.exceptions import ConnectionError
+
+    with patch('rethinkdb.connect') as mock_connect:
+        mock_connect.side_effect = [
+            r.ReqlDriverError('mock'),
+            r.ReqlDriverError('mock'),
+            r.ReqlDriverError('mock')
+        ]
+
+        conn = connect(max_tries=3)
+        query = r.expr('1')
+        with pytest.raises(ConnectionError):
+            assert conn.run(query) == '1'
 
 
 def test_changefeed_reconnects_when_connection_lost(monkeypatch):

--- a/tests/backend/rethinkdb/test_connection.py
+++ b/tests/backend/rethinkdb/test_connection.py
@@ -1,7 +1,6 @@
 import time
 import multiprocessing as mp
 from threading import Thread
-from unittest import mock
 from unittest.mock import patch
 
 import pytest

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -139,12 +139,17 @@ def test_autoconfigure_read_both_from_file_and_env(monkeypatch, request):
         'host': DATABASE_HOST,
         'port': DATABASE_PORT,
         'name': DATABASE_NAME,
+        'connection_timeout': 5000,
+        'max_tries': 3
     }
+
     database_mongodb = {
         'backend': 'mongodb',
         'host': DATABASE_HOST,
         'port': DATABASE_PORT,
         'name': DATABASE_NAME,
+        'connection_timeout': 5000,
+        'max_tries': 3,
         'replicaset': 'bigchain-rs',
     }
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,6 +10,8 @@ def config(request, monkeypatch):
             'port': 28015,
             'name': 'bigchain',
             'replicaset': 'bigchain-rs',
+            'connection_timeout': 5000,
+            'max_tries': 3
         },
         'keypair': {
             'public': 'pubkey',


### PR DESCRIPTION
I moved some code around. The "reconnect" feature is now generalized in the `bigchaindb.backend.connection::Connection` class. The two classes `RethinkDBConnection` and `MongoDBConnection` are a bit simpler now. What they have to do is just catch known exceptions and re-raise them using our domain specific exceptions in `bigchaindb.backend.exceptions`.

Close #1158.