### PR TITLE
Validate vote signature in get_last_voted_block

### DIFF
--- a/bigchaindb/backend/query.py
+++ b/bigchaindb/backend/query.py
@@ -259,7 +259,7 @@ def get_genesis_block(connection):
 
 
 @singledispatch
-def get_last_voted_block(connection, node_pubkey):
+def get_votes_by_pubkey(connection, node_pubkey):
     """Get the last voted block for a specific node.
 
     Args:

--- a/bigchaindb/backend/rethinkdb/query.py
+++ b/bigchaindb/backend/rethinkdb/query.py
@@ -191,7 +191,8 @@ def get_votes_by_pubkey(connection, node_pubkey):
     return connection.run(
         r.table('votes', read_mode=READ_MODE)
         .filter(r.row['node_pubkey'] == node_pubkey)
-        .order_by(r.desc(r.row['vote']['timestamp'])))
+        .order_by(r.desc(r.row['vote']['timestamp']))
+        .without('id'))
 
 
 @register_query(RethinkDBConnection)

--- a/bigchaindb/backend/rethinkdb/query.py
+++ b/bigchaindb/backend/rethinkdb/query.py
@@ -4,7 +4,6 @@ from time import time
 import rethinkdb as r
 
 from bigchaindb import backend, utils
-from bigchaindb.common import exceptions
 from bigchaindb.common.transaction import Transaction
 from bigchaindb.backend.utils import module_dispatch_registrar
 from bigchaindb.backend.rethinkdb.connection import RethinkDBConnection
@@ -188,56 +187,11 @@ def get_genesis_block(connection):
 
 
 @register_query(RethinkDBConnection)
-def get_last_voted_block(connection, node_pubkey):
-    try:
-        # get the latest value for the vote timestamp (over all votes)
-        max_timestamp = connection.run(
-            r.table('votes', read_mode=READ_MODE)
-            .filter(r.row['node_pubkey'] == node_pubkey)
-            .max(r.row['vote']['timestamp']))['vote']['timestamp']
-
-        last_voted = list(connection.run(
-            r.table('votes', read_mode=READ_MODE)
-            .filter(r.row['vote']['timestamp'] == max_timestamp)
-            .filter(r.row['node_pubkey'] == node_pubkey)))
-
-    except r.ReqlNonExistenceError:
-        # return last vote if last vote exists else return Genesis block
-        return get_genesis_block(connection)
-
-    # Now the fun starts. Since the resolution of timestamp is a second,
-    # we might have more than one vote per timestamp. If this is the case
-    # then we need to rebuild the chain for the blocks that have been retrieved
-    # to get the last one.
-
-    # Given a block_id, mapping returns the id of the block pointing at it.
-    mapping = {v['vote']['previous_block']: v['vote']['voting_for_block']
-               for v in last_voted}
-
-    # Since we follow the chain backwards, we can start from a random
-    # point of the chain and "move up" from it.
-    last_block_id = list(mapping.values())[0]
-
-    # We must be sure to break the infinite loop. This happens when:
-    # - the block we are currenty iterating is the one we are looking for.
-    #   This will trigger a KeyError, breaking the loop
-    # - we are visiting again a node we already explored, hence there is
-    #   a loop. This might happen if a vote points both `previous_block`
-    #   and `voting_for_block` to the same `block_id`
-    explored = set()
-
-    while True:
-        try:
-            if last_block_id in explored:
-                raise exceptions.CyclicBlockchainError()
-            explored.add(last_block_id)
-            last_block_id = mapping[last_block_id]
-        except KeyError:
-            break
-
+def get_votes_by_pubkey(connection, node_pubkey):
     return connection.run(
-            r.table('bigchain', read_mode=READ_MODE)
-            .get(last_block_id))
+        r.table('votes', read_mode=READ_MODE)
+        .filter(r.row['node_pubkey'] == node_pubkey)
+        .order_by(r.desc(r.row['vote']['timestamp'])))
 
 
 @register_query(RethinkDBConnection)

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -1,3 +1,4 @@
+import itertools
 import random
 from time import time
 
@@ -568,9 +569,45 @@ class Bigchain(object):
         return backend.query.write_vote(self.connection, vote)
 
     def get_last_voted_block(self):
-        """Returns the last block that this node voted on."""
-
-        return Block.from_dict(backend.query.get_last_voted_block(self.connection, self.me))
+        """
+        Returns the last block that this node voted on,
+        or the GENESIS block if this node hasn't voted on anything yet.
+        """
+        # Get all votes with my PK ordered by timestamp in descending order
+        all_votes = backend.query.get_votes_by_pubkey(self.connection, self.me)
+        safe_votes = filter(self.consensus.voting.verify_vote_schema, all_votes)
+        # Now the fun starts. Since the resolution of timestamp is a second,
+        # we might have more than one vote per timestamp. If this is the case
+        # then we need to rebuild the chain for the blocks that have been retrieved
+        # to get the last one.
+        votes_by_ts = itertools.groupby(safe_votes, lambda v: v['vote']['timestamp'])
+        for _, votes in votes_by_ts:
+            votes = list(votes)
+            # Given a block_id, mapping returns the id of the block pointing at it.
+            mapping = {}
+            seen = set()
+            for vote in votes:
+                if self.consensus.voting.verify_vote_signature(vote):
+                    block_id = vote['vote']['voting_for_block']
+                    mapping[vote['vote']['previous_block']] = block_id
+            if mapping:
+                # Since we follow the chain backwards, we can start from a random
+                # point of the chain and "move up" from it.
+                while block_id in mapping:
+                    block_id = mapping[block_id]
+                    # We must be sure to break the infinite loop. This happens when:
+                    # - the block we are currenty iterating is the one we are looking for.
+                    #   This will trigger a KeyError, breaking the loop
+                    # - we are visiting again a node we already explored, hence there is
+                    #   a loop. This might happen if a vote points both `previous_block`
+                    #   and `voting_for_block` to the same `block_id`
+                    if block_id in seen:
+                        raise exceptions.CyclicBlockchainError()
+                    seen.add(block_id)
+                block = backend.query.get_block(self.connection, block_id)
+                return Block.from_dict(block)
+        # Didn't find a vote - return GENESIS block
+        return Block.from_dict(backend.query.get_genesis_block(self.connection))
 
     def get_unvoted_blocks(self):
         """Return all the blocks that have not been voted on by this node.

