### PR TITLE
Fix bug 1271 false double spend

### DIFF
--- a/bigchaindb/backend/mongodb/query.py
+++ b/bigchaindb/backend/mongodb/query.py
@@ -153,14 +153,22 @@ def get_spent(conn, transaction_id, output):
     cursor = conn.run(
         conn.collection('bigchain').aggregate([
             {'$match': {
-                'block.transactions.inputs.fulfills.txid': transaction_id,
-                'block.transactions.inputs.fulfills.output': output
+                'block.transactions.inputs': {
+                    '$elemMatch': {
+                        'fulfills.txid': transaction_id,
+                        'fulfills.output': output,
+                    },
+                },
             }},
             {'$unwind': '$block.transactions'},
             {'$match': {
-                'block.transactions.inputs.fulfills.txid': transaction_id,
-                'block.transactions.inputs.fulfills.output': output
-            }}
+                'block.transactions.inputs': {
+                    '$elemMatch': {
+                        'fulfills.txid': transaction_id,
+                        'fulfills.output': output,
+                    },
+                },
+            }},
         ]))
     # we need to access some nested fields before returning so lets use a
     # generator to avoid having to read all records on the cursor at this point

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,6 +224,54 @@ def user2_pk():
 
 
 @pytest.fixture
+def alice():
+    from bigchaindb.common.crypto import generate_key_pair
+    return generate_key_pair()
+
+
+@pytest.fixture
+def alice_privkey(alice):
+    return alice.private_key
+
+
+@pytest.fixture
+def alice_pubkey(alice):
+    return alice.public_key
+
+
+@pytest.fixture
+def bob():
+    from bigchaindb.common.crypto import generate_key_pair
+    return generate_key_pair()
+
+
+@pytest.fixture
+def bob_privkey(bob):
+    return bob.private_key
+
+
+@pytest.fixture
+def bob_pubkey(carol):
+    return bob.public_key
+
+
+@pytest.fixture
+def carol():
+    from bigchaindb.common.crypto import generate_key_pair
+    return generate_key_pair()
+
+
+@pytest.fixture
+def carol_privkey(carol):
+    return carol.private_key
+
+
+@pytest.fixture
+def carol_pubkey(carol):
+    return carol.public_key
+
+
+@pytest.fixture
 def b():
     from bigchaindb import Bigchain
     return Bigchain()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -80,3 +80,46 @@ def test_get_blocks_status_containing_tx(monkeypatch):
     bigchain = Bigchain(public_key='pubkey', private_key='privkey')
     with pytest.raises(Exception):
         bigchain.get_blocks_status_containing_tx('txid')
+
+
+@pytest.mark.genesis
+def test_get_spent_issue_1271(b, alice, bob, carol):
+    from bigchaindb.models import Transaction
+
+    tx_1 = Transaction.create(
+        [carol.public_key],
+        [([carol.public_key], 8)],
+    ).sign([carol.private_key])
+
+    tx_2 = Transaction.transfer(
+        tx_1.to_inputs(),
+        [([bob.public_key], 2),
+         ([alice.public_key], 2),
+         ([carol.public_key], 4)],
+        asset_id=tx_1.id,
+    ).sign([carol.private_key])
+
+    tx_3 = Transaction.transfer(
+        tx_2.to_inputs()[2:3],
+        [([alice.public_key], 1),
+         ([carol.public_key], 3)],
+        asset_id=tx_1.id,
+    ).sign([carol.private_key])
+
+    tx_4 = Transaction.transfer(
+        tx_2.to_inputs()[1:2] + tx_3.to_inputs()[0:1],
+        [([bob.public_key], 3)],
+        asset_id=tx_1.id,
+    ).sign([alice.private_key])
+
+    tx_5 = Transaction.transfer(
+        tx_2.to_inputs()[0:1],
+        [([alice.public_key], 2)],
+        asset_id=tx_1.id,
+    ).sign([bob.private_key])
+    block_5 = b.create_block([tx_1, tx_2, tx_3, tx_4, tx_5])
+    b.write_block(block_5)
+    assert b.get_spent(tx_2.id, 0) == tx_5
+    assert not b.get_spent(tx_5.id, 0)
+    assert b.get_outputs_filtered(alice.public_key)
+    assert b.get_outputs_filtered(alice.public_key, include_spent=False)


### PR DESCRIPTION
This PR proposes a simple solution for issue #1271 reported by @jmduque. The commit holding the proposed solution is at https://github.com/bigchaindb/bigchaindb/pull/1293/commits/b192f5cd2d46e03384517e4445cc1263f5b132c8

As @jmduque pointed out the mongodb-based query `get_spent()` may return transactions for which the inputs match the given txid and output index in separate inputs. That is, a transaction containing two inputs such that one input matches the given txid meanwhile the other input matches the given output index will be returned by `get_spent()`.  See this [commit](https://github.com/bigchaindb/bigchaindb/pull/1293/commits/84d0941b429460f215bd4afb5a7bb372fa8b0d37) for a test replaying this use case.

One side effect of this problem is that the `Bigchain.get_spent()` method under `core.py` may raise a double spending error ([CriticalDoubleSpend](https://github.com/bigchaindb/bigchaindb/blob/master/bigchaindb/core.py#L350-L352)),. when in fact everything is fine. This problem was the original problem reported by @jmduque and this [commit](https://github.com/bigchaindb/bigchaindb/pull/1293/commits/de9ae3bada0998a15951cf8230b7cc19d902b8e0) reproduces the problem, based on @ttmc's very helpful [diagram](https://github.com/bigchaindb/bigchaindb/issues/1271#issuecomment-285669515).

Lastly, in order to support the new tests 3 fixtures were added to represent three characters: `alice`, `bob` and `carol`. These fixtures can be re-used as needed. It should be noted that their key pairs are not hard-coded and will be re-generated in each test wherever the fixtures are invoked.