### PR TITLE
Local block_results table

### DIFF
--- a/bigchaindb/backend/mongodb/connection.py
+++ b/bigchaindb/backend/mongodb/connection.py
@@ -85,6 +85,10 @@ class MongoDBConnection(Connection):
                 pymongo.errors.OperationFailure) as exc:
             raise ConnectionError() from exc
 
+    def get_local_collection(self, name):
+        """Return a namespaced local collection"""
+        return self.conn.local[self.dbname + '_' + name]
+
 
 def initialize_replica_set(host, port, connection_timeout):
     """Initialize a replica set. If already initialized skip."""

--- a/bigchaindb/backend/mongodb/query.py
+++ b/bigchaindb/backend/mongodb/query.py
@@ -304,20 +304,13 @@ def get_unvoted_blocks(conn, node_pubkey):
 
 
 @register_query(MongoDBConnection)
-def get_last_cached_block_result(conn):
-    return _unid('block_id',
-                 conn.get_local_collection('block_results')
-                 .find_one(sort=[('height', -1)]))
-
-
-@register_query(MongoDBConnection)
-def insert_cached_block_result(conn, result):
+def insert_block_result(conn, result):
     return (conn.get_local_collection('block_results')
             .insert_one(_id('block_id', result)))
 
 
 @register_query(MongoDBConnection)
-def get_cached_block_result(conn, block_id):
+def get_block_result(conn, block_id):
     return _unid('block_id',
                  conn.get_local_collection('block_results')
                  .find_one({'_id': block_id}))

--- a/bigchaindb/backend/mongodb/query.py
+++ b/bigchaindb/backend/mongodb/query.py
@@ -301,3 +301,20 @@ def get_unvoted_blocks(conn, node_pubkey):
                 'votes': False, '_id': False
             }}
         ]))
+
+
+@register_query(MongoDBConnection)
+def get_last_cached_block_result(conn):
+    return (conn.get_local_collection('block_results')
+            .find_one(sort=[('height', -1)], projection={'_id': False}))
+
+
+@register_query(MongoDBConnection)
+def insert_cached_block_result(conn, result):
+    return conn.get_local_collection('block_results').insert_one(result.copy())
+
+
+@register_query(MongoDBConnection)
+def get_cached_block_result(conn, block_id):
+    return (conn.get_local_collection('block_results')
+            .find_one({'block_id': block_id}, projection={'_id': False}))

--- a/bigchaindb/backend/mongodb/query.py
+++ b/bigchaindb/backend/mongodb/query.py
@@ -305,16 +305,33 @@ def get_unvoted_blocks(conn, node_pubkey):
 
 @register_query(MongoDBConnection)
 def get_last_cached_block_result(conn):
-    return (conn.get_local_collection('block_results')
-            .find_one(sort=[('height', -1)], projection={'_id': False}))
+    return _unid('block_id',
+                 conn.get_local_collection('block_results')
+                 .find_one(sort=[('height', -1)]))
 
 
 @register_query(MongoDBConnection)
 def insert_cached_block_result(conn, result):
-    return conn.get_local_collection('block_results').insert_one(result.copy())
+    return (conn.get_local_collection('block_results')
+            .insert_one(_id('block_id', result)))
 
 
 @register_query(MongoDBConnection)
 def get_cached_block_result(conn, block_id):
-    return (conn.get_local_collection('block_results')
-            .find_one({'block_id': block_id}, projection={'_id': False}))
+    return _unid('block_id',
+                 conn.get_local_collection('block_results')
+                 .find_one({'_id': block_id}))
+
+
+def _id(key, record):
+    r = record.copy()
+    r['_id'] = r[key]
+    del r[key]
+    return r
+
+
+def _unid(key, record):
+    if record:
+        record[key] = record['_id']
+        del record['_id']
+        return record

--- a/bigchaindb/backend/mongodb/schema.py
+++ b/bigchaindb/backend/mongodb/schema.py
@@ -42,7 +42,6 @@ def create_indexes(conn, dbname):
     create_bigchain_secondary_index(conn, dbname)
     create_backlog_secondary_index(conn, dbname)
     create_votes_secondary_index(conn, dbname)
-    create_block_results_secondary_indexes(conn, dbname)
 
 
 @register_schema(MongoDBConnection)
