### PR TITLE
Pin down rapidjson

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ install_requires = [
     'pymongo~=3.4',
     'pysha3~=1.0.2',
     'cryptoconditions>=0.5.0',
-    'python-rapidjson>=0.0.8',
+    'python-rapidjson==0.0.8',
     'logstats>=0.2.1',
     'flask>=0.10.1',
     'flask-restful~=0.3.0',


### PR DESCRIPTION
This is important as installing BigchainDB will fail due to https://github.com/python-rapidjson/python-rapidjson/issues/62.

Note to @ttmc @r-marques @vrde @libscott @TimDaub: this is a threshold condition of "1", i.e.  just one of you is enough to review the PR. I added you all as this should get merged as quickly as possible, Current installations will fail without it.