### PR TITLE
Advertise Event API support

### DIFF
--- a/bigchaindb/web/views/base.py
+++ b/bigchaindb/web/views/base.py
@@ -21,3 +21,8 @@ def make_error(status_code, message=None):
 def base_url():
     return '%s://%s/' % (request.environ['wsgi.url_scheme'],
                          request.environ['HTTP_HOST'])
+
+
+def base_ws_uri():
+    """Base websocket uri."""
+    return '%s://%s/' % ('ws', request.environ['HTTP_HOST'])

--- a/bigchaindb/web/views/info.py
+++ b/bigchaindb/web/views/info.py
@@ -4,7 +4,7 @@ import flask
 from flask_restful import Resource
 
 import bigchaindb
-from bigchaindb.web.views.base import base_url
+from bigchaindb.web.views.base import base_url, base_ws_uri
 from bigchaindb import version
 
 
@@ -30,16 +30,19 @@ class RootIndex(Resource):
 class ApiV1Index(Resource):
     def get(self):
         api_root = base_url() + 'api/v1/'
+        websocket_root = base_ws_uri() + 'api/v1/'
         docs_url = [
             'https://docs.bigchaindb.com/projects/server/en/v',
             version.__version__,
             '/drivers-clients/http-client-server-api.html',
         ]
-        return {
+        return flask.jsonify({
             '_links': {
                 'docs': ''.join(docs_url),
                 'self': api_root,
                 'statuses': api_root + 'statuses/',
                 'transactions': api_root + 'transactions/',
+                # TODO: The version should probably not be hardcoded
+                'streams_v1': websocket_root + 'streams/',
             },
-        }
+        })

--- a/tests/web/test_info.py
+++ b/tests/web/test_info.py
@@ -31,5 +31,6 @@ def test_api_v1_endpoint(client):
             'self': 'http://localhost/api/v1/',
             'statuses': 'http://localhost/api/v1/statuses/',
             'transactions': 'http://localhost/api/v1/transactions/',
+            'streams_v1': 'ws://localhost/api/v1/streams/',
         }
     }


### PR DESCRIPTION
This pr adds information to the api info endpoint about the streams of the event api.

```json
{
  "_links": {
    "docs": "https://docs.bigchaindb.com/projects/server/en/v0.10.0.dev/drivers-clients/http-client-server-api.html", 
    "self": "http://127.0.0.1:9984/api/v1/", 
    "statuses": "http://127.0.0.1:9984/api/v1/statuses/", 
    "streams_v1": "ws://127.0.0.1:9984/api/v1/streams/", 
    "transactions": "http://127.0.0.1:9984/api/v1/transactions/"
  }
}

```