### PR TITLE
Avoid dupe txs in block

### DIFF
--- a/bigchaindb/common/exceptions.py
+++ b/bigchaindb/common/exceptions.py
@@ -41,6 +41,10 @@ class InvalidSignature(BigchainDBError):
     operation"""
 
 
+class DuplicateTransaction(ValidationError):
+    """Raised if a duplicated transaction is found"""
+
+
 class DatabaseAlreadyExists(BigchainDBError):
     """Raised when trying to create the database but the db is already there"""
 

--- a/bigchaindb/models.py
+++ b/bigchaindb/models.py
@@ -262,7 +262,7 @@ class Block(object):
             DoubleSpend: if the transaction is a double spend
             InvalidHash: if the hash of the transaction is wrong
             InvalidSignature: if the signature of the transaction is wrong
-            ValidationError: If the block contains a duplicated TX
+            DuplicateTransaction: If the block contains a duplicated TX
         """
         txids = [tx.id for tx in self.transactions]
         if len(txids) != len(set(txids)):

--- a/bigchaindb/models.py
+++ b/bigchaindb/models.py
@@ -3,7 +3,8 @@ from bigchaindb.common.exceptions import (InvalidHash, InvalidSignature,
                                           OperationError, DoubleSpend,
                                           TransactionDoesNotExist,
                                           TransactionNotInValidBlock,
-                                          AssetIdMismatch, AmountError)
+                                          AssetIdMismatch, AmountError,
+                                          DuplicateTransaction)
 from bigchaindb.common.transaction import Transaction
 from bigchaindb.common.utils import gen_timestamp, serialize
 from bigchaindb.common.schema import validate_transaction_schema
@@ -261,7 +262,12 @@ class Block(object):
             DoubleSpend: if the transaction is a double spend
             InvalidHash: if the hash of the transaction is wrong
             InvalidSignature: if the signature of the transaction is wrong
+            ValidationError: If the block contains a duplicated TX
         """
+        txids = [tx.id for tx in self.transactions]
+        if len(txids) != len(set(txids)):
+            raise DuplicateTransaction('Block has duplicate transaction')
+
         for tx in self.transactions:
             # If a transaction is not valid, `validate_transactions` will
             # throw an an exception and block validation will be canceled.

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -5,27 +5,6 @@ import pytest
 pytestmark = [pytest.mark.bdb, pytest.mark.usefixtures('processes')]
 
 
-def test_fast_double_create(b, user_pk):
-    from bigchaindb.models import Transaction
-    from bigchaindb.backend.query import count_blocks
-    tx = Transaction.create([b.me], [([user_pk], 1)],
-                            metadata={'test': 'test'}).sign([b.me_private])
-
-    # write everything fast
-    b.write_transaction(tx)
-    b.write_transaction(tx)
-
-    time.sleep(2)
-    tx_returned = b.get_transaction(tx.id)
-
-    # test that the tx can be queried
-    assert tx_returned == tx
-    # test the transaction appears only once
-    last_voted_block = b.get_last_voted_block()
-    assert len(last_voted_block.transactions) == 1
-    assert count_blocks(b.connection) == 2
-
-
 def test_double_create(b, user_pk):
     from bigchaindb.models import Transaction
     from bigchaindb.backend.query import count_blocks

--- a/tests/pipelines/stepping.py
+++ b/tests/pipelines/stepping.py
@@ -72,6 +72,7 @@ class MultipipesStepper:
             r = f(**kwargs)
             if r is not None:
                 self._enqueue(next_name, r)
+            return r
 
         self.tasks[name] = functools.wraps(f)(inner)
         self.input_tasks.add(name)
@@ -90,6 +91,7 @@ class MultipipesStepper:
             out = f(*args, **kwargs)
             if out is not None and next:
                 self._enqueue(next_name, out)
+            return out
 
         task = functools.wraps(f)(inner)
         self.tasks[name] = task
@@ -111,12 +113,12 @@ class MultipipesStepper:
         logging.debug('Stepping %s', name)
         task = self.tasks[name]
         if name in self.input_tasks:
-            task(**kwargs)
+            return task(**kwargs)
         else:
             queue = self.queues.get(name, [])
             if not queue:
                 raise Empty(name)
-            task(*queue.pop(0), **kwargs)
+            return task(*queue.pop(0), **kwargs)
         logging.debug('Stepped %s', name)
 
     @property

--- a/tests/pipelines/test_block_creation.py
+++ b/tests/pipelines/test_block_creation.py
@@ -231,7 +231,7 @@ def test_full_pipeline(b, user_pk):
 def test_block_snowflake(create_tx, signed_transfer_tx):
     from bigchaindb.pipelines.block import tx_collector
     snowflake = tx_collector()
-    snowflake.send(create_tx)
+    assert snowflake.send(create_tx) == [create_tx]
     snowflake.send(signed_transfer_tx)
     snowflake.send(create_tx)
     assert snowflake.send(None) == [create_tx, signed_transfer_tx]

--- a/tests/pipelines/test_block_creation.py
+++ b/tests/pipelines/test_block_creation.py
@@ -226,3 +226,12 @@ def test_full_pipeline(b, user_pk):
     block_len = len(block_doc.transactions)
     assert chained_block == block_doc
     assert number_assigned_to_others == 100 - block_len
+
+
+def test_block_snowflake(create_tx, signed_transfer_tx):
+    from bigchaindb.pipelines.block import tx_collector
+    snowflake = tx_collector()
+    snowflake.send(create_tx)
+    snowflake.send(signed_transfer_tx)
+    snowflake.send(create_tx)
+    assert snowflake.send(None) == [create_tx, signed_transfer_tx]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -163,3 +163,11 @@ class TestBlockModel(object):
 
         public_key = PublicKey(b.me)
         assert public_key.verify(expected_block_serialized, block.signature)
+
+    def test_block_dupe_tx(self, b):
+        from bigchaindb.models import Transaction
+        from bigchaindb.common.exceptions import DuplicateTransaction
+        tx = Transaction.create([b.me], [([b.me], 1)])
+        block = b.create_block([tx, tx])
+        with raises(DuplicateTransaction):
+            block._validate_block_transactions(b)


### PR DESCRIPTION
Fixes #1229.

- [x] Transaction collector to dedupe transactions in a block.
- [x] DuplicateTransaction exception if dupe tx found in block validation
- [x] Stepping pipeline step calls return output
- [x] Remove old integration test
- [x] ~Catch DuplicateTransaction in Vote pipeline~ Not needed after #1243

