### PR TITLE
Pass host and port to rethinkdb connection

### DIFF
--- a/tests/backend/rethinkdb/test_connection.py
+++ b/tests/backend/rethinkdb/test_connection.py
@@ -46,7 +46,7 @@ def test_raise_exception_when_max_tries():
         conn.run(MockQuery())
 
 
-def test_reconnect_when_connection_lost():
+def test_reconnect_when_connection_lost(db_host, db_port):
     from bigchaindb.backend import connect
 
     original_connect = r.connect
@@ -54,7 +54,7 @@ def test_reconnect_when_connection_lost():
     with patch('rethinkdb.connect') as mock_connect:
         mock_connect.side_effect = [
             r.ReqlDriverError('mock'),
-            original_connect()
+            original_connect(host=db_host, port=db_port)
         ]
 
         conn = connect()


### PR DESCRIPTION
This is needed when running the tests in containers for instance