### PR TITLE
Feat/add log level rebased

### DIFF
--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -25,7 +25,6 @@ from bigchaindb.commands.messages import (
     RETHINKDB_STARTUP_ERROR,
 )
 from bigchaindb.commands.utils import configure_bigchaindb, input_on_stderr
-from bigchaindb.log.setup import setup_logging
 
 
 logging.basicConfig(level=logging.INFO)

--- a/bigchaindb/commands/bigchain.py
+++ b/bigchaindb/commands/bigchain.py
@@ -173,9 +173,6 @@ def run_start(args):
     """Start the processes to run the node"""
     logger.info('BigchainDB Version %s', bigchaindb.__version__)
 
-    # TODO setup logging -- pass logging config, extracted out from main config
-    setup_logging()
-
     if args.allow_temp_keypair:
         if not (bigchaindb.config['keypair']['private'] or
                 bigchaindb.config['keypair']['public']):

--- a/bigchaindb/commands/utils.py
+++ b/bigchaindb/commands/utils.py
@@ -25,10 +25,10 @@ def configure_bigchaindb(command):
     def configure(args):
         bigchaindb.config_utils.autoconfigure(filename=args.config, force=True)
 
-        logging_config = bigchaindb.config['logging'] or {}
+        logging_config = bigchaindb.config['log'] or {}
         if 'log_level' in args and args.log_level:
-            logging_config['level'] = args.log_level
-        setup_logging(logging_config)
+            logging_config['level_console'] = args.log_level
+        setup_logging(user_log_config=logging_config)
 
         command(args)
 

--- a/bigchaindb/commands/utils.py
+++ b/bigchaindb/commands/utils.py
@@ -16,6 +16,7 @@ import bigchaindb
 import bigchaindb.config_utils
 from bigchaindb import backend
 from bigchaindb.common.exceptions import StartupError
+from bigchaindb.log.setup import setup_logging
 from bigchaindb.version import __version__
 
 
@@ -23,6 +24,12 @@ def configure_bigchaindb(command):
     @functools.wraps(command)
     def configure(args):
         bigchaindb.config_utils.autoconfigure(filename=args.config, force=True)
+
+        logging_config = bigchaindb.config['logging'] or {}
+        if 'log_level' in args and args.log_level:
+            logging_config['level'] = args.log_level
+        setup_logging(logging_config)
+
         command(args)
 
     return configure

--- a/bigchaindb/commands/utils.py
+++ b/bigchaindb/commands/utils.py
@@ -151,6 +151,10 @@ base_parser.add_argument('-c', '--config',
                          help='Specify the location of the configuration file '
                               '(use "-" for stdout)')
 
