### PR TITLE
Add a new exception for MongoDB Authentication errors

### DIFF
--- a/bigchaindb/backend/exceptions.py
+++ b/bigchaindb/backend/exceptions.py
@@ -9,6 +9,10 @@ class ConnectionError(BackendError):
     """Exception raised when the connection to the backend fails."""
 
 
+class AuthenticationError(ConnectionError):
+    """Exception raised when MongoDB Authentication fails"""
+
+
 class OperationError(BackendError):
     """Exception raised when a backend operation fails."""
 

--- a/bigchaindb/backend/mongodb/connection.py
+++ b/bigchaindb/backend/mongodb/connection.py
@@ -8,7 +8,8 @@ from bigchaindb.utils import Lazy
 from bigchaindb.common.exceptions import ConfigurationError
 from bigchaindb.backend.exceptions import (DuplicateKeyError,
                                            OperationError,
-                                           ConnectionError)
+                                           ConnectionError,
+                                           AuthenticationError)
 from bigchaindb.backend.connection import Connection
 
 logger = logging.getLogger(__name__)
@@ -83,6 +84,8 @@ class MongoDBConnection(Connection):
         # `initialize_replica_set` might raise `ConnectionFailure` or `OperationFailure`.
         except (pymongo.errors.ConnectionFailure,
                 pymongo.errors.OperationFailure) as exc:
+            if "Authentication fail" in str(exc):
+                raise AuthenticationError() from exc
             raise ConnectionError() from exc
 
 


### PR DESCRIPTION
Fixes issue #1336 

Have used 'Authentication fail' as the comparison string for authentication failure so that we are able to handle both 'Authentication failed' and 'Authentication failure' error messages.
Also, was thinking of comparing the strings ignoring the case so that if mongo changes their return text to Authentication Fail, it still works. Should we do that or does it seem unnecessary?