@@ -107,9 +106,3 @@ def create_votes_secondary_index(conn, dbname):
                                               ASCENDING)],
                                             name='block_and_voter',
                                             unique=True)
-
-
-def create_block_results_secondary_indexes(conn, dbname):
-    logger.info('create `block_results` secondary index.')
-    collection = conn.get_local_collection('block_results')
-    collection.create_index([('height', DESCENDING)], name='height', unique=True)

--- a/bigchaindb/backend/mongodb/schema.py
+++ b/bigchaindb/backend/mongodb/schema.py
@@ -112,5 +112,4 @@ def create_votes_secondary_index(conn, dbname):
 def create_block_results_secondary_indexes(conn, dbname):
     logger.info('create `block_results` secondary index.')
     collection = conn.get_local_collection('block_results')
-    collection.create_index('block_id', name='block_id', unique=True)
     collection.create_index([('height', DESCENDING)], name='height', unique=True)

--- a/bigchaindb/backend/query.py
+++ b/bigchaindb/backend/query.py
@@ -301,7 +301,7 @@ def get_txids_filtered(connection, asset_id, operation=None):
 
 
 @singledispatch
-def get_cached_block_result(connection, block_id):
+def get_block_result(connection, block_id):
     """
     Return cached block result, if it's there.
 
@@ -313,10 +313,8 @@ def get_cached_block_result(connection, block_id):
 
 
 @singledispatch
-def get_last_cached_block_result(connection):
-    raise NotImplementedError
-
-
-@singledispatch
-def insert_cached_block_result(connection, result):
+def insert_block_result(connection, result):
+    """
+    Insert a block validation result
+    """
     raise NotImplementedError

--- a/bigchaindb/backend/query.py
+++ b/bigchaindb/backend/query.py
@@ -298,3 +298,25 @@ def get_txids_filtered(connection, asset_id, operation=None):
     """
 
     raise NotImplementedError
+
+
+@singledispatch
+def get_cached_block_result(connection, block_id):
+    """
+    Return cached block result, if it's there.
+
+    Args:
+        block_id (str): ID of block
+    """
+
+    raise NotImplementedError
+
+
+@singledispatch
+def get_last_cached_block_result(connection):
+    raise NotImplementedError
+
+
+@singledispatch
+def insert_cached_block_result(connection, result):
+    raise NotImplementedError

--- a/bigchaindb/backend/rethinkdb/connection.py
+++ b/bigchaindb/backend/rethinkdb/connection.py
@@ -43,3 +43,17 @@ class RethinkDBConnection(Connection):
             return r.connect(host=self.host, port=self.port, db=self.dbname)
         except r.ReqlDriverError as exc:
             raise ConnectionError from exc
+
+    @property
+    def local_table_suffix(self):
+        """Get local table suffix"""
+        if not RethinkDBConnection._LOCAL_TABLE_SUFFIX:
+            suffix = self.conn.server()['id'].replace('-', '_')
+            RethinkDBConnection._LOCAL_TABLE_SUFFIX = suffix
+        return RethinkDBConnection._LOCAL_TABLE_SUFFIX
+
+    _LOCAL_TABLE_SUFFIX = None
+
+    def local_table(self, name):
+        """Namespace a table to local db server"""
+        return '%s_%s' % (name, self.local_table_suffix)

--- a/bigchaindb/backend/rethinkdb/query.py
+++ b/bigchaindb/backend/rethinkdb/query.py
@@ -256,27 +256,13 @@ def get_unvoted_blocks(connection, node_pubkey):
 
 
 @register_query(RethinkDBConnection)
-def get_last_cached_block_result(connection):
-    try:
-        return connection.run(
-                r.table('block_results', read_mode=READ_MODE)
-                .order_by(r.desc(r.row['height']))
-                .nth(0))
-    except r.ReqlNonExistenceError:
-        pass
+def insert_block_result(connection, result):
+    return connection.run(r.table('block_results').insert(result.copy()))
 
 
 @register_query(RethinkDBConnection)
-def insert_cached_block_result(connection, result):
-    return connection.run(
-            r.table('block_results').insert(result.copy()))
-
-
-@register_query(RethinkDBConnection)
-def get_cached_block_result(connection, block_id):
+def get_block_result(connection, block_id):
     try:
