### PR TITLE
Treat --log-level argument as case-insensitive

### DIFF
--- a/bigchaindb/commands/utils.py
+++ b/bigchaindb/commands/utils.py
@@ -198,7 +198,7 @@ base_parser.add_argument('-c', '--config',
                               '(use "-" for stdout)')
 
 base_parser.add_argument('-l', '--log-level',
-                         type=lambda l: l.upper(),  # case insensitive conversion
+                         type=str.upper  # convert to uppercase for comparison to choices
                          choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                          default='INFO',
                          help='Log level')

--- a/bigchaindb/commands/utils.py
+++ b/bigchaindb/commands/utils.py
@@ -198,7 +198,7 @@ base_parser.add_argument('-c', '--config',
                               '(use "-" for stdout)')
 
 base_parser.add_argument('-l', '--log-level',
-                         type=str.upper  # convert to uppercase for comparison to choices
+                         type=str.upper, # convert to uppercase for comparison to choices
                          choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                          default='INFO',
                          help='Log level')

--- a/bigchaindb/commands/utils.py
+++ b/bigchaindb/commands/utils.py
@@ -198,6 +198,7 @@ base_parser.add_argument('-c', '--config',
                               '(use "-" for stdout)')
 
 base_parser.add_argument('-l', '--log-level',
+                         type=lambda l: l.upper(),  # case insensitive conversion
                          choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                          default='INFO',
                          help='Log level')

--- a/bigchaindb/commands/utils.py
+++ b/bigchaindb/commands/utils.py
@@ -198,7 +198,7 @@ base_parser.add_argument('-c', '--config',
                               '(use "-" for stdout)')
 
 base_parser.add_argument('-l', '--log-level',
-                         type=str.upper, # convert to uppercase for comparison to choices
+                         type=str.upper,  # convert to uppercase for comparison to choices
                          choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                          default='INFO',
                          help='Log level')


### PR DESCRIPTION
Resolves #1316 

`ArgumentParser.add_argument` takes a callable in the `type` kwarg, which we exploit to uppercase the log level name before it's checked against `choices`