### PR TITLE
New docs page about updating all the software on a BigchainDB node on Kubernetes

### DIFF
--- a/docs/server/source/cloud-deployment-templates/index.rst
+++ b/docs/server/source/cloud-deployment-templates/index.rst
@@ -16,3 +16,5 @@ If you find the cloud deployment templates for nodes helpful, then you may also 
    template-kubernetes-azure
    node-on-kubernetes
    add-node-on-kubernetes
+   upgrade-on-kubernetes
+   

--- a/docs/server/source/cloud-deployment-templates/upgrade-on-kubernetes.rst
+++ b/docs/server/source/cloud-deployment-templates/upgrade-on-kubernetes.rst
@@ -1,0 +1,105 @@
+Kubernetes Template: Upgrade all Software in a BigchainDB Node
+==============================================================
+
+This page outlines how to upgrade all the software associated
+with a BigchainDB node running on Kubernetes,
+including host operating systems, Docker, Kubernetes,
+and BigchainDB-related software.
+
+
+Upgrade Host OS, Docker and Kubernetes
+--------------------------------------
+
+Some Kubernetes installation & management systems
+can do full or partial upgrades of host OSes, Docker,
+or Kubernetes, e.g.
+`Tectonic <https://coreos.com/tectonic/>`_, 
+`Rancher <https://docs.rancher.com/rancher/v1.5/en/>`_,
+and 
+`Kubo <https://pivotal.io/kubo>`_.
+Consult the documentation for your system.
+
+**Azure Container Service (ACS).**
+On Dec. 15, 2016, a Microsoft employee
+`wrote <https://github.com/colemickens/azure-kubernetes-status/issues/15#issuecomment-267453251>`_:
+"In the coming months we [the Azure Kubernetes team] will be building managed updates in the ACS service."
+At the time of writing, managed updates were not yet available,
+but you should check the latest
+`ACS documentation <https://docs.microsoft.com/en-us/azure/container-service/>`_
+to see what's available now.
+Also at the time of writing, ACS only supported Ubuntu
+as the host (master and agent) operating system.
+You can upgrade Ubuntu and Docker on Azure
+by SSHing into each of the hosts,
+as documented on 
+:ref:`another page <Optional: SSH to Your New Kubernetes Cluster Nodes>`.
+
+In general, you can SSH to each host in your Kubernetes Cluster
+to update the OS and Docker.
+
+.. note::
+
+   Once you are in an SSH session with a host,
+   the ``docker info`` command is a handy way to detemine the
+   host OS (including version) and the Docker version.
+
+When you want to upgrade the software on a Kubernetes node,
+you should "drain" the node first,
+i.e. tell Kubernetes to gracefully terminate all pods
+on the node and mark it as unscheduleable
+(so no new pods get put on the node during its downtime).
+
+.. code::
+
+   kubectl drain $NODENAME
+
+There are `more details in the Kubernetes docs <https://kubernetes.io/docs/admin/cluster-management/#maintenance-on-a-node>`_,
+including instructions to make the node scheduleable again.
+
+To manually upgrade the host OS,
+see the docs for that OS.
+
+To manually upgrade Docker, see
+`the Docker docs <https://docs.docker.com/>`_.
+
+To manually upgrade all Kubernetes software in your Kubernetes cluster, see
+`the Kubernetes docs <https://kubernetes.io/docs/admin/cluster-management/>`_.
+
+
+Upgrade BigchainDB-Related Software
+-----------------------------------
+
+We use Kubernetes "Deployments" for NGINX, BigchainDB,
+and most other BigchainDB-related software.
+The only exception is MongoDB; we use a Kubernetes
+StatefulSet for that.
+
+The nice thing about Kubernetes Deployments
+is that Kubernetes can manage most of the upgrade process.
+A typical upgrade workflow for a single Deployment would be:
+
+.. code::
+
+   $ KUBE_EDITOR=nano kubectl edit deployment/<name of Deployment>
+
+The `kubectl edit <https://kubernetes.io/docs/user-guide/kubectl/kubectl_edit/>`_ 
+command opens the specified editor (nano in the above example),
+allowing you to edit the specified Deployment *in the Kubernetes cluster*.
+You can change the version tag on the Docker image, for example. 
+Don't forget to save your edits before exiting the editor.
+The Kubernetes docs have more information about
+`updating a Deployment <https://kubernetes.io/docs/user-guide/deployments/#updating-a-deployment>`_.
+
+
+The upgrade story for the MongoDB StatefulSet is *different*.
+(This is because MongoDB has persistent state,
+which is stored in some storage associated with a PersistentVolumeClaim.)
+At the time of writing, StatefulSets were still in beta,
+and they did not support automated image upgrade (Docker image tag upgrade).
+We expect that to change.
+Rather than trying to keep these docs up-to-date,
+we advise you to check out the current
+`Kubernetes docs about updating containers in StatefulSets
+<https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-containers>`_.
+
+


### PR DESCRIPTION
This is a first draft of some documentation about how to update all the software associated with a BigchaindB node running on Kubernetes, including:

- the host operating systems
- Docker
- Kubernetes
- BigchainDB-related software

As with all these BDB-node-on-Kubernetes docs, I expect they'll eventually be moved out of this section to some docs about Production BigchainDB Node Administration. 