-        return connection.run(
-                r.table('block_results')
-                .get(block_id))
+        return connection.run(r.table('block_results').get(block_id))
     except r.ReqlNonExistenceError:
         pass

--- a/bigchaindb/backend/rethinkdb/query.py
+++ b/bigchaindb/backend/rethinkdb/query.py
@@ -257,12 +257,14 @@ def get_unvoted_blocks(connection, node_pubkey):
 
 @register_query(RethinkDBConnection)
 def insert_block_result(connection, result):
-    return connection.run(r.table('block_results').insert(result.copy()))
+    table = connection.local_table('block_results')
+    return connection.run(r.table(table).insert(result.copy()))
 
 
 @register_query(RethinkDBConnection)
 def get_block_result(connection, block_id):
+    table = connection.local_table('block_results')
     try:
-        return connection.run(r.table('block_results').get(block_id))
+        return connection.run(r.table(table).get(block_id))
     except r.ReqlNonExistenceError:
         pass

--- a/bigchaindb/backend/rethinkdb/query.py
+++ b/bigchaindb/backend/rethinkdb/query.py
@@ -261,7 +261,6 @@ def get_last_cached_block_result(connection):
         return connection.run(
                 r.table('block_results', read_mode=READ_MODE)
                 .order_by(r.desc(r.row['height']))
-                .without('id')
                 .nth(0))
     except r.ReqlNonExistenceError:
         pass
@@ -278,8 +277,6 @@ def get_cached_block_result(connection, block_id):
     try:
         return connection.run(
                 r.table('block_results')
-                .get_all(block_id, index='block_id')
-                .without('id')
-                .nth(0))
+                .get(block_id))
     except r.ReqlNonExistenceError:
         pass

--- a/bigchaindb/backend/rethinkdb/query.py
+++ b/bigchaindb/backend/rethinkdb/query.py
@@ -264,7 +264,4 @@ def insert_block_result(connection, result):
 @register_query(RethinkDBConnection)
 def get_block_result(connection, block_id):
     table = connection.local_table('block_results')
-    try:
-        return connection.run(r.table(table).get(block_id))
-    except r.ReqlNonExistenceError:
-        pass
+    return connection.run(r.table(table).get(block_id))

--- a/bigchaindb/backend/rethinkdb/schema.py
+++ b/bigchaindb/backend/rethinkdb/schema.py
@@ -23,7 +23,7 @@ def create_database(connection, dbname):
 
 @register_schema(RethinkDBConnection)
 def create_tables(connection, dbname):
-    for table_name in ['bigchain', 'backlog', 'votes']:
+    for table_name in ['bigchain', 'backlog', 'votes', 'block_results']:
         logger.info('Create `%s` table.', table_name)
         connection.run(r.db(dbname).table_create(table_name))
 
@@ -33,6 +33,7 @@ def create_indexes(connection, dbname):
     create_bigchain_secondary_index(connection, dbname)
     create_backlog_secondary_index(connection, dbname)
     create_votes_secondary_index(connection, dbname)
+    create_block_results_secondary_indexes(connection, dbname)
 
 
 @register_schema(RethinkDBConnection)
@@ -127,4 +128,24 @@ def create_votes_secondary_index(connection, dbname):
     connection.run(
         r.db(dbname)
         .table('votes')
+        .index_wait())
+
+
+def create_block_results_secondary_indexes(connection, dbname):
+    logger.info('Create `block_results` secondary indexes.')
+
+    connection.run(
+        r.db(dbname)
+        .table('block_results')
+        .index_create('block_id', r.row['block_id']))
+
+    connection.run(
+        r.db(dbname)
+        .table('block_results')
+        .index_create('height', r.row['height']))
+
+    # wait for rethinkdb to finish creating secondary indexes
+    connection.run(
+        r.db(dbname)
+        .table('block_results')
         .index_wait())

--- a/bigchaindb/backend/rethinkdb/schema.py
+++ b/bigchaindb/backend/rethinkdb/schema.py
@@ -35,7 +35,6 @@ def create_indexes(connection, dbname):
     create_bigchain_secondary_index(connection, dbname)
     create_backlog_secondary_index(connection, dbname)
     create_votes_secondary_index(connection, dbname)
