### PR TITLE
Fixed documentation about transactions endpoint.

### DIFF
--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -46,8 +46,10 @@ Transactions
 
    Get the transaction with the ID ``tx_id``.
 
-   This endpoint returns a transaction only if a ``VALID`` block on
-   ``bigchain`` exists.
+   This endpoint returns a transaction if it was included in a ``VALID`` block,
+   if it is still waiting to be processed ``BACKLOG`` or is still in an
+   undecided block ``UNDECIDED``. BigchainDB does not keep state about invalid
+   transactions. A request to an invalid transaction will return a ``404 Not Found``.
 
    :param tx_id: transaction ID
    :type tx_id: hex string

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -49,8 +49,9 @@ Transactions
    This endpoint returns a transaction if it was included in a ``VALID`` block,
    if it is still waiting to be processed (``BACKLOG``) or is still in an
    undecided block (``UNDECIDED``). All instances of a transaction in invalid
-   blocks are ignored and treated as if they don't exist. A request to an
-   invalid transaction will return a ``404 Not Found``.
+   blocks are ignored and treated as if they don't exist. If a request is made
+   for a transaction and instances of that transaction are found only in
+   invalid blocks, then the response will be ``404 Not Found``.
 
    :param tx_id: transaction ID
    :type tx_id: hex string

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -47,9 +47,10 @@ Transactions
    Get the transaction with the ID ``tx_id``.
 
    This endpoint returns a transaction if it was included in a ``VALID`` block,
-   if it is still waiting to be processed ``BACKLOG`` or is still in an
-   undecided block ``UNDECIDED``. BigchainDB does not keep state about invalid
-   transactions. A request to an invalid transaction will return a ``404 Not Found``.
+   if it is still waiting to be processed (``BACKLOG``) or is still in an
+   undecided block (``UNDECIDED``). All instances of a transaction in invalid
+   blocks are ignored and treated as if they don't exist. A request to an
+   invalid transaction will return a ``404 Not Found``.
 
    :param tx_id: transaction ID
    :type tx_id: hex string


### PR DESCRIPTION
relates to #1038 

The `/transactions` endpoint says that a transaction is returned if it was included in a valid block. This is not true. A transaction is returned as long as it was not included in an invalid block.

So this enpoint will return a transaction as long as it is in the `UNDECIDED`, `BACKLOG` and `VALID` state.