### PR TITLE
Travis adjust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,17 @@ env:
 matrix:
   fast_finish: true
   exclude:
-  - python: 3.4 
+  - python: 3.4
     env: TOXENV=flake8 
-  - python: 3.4 
+  - python: 3.4
     env: TOXENV=docsroot
-  - python: 3.4 
+  - python: 3.4
+    env: TOXENV=docsserver
+  - python: 3.5
+    env: TOXENV=flake8 
+  - python: 3.5 
+    env: TOXENV=docsroot
+  - python: 3.5 
     env: TOXENV=docsserver
   include:
   - python: 3.4

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist = true
 envlist = py{34,35,36}-{rethinkdb,mongodb}, flake8, docsroot, docsserver
 
 [base]
-basepython = python3.5
+basepython = python3.6
 deps = pip>=9.0.1   
 
 [testenv]


### PR DESCRIPTION
As we added Python 3.6 to the matrix we had forgotten to exclude it for the docs and flake8. This PR swaps it around, making Python 3.6 the version to test the docs and run flake8.