-    create_block_results_secondary_indexes(connection, dbname)
 
 
 @register_schema(RethinkDBConnection)
@@ -130,19 +129,4 @@ def create_votes_secondary_index(connection, dbname):
     connection.run(
         r.db(dbname)
         .table('votes')
-        .index_wait())
-
-
-def create_block_results_secondary_indexes(connection, dbname):
-    logger.info('Create `block_results` secondary indexes.')
-
-    connection.run(
-        r.db(dbname)
-        .table('block_results')
-        .index_create('height', r.row['height']))
-
-    # wait for rethinkdb to finish creating secondary indexes
-    connection.run(
-        r.db(dbname)
-        .table('block_results')
         .index_wait())

--- a/bigchaindb/backend/rethinkdb/schema.py
+++ b/bigchaindb/backend/rethinkdb/schema.py
@@ -27,7 +27,9 @@ def create_tables(connection, dbname):
         logger.info('Create `%s` table.', table_name)
         connection.run(r.db(dbname).table_create(table_name))
 
-    connection.run(r.db(dbname).table_create('block_results', primary_key='block_id'))
+    table_name = connection.local_table('block_results')
+    connection.run(r.db(dbname).table_create(table_name,
+                                             primary_key='block_id'))
 
 
 @register_schema(RethinkDBConnection)

--- a/bigchaindb/backend/rethinkdb/schema.py
+++ b/bigchaindb/backend/rethinkdb/schema.py
@@ -23,9 +23,11 @@ def create_database(connection, dbname):
 
 @register_schema(RethinkDBConnection)
 def create_tables(connection, dbname):
-    for table_name in ['bigchain', 'backlog', 'votes', 'block_results']:
+    for table_name in ['bigchain', 'backlog', 'votes']:
         logger.info('Create `%s` table.', table_name)
         connection.run(r.db(dbname).table_create(table_name))
+
+    connection.run(r.db(dbname).table_create('block_results', primary_key='block_id'))
 
 
 @register_schema(RethinkDBConnection)
@@ -133,11 +135,6 @@ def create_votes_secondary_index(connection, dbname):
 
 def create_block_results_secondary_indexes(connection, dbname):
     logger.info('Create `block_results` secondary indexes.')