+base_parser.add_argument('-l', '--log-level',
+                         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+                         help='Log level')
+
 base_parser.add_argument('-y', '--yes', '--yes-please',
                          action='store_true',
                          help='Assume "yes" as answer to all prompts and run '

--- a/bigchaindb/config_utils.py
+++ b/bigchaindb/config_utils.py
@@ -220,11 +220,14 @@ def write_config(config, filename=None):
         json.dump(config, f, indent=4)
 
 
+def is_configured():
+    return bool(bigchaindb.config.get('CONFIGURED'))
+
+
 def autoconfigure(filename=None, config=None, force=False):
     """Run ``file_config`` and ``env_config`` if the module has not
     been initialized."""
-
-    if not force and bigchaindb.config.get('CONFIGURED'):
+    if not force and is_configured():
         logger.debug('System already configured, skipping autoconfiguration')
         return
 

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -55,7 +55,7 @@ def run_start_args(request):
 @pytest.fixture
 def mocked_setup_logging(mocker):
     return mocker.patch(
-        'bigchaindb.commands.bigchain.setup_logging',
+        'bigchaindb.commands.utils.setup_logging',
         autospec=True,
         spec_set=True,
     )

--- a/tests/commands/rethinkdb/test_commands.py
+++ b/tests/commands/rethinkdb/test_commands.py
@@ -16,7 +16,7 @@ def test_bigchain_run_start_with_rethinkdb(mock_start_rethinkdb,
     run_start(args)
 
     mock_start_rethinkdb.assert_called_with()
-    mocked_setup_logging.assert_called_once_with()
+    mocked_setup_logging.assert_called_once_with(user_log_config={})
 
 
 @patch('subprocess.Popen')
@@ -38,7 +38,7 @@ def test_start_rethinkdb_exits_when_cannot_start(mock_popen):
 
 
 @patch('rethinkdb.ast.Table.reconfigure')
-def test_set_shards(mock_reconfigure, monkeypatch, b):
+def test_set_shards(mock_reconfigure, monkeypatch, b, mocked_setup_logging):
     from bigchaindb.commands.bigchain import run_set_shards
 
     # this will mock the call to retrieve the database config
@@ -50,6 +50,8 @@ def test_set_shards(mock_reconfigure, monkeypatch, b):
     args = Namespace(num_shards=3, config=None)
     run_set_shards(args)
     mock_reconfigure.assert_called_with(replicas=1, shards=3, dry_run=False)
+    mocked_setup_logging.assert_called_once_with(user_log_config={})
+    mocked_setup_logging.reset_mock()
 
     # this will mock the call to retrieve the database config
     # we will set it to return three replica
@@ -59,9 +61,10 @@ def test_set_shards(mock_reconfigure, monkeypatch, b):
     monkeypatch.setattr(rethinkdb.RqlQuery, 'run', mockreturn_three_replicas)
     run_set_shards(args)
     mock_reconfigure.assert_called_with(replicas=3, shards=3, dry_run=False)
+    mocked_setup_logging.assert_called_once_with(user_log_config={})
 
 
-def test_set_shards_raises_exception(monkeypatch, b):
+def test_set_shards_raises_exception(monkeypatch, b, mocked_setup_logging):
     from bigchaindb.commands.bigchain import run_set_shards
 
     # test that we are correctly catching the exception
@@ -78,10 +81,11 @@ def test_set_shards_raises_exception(monkeypatch, b):
     with pytest.raises(SystemExit) as exc:
         run_set_shards(args)
     assert exc.value.args == ('Failed to reconfigure tables.',)
+    mocked_setup_logging.assert_called_once_with(user_log_config={})
 
 
 @patch('rethinkdb.ast.Table.reconfigure')
-def test_set_replicas(mock_reconfigure, monkeypatch, b):
+def test_set_replicas(mock_reconfigure, monkeypatch, b, mocked_setup_logging):
     from bigchaindb.commands.bigchain import run_set_replicas
 
     # this will mock the call to retrieve the database config
@@ -93,6 +97,8 @@ def test_set_replicas(mock_reconfigure, monkeypatch, b):
     args = Namespace(num_replicas=2, config=None)
     run_set_replicas(args)
     mock_reconfigure.assert_called_with(replicas=2, shards=2, dry_run=False)
+    mocked_setup_logging.assert_called_once_with(user_log_config={})
+    mocked_setup_logging.reset_mock()
 
     # this will mock the call to retrieve the database config
     # we will set it to return three shards
@@ -102,9 +108,10 @@ def test_set_replicas(mock_reconfigure, monkeypatch, b):
     monkeypatch.setattr(rethinkdb.RqlQuery, 'run', mockreturn_three_shards)
     run_set_replicas(args)
     mock_reconfigure.assert_called_with(replicas=2, shards=3, dry_run=False)
+    mocked_setup_logging.assert_called_once_with(user_log_config={})
 
 
-def test_set_replicas_raises_exception(monkeypatch, b):
+def test_set_replicas_raises_exception(monkeypatch, b, mocked_setup_logging):
     from bigchaindb.commands.bigchain import run_set_replicas
 
     # test that we are correctly catching the exception
@@ -121,3 +128,4 @@ def test_set_replicas_raises_exception(monkeypatch, b):
     with pytest.raises(SystemExit) as exc:
         run_set_replicas(args)
     assert exc.value.args == ('Failed to reconfigure tables.',)
+    mocked_setup_logging.assert_called_once_with(user_log_config={})

--- a/tests/commands/test_utils.py
+++ b/tests/commands/test_utils.py
@@ -1,7 +1,10 @@
 import argparse
+from argparse import ArgumentTypeError, Namespace
+import logging
+from logging import getLogger
+
 import pytest
 
-from argparse import ArgumentTypeError, Namespace
 from unittest.mock import patch
 
 
@@ -32,8 +35,6 @@ def test_configure_bigchaindb_configures_bigchaindb(mocked_setup_logging):
 @pytest.mark.parametrize('log_level', ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'))
 def test_configure_bigchaindb_configures_logging(log_level,
                                                  mocked_setup_sub_logger):
-    import logging
-    from logging import getLogger
     from bigchaindb.commands.utils import configure_bigchaindb
     from bigchaindb.log.configs import PUBLISHER_LOGGING_CONFIG
     root_logger = getLogger()

--- a/tests/commands/test_utils.py
+++ b/tests/commands/test_utils.py
@@ -32,13 +32,19 @@ def test_configure_bigchaindb_configures_bigchaindb(mocked_setup_logging):
 @pytest.mark.usefixtures('ignore_local_config_file',
                          'reset_bigchaindb_config',
                          'reset_logging_config')
-@pytest.mark.parametrize('log_level', ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'))
+@pytest.mark.parametrize('log_level', (
+    logging.DEBUG,
+    logging.INFO,
+    logging.WARNING,
+    logging.ERROR,
+    logging.CRITICAL,
+))
 def test_configure_bigchaindb_configures_logging(log_level,
                                                  mocked_setup_sub_logger):
     from bigchaindb.commands.utils import configure_bigchaindb
     from bigchaindb.log.configs import PUBLISHER_LOGGING_CONFIG
     root_logger = getLogger()
-    assert root_logger.level == 0
+    assert root_logger.level == logging.NOTSET
 
     @configure_bigchaindb
     def test_configure_logger(args):

--- a/tests/commands/test_utils.py
+++ b/tests/commands/test_utils.py
@@ -1,7 +1,48 @@
 import argparse
 import pytest
 
+from argparse import ArgumentTypeError, Namespace
 from unittest.mock import patch
+
+
+@pytest.fixture
+def reset_bigchaindb_config(monkeypatch):
+    import bigchaindb
+    monkeypatch.setattr('bigchaindb.config', bigchaindb._config)
+
+
+@pytest.mark.usefixtures('ignore_local_config_file', 'reset_bigchaindb_config')
+def test_configure_bigchaindb_configures_bigchaindb():
+    from bigchaindb.commands.utils import configure_bigchaindb
+    from bigchaindb.config_utils import is_configured
+    assert not is_configured()
+
+    @configure_bigchaindb
+    def test_configure(args):
+        assert is_configured()
+
+    args = Namespace(config=None)
+    test_configure(args)
+
+
+@pytest.mark.usefixtures('ignore_local_config_file',
+                         'reset_bigchaindb_config',
+                         'reset_logging_config')
+@pytest.mark.parametrize('log_level', ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'))
+def test_configure_bigchaindb_configures_logging(log_level):
+    import logging
+    from logging import getLogger
+    from bigchaindb.commands.utils import configure_bigchaindb
+    root_logger = getLogger()
+    assert root_logger.level == 0
+
+    @configure_bigchaindb
+    def test_configure_logger(args):
+        root_logger = getLogger()
+        assert root_logger.level == getattr(logging, log_level)
+
+    args = Namespace(config=None, log_level=log_level)
+    test_configure_logger(args)
 
 
 def test_start_raises_if_command_not_implemented():
@@ -51,13 +92,13 @@ def test_mongodb_host_type():
     from bigchaindb.commands.utils import mongodb_host
 
     # bad port provided
-    with pytest.raises(argparse.ArgumentTypeError):
+    with pytest.raises(ArgumentTypeError):
         mongodb_host('localhost:11111111111')
 
     # no port information provided
-    with pytest.raises(argparse.ArgumentTypeError):
+    with pytest.raises(ArgumentTypeError):
         mongodb_host('localhost')
 
     # bad host provided
-    with pytest.raises(argparse.ArgumentTypeError):
+    with pytest.raises(ArgumentTypeError):
         mongodb_host(':27017')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ import random
 
 import pytest
 
+from logging import getLogger
+from logging.config import dictConfig
 from bigchaindb.common import crypto
 
 TEST_DB_NAME = 'bigchain_test'
@@ -201,6 +203,15 @@ def ignore_local_config_file(monkeypatch):
 
     monkeypatch.setattr('bigchaindb.config_utils.file_config',
                         mock_file_config)
+
+
+@pytest.fixture
+def reset_logging_config():
+    # root_logger_level = getLogger().level
+    root_logger_level = 'DEBUG'
+    dictConfig({'version': 1, 'root': {'level': 'NOTSET'}})
+    yield
+    getLogger().setLevel(root_logger_level)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -442,3 +442,15 @@ def db_name(db_config):
 def db_conn():
     from bigchaindb.backend import connect
     return connect()
+
+
+@pytest.fixture
+def mocked_setup_pub_logger(mocker):
+    return mocker.patch(
+        'bigchaindb.log.setup.setup_pub_logger', autospec=True, spec_set=True)
+
+
+@pytest.fixture
+def mocked_setup_sub_logger(mocker):
+    return mocker.patch(
+        'bigchaindb.log.setup.setup_sub_logger', autospec=True, spec_set=True)

--- a/tests/log/test_setup.py
+++ b/tests/log/test_setup.py
@@ -31,18 +31,6 @@ def mocked_socket_server(mocker):
 
 
 @fixture
-def mocked_setup_pub_logger(mocker):
-    return mocker.patch(
-        'bigchaindb.log.setup.setup_pub_logger', autospec=True, spec_set=True)
-
-
-@fixture
-def mocked_setup_sub_logger(mocker):
-    return mocker.patch(
-        'bigchaindb.log.setup.setup_sub_logger', autospec=True, spec_set=True)
-
-
-@fixture
 def log_record_dict():
     return {
         'args': None,
@@ -225,6 +213,7 @@ class TestLogRecordSocketServer:
         assert server.server_address == (
             '127.0.0.1', logging.handlers.DEFAULT_TCP_LOGGING_PORT)
         assert server.RequestHandlerClass == LogRecordStreamHandler
+        server.server_close()
 
     @mark.parametrize('side_effect', (None, KeyboardInterrupt))
     def test_server_forever(self, mocker, side_effect):


### PR DESCRIPTION
Carrying over work from @sohkai in #1219:

> Adds a `-l` / `--log-level` option to all CLI commands.

> Builds on #1211, #1218, and work in progress commits from @sbellem that will be made into a pull request.

> Tests don't rely on any actual logs, but just that the expected log level is set.