### PR TITLE
Must update meaning of 'latest' image on Docker Hub when do a minor release

### DIFF
--- a/Release_Process.md
+++ b/Release_Process.md
@@ -14,10 +14,8 @@ A minor release is preceeded by a feature freeze and created from the 'master' b
 1. In `bigchaindb/version.py`, update `__version__` and `__short_version__`, e.g. to `0.9` and `0.9.0` (with no `.dev` on the end)
 1. Commit that change, and push the new branch to GitHub
 1. Follow steps outlined in [Common Steps](#common-steps)
-1. In 'master' branch, Edit `bigchaindb/version.py`, increment the minor version to the next planned release, e.g. `0.10.0.dev'
-This is so people reading the latest docs will know that they're for the latest (master branch)
-version of BigchainDB Server, not the docs at the time of the most recent release (which are also
-available).
+1. In 'master' branch, Edit `bigchaindb/version.py`, increment the minor version to the next planned release, e.g. `0.10.0.dev`. This is so people reading the latest docs will know that they're for the latest (master branch) version of BigchainDB Server, not the docs at the time of the most recent release (which are also available).
+1. Go to [Docker Hub](https://hub.docker.com/), sign in, go to Settings - Build Settings, and under the build with Docker Tag Name equal to `latest`, change the Name to the number of the new release, e.g. `0.9`
 
 Congratulations, you have released BigchainDB!
 


### PR DESCRIPTION
I just added a step to the `Release_Process.md` file.

(While I was at it, I also made some minor typo/formatting fixes to the previous step in the process.)