-
-    connection.run(
-        r.db(dbname)
-        .table('block_results')
-        .index_create('block_id', r.row['block_id']))
 
     connection.run(
         r.db(dbname)

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -595,24 +595,15 @@ class Bigchain(object):
            valid, invalid, or undecided."""
         return self.block_election(block)['status']
 
-    def get_cached_block_result(self, block_id):
+    def get_block_result(self, block_id):
         """ Get a cached block result """
-        return backend.query.get_cached_block_result(self.connection, block_id)
+        return backend.query.get_block_result(self.connection, block_id)
 
-    def insert_cached_block_result(self, block_id, result):
+    def insert_block_result(self, block_id, result):
         """ Insert a block result """
-        last = backend.query.get_last_cached_block_result(self.connection)
-        height = 0
-        last_chain = ''
-        if last:
-            height = last['height'] + 1
-            last_chain = last['chain_hash']
-        chain = crypto.hash_data(last_chain + block_id)
         result = {
             'block_id': block_id,
-            'height': height,
-            'chain_hash': chain,
             'timestamp': gen_timestamp(),
             'result': result,
         }
-        backend.query.insert_cached_block_result(self.connection, result)
+        backend.query.insert_block_result(self.connection, result)

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -583,8 +583,6 @@ class Bigchain(object):
         return backend.query.get_unvoted_blocks(self.connection, self.me)
 
     def block_election(self, block):
-        if type(block) != dict:
-            block = block.to_dict()
         votes = list(backend.query.get_votes_by_block_id(self.connection,
                                                          block['id']))
         return self.consensus.voting.block_election(block, votes,
@@ -593,7 +591,15 @@ class Bigchain(object):
     def block_election_status(self, block):
         """Tally the votes on a block, and return the status:
            valid, invalid, or undecided."""
-        return self.block_election(block)['status']
+        if type(block) != dict:
+            block = block.to_dict()
+        result = self.get_block_result(block['id'])
+        if result is not None:
+            return self.BLOCK_VALID if result['result'] else self.BLOCK_INVALID
+        status = self.block_election(block)['status']
+        if status != self.BLOCK_UNDECIDED:
+            self.insert_block_result(block['id'], status == self.BLOCK_VALID)
+        return status
 
     def get_block_result(self, block_id):
         """ Get a cached block result """

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -594,3 +594,25 @@ class Bigchain(object):
         """Tally the votes on a block, and return the status:
            valid, invalid, or undecided."""
         return self.block_election(block)['status']
+
+    def get_cached_block_result(self, block_id):
+        """ Get a cached block result """
+        return backend.query.get_cached_block_result(self.connection, block_id)
+
+    def insert_cached_block_result(self, block_id, result):
+        """ Insert a block result """
+        last = backend.query.get_last_cached_block_result(self.connection)
+        height = 0
+        last_chain = ''
+        if last:
+            height = last['height'] + 1
+            last_chain = last['chain_hash']
+        chain = crypto.hash_data(last_chain + block_id)
+        result = {
+            'block_id': block_id,
+            'height': height,
+            'chain_hash': chain,
+            'timestamp': gen_timestamp(),
+            'result': result,
+        }
+        backend.query.insert_cached_block_result(self.connection, result)

--- a/tests/backend/mongodb/test_queries.py
+++ b/tests/backend/mongodb/test_queries.py
@@ -424,8 +424,7 @@ def test_block_result_queries():
     conn = connect()
     a = {'block_id': 'xa', 'height': 1}
     b = {'block_id': 'xb', 'height': 0}
-    query.insert_cached_block_result(conn, a)
-    query.insert_cached_block_result(conn, b)
-    assert query.get_cached_block_result(conn, 'xc') is None
-    assert query.get_cached_block_result(conn, 'xb') == b
-    assert query.get_last_cached_block_result(conn) == a
+    query.insert_block_result(conn, a)
+    query.insert_block_result(conn, b)
+    assert query.get_block_result(conn, 'xc') is None
+    assert query.get_block_result(conn, 'xb') == b

--- a/tests/backend/mongodb/test_queries.py
+++ b/tests/backend/mongodb/test_queries.py
@@ -417,3 +417,15 @@ def test_get_txids_filtered(signed_create_tx, signed_transfer_tx):
     # Test get by asset and TRANSFER
     txids = set(query.get_txids_filtered(conn, asset_id, Transaction.TRANSFER))
     assert txids == {signed_transfer_tx.id}
+
+
+def test_block_result_queries():
+    from bigchaindb.backend import connect, query
+    conn = connect()
+    a = {'block_id': 'xa', 'height': 1}
+    b = {'block_id': 'xb', 'height': 0}
+    query.insert_cached_block_result(conn, a)
+    query.insert_cached_block_result(conn, b)
+    assert query.get_cached_block_result(conn, 'xc') is None
+    assert query.get_cached_block_result(conn, 'xb') == b
+    assert query.get_last_cached_block_result(conn) == a

--- a/tests/backend/mongodb/test_schema.py
+++ b/tests/backend/mongodb/test_schema.py
@@ -13,7 +13,7 @@ def test_init_creates_db_tables_and_indexes():
     dbname = bigchaindb.config['database']['name']
 
     # the db is set up by the fixture so we need to remove it
-    conn.conn.drop_database(dbname)
+    _drop(conn, dbname)
 
     init_database()
 
@@ -57,12 +57,14 @@ def test_create_tables():
     dbname = bigchaindb.config['database']['name']
 
     # The db is set up by the fixtures so we need to remove it
-    conn.conn.drop_database(dbname)
+    _drop(conn, dbname)
     schema.create_database(conn, dbname)
     schema.create_tables(conn, dbname)
 
     collection_names = conn.conn[dbname].collection_names()
     assert sorted(collection_names) == ['backlog', 'bigchain', 'votes']
+
+    assert (dbname + '_block_results') in conn.conn.local.collection_names()
 
 
 def test_create_secondary_indexes():
@@ -74,7 +76,7 @@ def test_create_secondary_indexes():
     dbname = bigchaindb.config['database']['name']
 
     # The db is set up by the fixtures so we need to remove it
-    conn.conn.drop_database(dbname)
+    _drop(conn, dbname)
     schema.create_database(conn, dbname)
     schema.create_tables(conn, dbname)
     schema.create_indexes(conn, dbname)
@@ -92,6 +94,11 @@ def test_create_secondary_indexes():
     # Votes table
     indexes = conn.conn[dbname]['votes'].index_information().keys()
     assert sorted(indexes) == ['_id_', 'block_and_voter']
+
+
+def _drop(conn, dbname):
+    conn.conn.drop_database(dbname)
+    conn.get_local_collection('block_results').drop()
 
 
 def test_drop(dummy_db):

--- a/tests/backend/rethinkdb/test_schema.py
+++ b/tests/backend/rethinkdb/test_schema.py
@@ -97,8 +97,8 @@ def test_create_secondary_indexes():
         'block_and_voter')) is True
 
     # Block results table
-    assert (set(conn.run(r.db(dbname).table('block_results').index_list())) ==
-            {'height', 'block_id'})
+    assert (conn.run(r.db(dbname).table('block_results').index_list()) ==
+            ['height'])
 
 
 def test_drop(dummy_db):

--- a/tests/backend/rethinkdb/test_schema.py
+++ b/tests/backend/rethinkdb/test_schema.py
@@ -61,7 +61,8 @@ def test_create_tables():
     schema.create_tables(conn, dbname)
 
     assert (set(conn.run(r.db(dbname).table_list())) ==
-            {'backlog', 'bigchain', 'block_results', 'votes'})
+            {'backlog', 'bigchain', 'votes',
+             conn.local_table('block_results')})
 
 
 @pytest.mark.bdb
@@ -95,10 +96,6 @@ def test_create_secondary_indexes():
     # Votes table
     assert conn.run(r.db(dbname).table('votes').index_list().contains(
         'block_and_voter')) is True
-
-    # Block results table
-    assert (conn.run(r.db(dbname).table('block_results').index_list()) ==
-            ['height'])
 
 
 def test_drop(dummy_db):

--- a/tests/backend/rethinkdb/test_schema.py
+++ b/tests/backend/rethinkdb/test_schema.py
@@ -60,10 +60,8 @@ def test_create_tables():
     schema.create_database(conn, dbname)
     schema.create_tables(conn, dbname)
 
-    assert conn.run(r.db(dbname).table_list().contains('bigchain')) is True
-    assert conn.run(r.db(dbname).table_list().contains('backlog')) is True
-    assert conn.run(r.db(dbname).table_list().contains('votes')) is True
-    assert len(conn.run(r.db(dbname).table_list())) == 3
+    assert (set(conn.run(r.db(dbname).table_list())) ==
+            {'backlog', 'bigchain', 'block_results', 'votes'})
 
 
 @pytest.mark.bdb
@@ -97,6 +95,10 @@ def test_create_secondary_indexes():
     # Votes table
     assert conn.run(r.db(dbname).table('votes').index_list().contains(
         'block_and_voter')) is True
+
+    # Block results table
+    assert (set(conn.run(r.db(dbname).table('block_results').index_list())) ==
+            {'height', 'block_id'})
 
 
 def test_drop(dummy_db):

--- a/tests/backend/test_generics.py
+++ b/tests/backend/test_generics.py
@@ -36,6 +36,8 @@ def test_schema(schema_func_name, args_qty):
     ('get_votes_by_block_id_and_voter', 2),
     ('update_transaction', 2),
     ('get_transaction_from_block', 2),
+    ('insert_block_result', 1),
+    ('get_block_result', 1),
 ))
 def test_query(query_func_name, args_qty):
     from bigchaindb.backend import query

--- a/tests/backend/test_generics.py
+++ b/tests/backend/test_generics.py
@@ -80,3 +80,10 @@ def test_admin(admin_func_name, kwargs):
     admin_func = getattr(admin, admin_func_name)
     with raises(NotImplementedError):
         admin_func(None, **kwargs)
+
+
+def test_connection():
+    from bigchaindb.backend.connection import Connection
+
+    with raises(NotImplementedError):
+        Connection().run(None)

--- a/tests/db/test_block_result_cache.py
+++ b/tests/db/test_block_result_cache.py
@@ -23,3 +23,41 @@ def test_insert_block_result(b):
 @pytest.mark.bdb
 def test_get_block_result_nonexistant(b):
     assert b.get_block_result('cba') is None
+
+
+@pytest.mark.bdb
+def test_block_election_status_uses_result_cache(b):
+    with patch('bigchaindb.core.gen_timestamp') as gt:
+        gt.return_value = 12
+        b.insert_block_result('a', False)
+    assert b.block_election_status({'id': 'a'}) == b.BLOCK_INVALID
+
+
+@pytest.mark.bdb
+def test_block_election_status_caches_result_valid(b):
+    with patch.object(b, 'block_election') as block_election:
+        block_election.return_value = {'status': b.BLOCK_VALID}
+        assert b.block_election_status({'id': 'a'}) == b.BLOCK_VALID
+        assert b.block_election_status({'id': 'a'}) == b.BLOCK_VALID
+        assert block_election.call_count == 1
+    assert b.get_block_result('a')['result'] is True
+
+
+@pytest.mark.bdb
+def test_block_election_status_caches_result_invalid(b):
+    with patch.object(b, 'block_election') as block_election:
+        block_election.return_value = {'status': b.BLOCK_INVALID}
+        assert b.block_election_status({'id': 'a'}) == b.BLOCK_INVALID
+        assert b.block_election_status({'id': 'a'}) == b.BLOCK_INVALID
+        assert block_election.call_count == 1
+    assert b.get_block_result('a')['result'] is False
+
+
+@pytest.mark.bdb
+def test_block_election_status_caches_result_undecided(b):
+    with patch.object(b, 'block_election') as block_election:
+        block_election.return_value = {'status': b.BLOCK_UNDECIDED}
+        assert b.block_election_status({'id': 'a'}) == b.BLOCK_UNDECIDED
+        assert b.block_election_status({'id': 'a'}) == b.BLOCK_UNDECIDED
+        assert block_election.call_count == 2
+    assert b.get_block_result('a') is None

--- a/tests/db/test_block_result_cache.py
+++ b/tests/db/test_block_result_cache.py
@@ -1,0 +1,49 @@
+import pytest
+from bigchaindb.backend import query
+from bigchaindb.common.crypto import hash_data
+from unittest.mock import patch
+
+
+@pytest.mark.bdb
+def test_insert_block_result_first(b):
+    with patch('bigchaindb.core.gen_timestamp') as gt:
+        gt.return_value = 12
+        b.insert_cached_block_result('a', True)
+    assert query.get_cached_block_result(b.connection, 'a') == {
+        'block_id': 'a',
+        'chain_hash': hash_data('a'),
+        'height': 0,
+        'result': True,
+        'timestamp': 12,
+    }
+
+
+@pytest.mark.bdb
+def test_insert_block_result_nonfirst(b):
+    with patch('bigchaindb.core.gen_timestamp') as gt:
+        gt.return_value = 12
+        b.insert_cached_block_result('a', True)
+        b.insert_cached_block_result('b', True)
+    assert query.get_cached_block_result(b.connection, 'b') == {
+        'block_id': 'b',
+        'chain_hash': hash_data(hash_data('a') + 'b'),
+        'height': 1,
+        'result': True,
+        'timestamp': 12,
+    }
+
+
+@pytest.mark.bdb
+def test_get_last_cached_block_result(b):
+    with patch('bigchaindb.core.gen_timestamp') as gt:
+        gt.return_value = 12
+        b.insert_cached_block_result('c', True)
+        b.insert_cached_block_result('b', True)
+        b.insert_cached_block_result('a', True)
+    assert query.get_last_cached_block_result(b.connection) == {
+        'block_id': 'a',
+        'chain_hash': hash_data(hash_data(hash_data('c') + 'b') + 'a'),
+        'height': 2,
+        'result': True,
+        'timestamp': 12,
+    }

--- a/tests/db/test_block_result_cache.py
+++ b/tests/db/test_block_result_cache.py
@@ -1,28 +1,25 @@
 import pytest
-from bigchaindb.backend import query
 from unittest.mock import patch
 
 
 @pytest.mark.bdb
-def test_insert_block_result_first(b):
+def test_insert_block_result(b):
     with patch('bigchaindb.core.gen_timestamp') as gt:
         gt.return_value = 12
-        b.insert_block_result('a', True)
-    assert query.get_block_result(b.connection, 'a') == {
+        b.insert_block_result('a', False)
+        b.insert_block_result('b', True)
+    assert b.get_block_result('a') == {
         'block_id': 'a',
+        'result': False,
+        'timestamp': 12,
+    }
+    assert b.get_block_result('b') == {
+        'block_id': 'b',
         'result': True,
         'timestamp': 12,
     }
 
 
 @pytest.mark.bdb
-def test_insert_block_result_nonfirst(b):
-    with patch('bigchaindb.core.gen_timestamp') as gt:
-        gt.return_value = 12
-        b.insert_block_result('a', True)
-        b.insert_block_result('b', True)
-    assert query.get_block_result(b.connection, 'b') == {
-        'block_id': 'b',
-        'result': True,
-        'timestamp': 12,
-    }
+def test_get_block_result_nonexistant(b):
+    assert b.get_block_result('cba') is None

--- a/tests/db/test_block_result_cache.py
+++ b/tests/db/test_block_result_cache.py
@@ -1,6 +1,5 @@
 import pytest
 from bigchaindb.backend import query
-from bigchaindb.common.crypto import hash_data
 from unittest.mock import patch
 
 
@@ -8,11 +7,9 @@ from unittest.mock import patch
 def test_insert_block_result_first(b):
     with patch('bigchaindb.core.gen_timestamp') as gt:
         gt.return_value = 12
-        b.insert_cached_block_result('a', True)
-    assert query.get_cached_block_result(b.connection, 'a') == {
+        b.insert_block_result('a', True)
+    assert query.get_block_result(b.connection, 'a') == {
         'block_id': 'a',
-        'chain_hash': hash_data('a'),
-        'height': 0,
         'result': True,
         'timestamp': 12,
     }
@@ -22,28 +19,10 @@ def test_insert_block_result_first(b):
 def test_insert_block_result_nonfirst(b):
     with patch('bigchaindb.core.gen_timestamp') as gt:
         gt.return_value = 12
-        b.insert_cached_block_result('a', True)
-        b.insert_cached_block_result('b', True)
-    assert query.get_cached_block_result(b.connection, 'b') == {
+        b.insert_block_result('a', True)
+        b.insert_block_result('b', True)
+    assert query.get_block_result(b.connection, 'b') == {
         'block_id': 'b',
-        'chain_hash': hash_data(hash_data('a') + 'b'),
-        'height': 1,
-        'result': True,
-        'timestamp': 12,
-    }
-
-
-@pytest.mark.bdb
-def test_get_last_cached_block_result(b):
-    with patch('bigchaindb.core.gen_timestamp') as gt:
-        gt.return_value = 12
-        b.insert_cached_block_result('c', True)
-        b.insert_cached_block_result('b', True)
-        b.insert_cached_block_result('a', True)
-    assert query.get_last_cached_block_result(b.connection) == {
-        'block_id': 'a',
-        'chain_hash': hash_data(hash_data(hash_data('c') + 'b') + 'a'),
-        'height': 2,
         'result': True,
         'timestamp': 12,
     }

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,6 +32,7 @@ def flush_rethink_db(connection, dbname):
         connection.run(r.db(dbname).table('bigchain').delete())
         connection.run(r.db(dbname).table('backlog').delete())
         connection.run(r.db(dbname).table('votes').delete())
+        connection.run(r.db(dbname).table('block_results').delete())
     except r.ReqlOpFailedError:
         pass
 
@@ -41,6 +42,7 @@ def flush_mongo_db(connection, dbname):
     connection.conn[dbname].bigchain.delete_many({})
     connection.conn[dbname].backlog.delete_many({})
     connection.conn[dbname].votes.delete_many({})
+    connection.conn.local[dbname + '_block_results'].delete_many({})
 
 
 @singledispatch

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,7 +32,8 @@ def flush_rethink_db(connection, dbname):
         connection.run(r.db(dbname).table('bigchain').delete())
         connection.run(r.db(dbname).table('backlog').delete())
         connection.run(r.db(dbname).table('votes').delete())
-        connection.run(r.db(dbname).table('block_results').delete())
+        block_results = connection.local_table('block_results')
+        connection.run(r.db(dbname).table(block_results).delete())
     except r.ReqlOpFailedError:
         pass
 


### PR DESCRIPTION
This PR introduces a local block results table, and uses it to cache results of `Bigchain.block_election_status`.