--- a/tests/backend/mongodb/test_queries.py
+++ b/tests/backend/mongodb/test_queries.py
@@ -366,7 +366,7 @@ def test_get_votes_by_pubkey(genesis_block, signed_create_tx, b):
     votes = []
 
     for i in times:
-        vote = b.vote('A', '0', True)
+        vote = b.vote('A' + str(i), '0', True)
         vote['vote']['timestamp'] = str(i)
         votes.append(vote.copy())
         conn.db.votes.insert_one(vote)

--- a/tests/backend/mongodb/test_queries.py
+++ b/tests/backend/mongodb/test_queries.py
@@ -350,31 +350,29 @@ def test_get_genesis_block(genesis_block):
     assert query.get_genesis_block(conn) == genesis_block.to_dict()
 
 
-def test_get_last_voted_block(genesis_block, signed_create_tx, b):
+def test_get_votes_by_pubkey(genesis_block, signed_create_tx, b):
     from bigchaindb.backend import connect, query
-    from bigchaindb.models import Block
-    from bigchaindb.common.exceptions import CyclicBlockchainError
     conn = connect()
 
-    # check that the last voted block is the genesis block
-    assert query.get_last_voted_block(conn, b.me) == genesis_block.to_dict()
+    def get_votes():
+        return list(query.get_votes_by_pubkey(conn, b.me))
 
-    # create and insert a new vote and block
-    block = Block(transactions=[signed_create_tx])
-    conn.db.bigchain.insert_one(block.to_dict())
-    vote = b.vote(block.id, genesis_block.id, True)
-    conn.db.votes.insert_one(vote)
+    assert get_votes() == []
 
-    assert query.get_last_voted_block(conn, b.me) == block.to_dict()
+    # Check that sort order is correct
+    # This relies on the timestamps being the same length,
+    # even though they are numbers.
+    times = [34, 24, 50, 42, 99]
+    votes = []
 
-    # force a bad chain
-    vote.pop('_id')
-    vote['vote']['voting_for_block'] = genesis_block.id
-    vote['vote']['previous_block'] = block.id
-    conn.db.votes.insert_one(vote)
+    for i in times:
+        vote = b.vote('A', '0', True)
+        vote['vote']['timestamp'] = str(i)
+        votes.append(vote.copy())
+        conn.db.votes.insert_one(vote)
 
-    with pytest.raises(CyclicBlockchainError):
-        query.get_last_voted_block(conn, b.me)
+    sorted_votes = [votes[times.index(i)] for i in sorted(times, reverse=True)]
+    assert get_votes() == sorted_votes
 
 
 def test_get_unvoted_blocks(signed_create_tx):

--- a/tests/backend/test_generics.py
+++ b/tests/backend/test_generics.py
@@ -30,7 +30,7 @@ def test_schema(schema_func_name, args_qty):
     ('write_block', 1),
     ('get_block', 1),
     ('write_vote', 1),
-    ('get_last_voted_block', 1),
+    ('get_votes_by_pubkey', 1),
     ('get_unvoted_blocks', 1),
     ('get_spent', 2),
     ('get_votes_by_block_id_and_voter', 2),


### PR DESCRIPTION
Currently it's unvalidated, so any node can confuse another node that's coming online.

This implementation also does not need to consider all the votes when finding the last voted block, since it works backwards from votes with the highest timestamp until it finds a good one.