### PR TITLE
Remove 'bigchaindb load' command, tests & docs

### DIFF
--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -9,15 +9,11 @@ import copy
 import json
 import sys
 
-import logstats
-
 from bigchaindb.common import crypto
 from bigchaindb.common.exceptions import (StartupError,
                                           DatabaseAlreadyExists,
                                           KeypairNotFoundException)
 import bigchaindb
-from bigchaindb.models import Transaction
-from bigchaindb.utils import ProcessGroup
 from bigchaindb import backend, processes
 from bigchaindb.backend import schema
 from bigchaindb.backend.admin import (set_replicas, set_shards, add_replicas,
@@ -206,39 +202,6 @@ def run_start(args):
     processes.start()
 
 
-def _run_load(tx_left, stats):
-    logstats.thread.start(stats)
-    b = bigchaindb.Bigchain()
-
-    while True:
-        tx = Transaction.create([b.me], [([b.me], 1)])
-        tx = tx.sign([b.me_private])
-        b.write_transaction(tx)
-
-        stats['transactions'] += 1
-
-        if tx_left is not None:
-            tx_left -= 1
-            if tx_left == 0:
-                break
-
-
-@configure_bigchaindb
-def run_load(args):
-    logger.info('Starting %s processes', args.multiprocess)
-    stats = logstats.Logstats()
-    logstats.thread.start(stats)
-
-    tx_left = None
-    if args.count > 0:
-        tx_left = int(args.count / args.multiprocess)
-
-    workers = ProcessGroup(concurrency=args.multiprocess,
-                           target=_run_load,
-                           args=(tx_left, stats.get_child()))
-    workers.start()
-
-
 @configure_bigchaindb
 def run_set_shards(args):
     conn = backend.connect()
@@ -373,25 +336,6 @@ def create_parser():
                                     help='A list of space separated hosts to '
                                          'remove from the replicaset. Each host '
                                          'should be in the form `host:port`.')
-
-    load_parser = subparsers.add_parser('load',
-                                        help='Write transactions to the backlog')
-
-    load_parser.add_argument('-m', '--multiprocess',
-                             nargs='?',
-                             type=int,
-                             default=False,
-                             help='Spawn multiple processes to run the command, '
-                                  'if no value is provided, the number of processes '
-                                  'is equal to the number of cores of the host machine')
-
-    load_parser.add_argument('-c', '--count',
-                             default=0,
-                             type=int,
-                             help='Number of transactions to push. If the parameter -m '
-                                  'is set, the count is distributed equally to all the '
-                                  'processes')
-
     return parser
 
 

--- a/docs/server/source/server-reference/bigchaindb-cli.md
+++ b/docs/server/source/server-reference/bigchaindb-cli.md
@@ -69,16 +69,6 @@ e.g. `bigchaindb --dev-start-rethinkdb start`. Note that this will also shutdown
 The option `--dev-allow-temp-keypair` will generate a keypair on the fly if no keypair is found, this is useful when you want to run a temporary instance of BigchainDB in a Docker container, for example.
 
 
-## bigchaindb load
-
-Write transactions to the backlog (for benchmarking tests). You can learn more about it using:
-```text
-$ bigchaindb load -h
-```
-
-Note: This command uses the Python Server API to write transactions to the database. It _doesn't_ use the HTTP API or a driver that wraps the HTTP API.
-
-
 ## bigchaindb set-shards
 
 This command is specific to RethinkDB so it will only run if BigchainDB is

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -21,7 +21,6 @@ def test_make_sure_we_dont_remove_any_command():
     assert parser.parse_args(['start']).command
     assert parser.parse_args(['set-shards', '1']).command
     assert parser.parse_args(['set-replicas', '1']).command
-    assert parser.parse_args(['load']).command
     assert parser.parse_args(['add-replicas', 'localhost:27017']).command
     assert parser.parse_args(['remove-replicas', 'localhost:27017']).command
 
@@ -382,27 +381,6 @@ def test_calling_main(start_mock, base_parser_mock, parse_args_mock,
                                                help='Number of replicas (i.e. '
                                                'the replication factor)')
 
-    subparsers.add_parser.assert_any_call('load',
-                                          help='Write transactions to the '
-                                          'backlog')
-
-    subsubparsers.add_argument.assert_any_call('-m', '--multiprocess',
-                                               nargs='?', type=int,
-                                               default=False,
-                                               help='Spawn multiple processes '
-                                               'to run the command, if no '
-                                               'value is provided, the number '
-                                               'of processes is equal to the '
-                                               'number of cores of the host '
-                                               'machine')
-    subsubparsers.add_argument.assert_any_call('-c', '--count',
-                                               default=0,
-                                               type=int,
-                                               help='Number of transactions '
-                                               'to push. If the parameter -m '
-                                               'is set, the count is '
-                                               'distributed equally to all '
-                                               'the processes')
     assert start_mock.called is True
 
 


### PR DESCRIPTION
The `bigchaindb load` command is a tool we've used when testing the performance of BigchainDB Server. It writes transactions straight into the backlog table using the RethinkDB/MongoDB Python driver (not using the HTTP API).

`bigchaindb load` doesn't need to be in the core BigchainDB Server functionality / code base, because it's not something a normal BigchainDB Server operator needs. In the future, we might make a separate, stand-alone tool for bulk-loading the backlog table directly (for use in testing). If we do, we can build that tool based on the `bigchaindb load` code in the Git history.

Also, `bigchaindb load` is currently broken, since BigchainDB transactions no longer include a timestamp or random asset ID. See issue #1255.

See also: pull request #1261, which removes the corresponding code in the AWS deployment scripts.