### PR TITLE
block_order table + integration

### DIFF
--- a/bigchaindb/backend/mongodb/query.py
+++ b/bigchaindb/backend/mongodb/query.py
@@ -207,9 +207,7 @@ def get_votes_by_block_id_and_voter(conn, block_id, node_pubkey):
 
 @register_query(MongoDBConnection)
 def write_block(conn, block):
-    return conn.run(
-        conn.collection('bigchain')
-        .insert_one(block.to_dict()))
+    return conn.run(conn.collection('bigchain').insert_one(block.copy()))
 
 
 @register_query(MongoDBConnection)
@@ -301,3 +299,21 @@ def get_unvoted_blocks(conn, node_pubkey):
                 'votes': False, '_id': False
             }}
         ]))
+
+
+@register_query(MongoDBConnection)
+def write_block_order(conn, link):
+    link = link.copy()
+    link['_id'] = link['id']
+    del link['id']
+    return conn.run(conn.collection('block_order').insert_one(link))
+
+
+@register_query(MongoDBConnection)
+def get_last_block_order(conn):
+    res = conn.run(conn.collection('block_order').find(sort=[('_id', -1)]).limit(1))
+    if res.count() > 0:
+        link = res.next()
+        link['id'] = link['_id']
+        del link['_id']
+        return link

--- a/bigchaindb/backend/mongodb/schema.py
+++ b/bigchaindb/backend/mongodb/schema.py
@@ -27,7 +27,7 @@ def create_database(conn, dbname):
 
 @register_schema(MongoDBConnection)
 def create_tables(conn, dbname):
-    for table_name in ['bigchain', 'backlog', 'votes']:
+    for table_name in ['bigchain', 'backlog', 'votes', 'block_order']:
         logger.info('Create `%s` table.', table_name)
         # create the table
         # TODO: read and write concerns can be declared here

--- a/bigchaindb/backend/query.py
+++ b/bigchaindb/backend/query.py
@@ -298,3 +298,19 @@ def get_txids_filtered(connection, asset_id, operation=None):
     """
 
     raise NotImplementedError
+
+
+@singledispatch
+def get_last_block_order(connection):
+    """
+    Return the latest block order link
+    """
+    raise NotImplementedError
+
+
+@singledispatch
+def write_block_order(connection, link):
+    """
+    Write a block order where the primary key is a contended block height
+    """
+    raise NotImplementedError

--- a/bigchaindb/backend/rethinkdb/query.py
+++ b/bigchaindb/backend/rethinkdb/query.py
@@ -150,7 +150,7 @@ def get_votes_by_block_id_and_voter(connection, block_id, node_pubkey):
 def write_block(connection, block):
     return connection.run(
             r.table('bigchain')
-            .insert(r.json(block.to_str()), durability=WRITE_DURABILITY))
+            .insert(block, durability=WRITE_DURABILITY))
 
 
 @register_query(RethinkDBConnection)
@@ -253,3 +253,17 @@ def get_unvoted_blocks(connection, node_pubkey):
     #        database level. Solving issue #444 can help untangling the situation
     unvoted_blocks = filter(lambda block: not utils.is_genesis_block(block), unvoted)
     return unvoted_blocks
+
+
+@register_query(RethinkDBConnection)
+def write_block_order(connection, link):
+    return connection.run(r.table('block_order').insert(link))
+
+
+@register_query(RethinkDBConnection)
+def get_last_block_order(connection):
+    try:
+        query = r.table('block_order').order_by(r.desc(r.row['id'])).nth(0)
+        return connection.run(query)
+    except r.ReqlNonExistenceError:
+        pass

--- a/bigchaindb/backend/rethinkdb/schema.py
+++ b/bigchaindb/backend/rethinkdb/schema.py
@@ -23,7 +23,7 @@ def create_database(connection, dbname):
 
 @register_schema(RethinkDBConnection)
 def create_tables(connection, dbname):
-    for table_name in ['bigchain', 'backlog', 'votes']:
+    for table_name in ['bigchain', 'backlog', 'votes', 'block_order']:
         logger.info('Create `%s` table.', table_name)
         connection.run(r.db(dbname).table_create(table_name))
 

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -505,6 +505,7 @@ class Bigchain(object):
         block = block.to_dict()
         backend.query.write_block(self.connection, block)
 
+        i = 0
         while True:
             link = {'id': 0, 'block_id': block['id']}
             prev = backend.query.get_last_block_order(self.connection)
@@ -515,7 +516,11 @@ class Bigchain(object):
                 backend.query.write_block_order(self.connection, link)
                 break
             except backend.exceptions.DuplicateKeyError:
-                logger.info('Contention writing block order')
+                if i == 0:
+                    logger.info('Block order contention')
+                i += 1
+        if i > 0:
+            logger.info('Wrote block order after %s tries', i)
 
     def prepare_genesis_block(self):
         """Prepare a genesis block."""

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -504,10 +504,17 @@ class Bigchain(object):
         """
         block = block.to_dict()
         backend.query.write_block(self.connection, block)
+        self._write_block_order(block['id'])
 
+    def _write_block_order(self, block_id):
+        """Write block order information
+
+        Args:
+            block_id (str): ID of the block
+        """
         i = 0
         while True:
-            link = {'id': 0, 'block_id': block['id']}
+            link = {'id': 0, 'block_id': block_id}
             prev = backend.query.get_last_block_order(self.connection)
             if prev:
                 link['prev_block'] = prev['block_id']
@@ -517,7 +524,7 @@ class Bigchain(object):
                 break
             except backend.exceptions.DuplicateKeyError:
                 if i == 0:
-                    logger.info('Block order contention')
+                    logger.info('Block order contention at height %s', link['id'])
                 i += 1
         if i > 0:
             logger.info('Wrote block order after %s tries', i)

--- a/tests/backend/mongodb/test_queries.py
+++ b/tests/backend/mongodb/test_queries.py
@@ -268,12 +268,12 @@ def test_write_block(signed_create_tx):
     conn = connect()
 
     # create and write block
-    block = Block(transactions=[signed_create_tx])
+    block = Block(transactions=[signed_create_tx]).to_dict()
     query.write_block(conn, block)
 
-    block_db = conn.db.bigchain.find_one({'id': block.id}, {'_id': False})
+    block_db = conn.db.bigchain.find_one({'id': block['id']}, {'_id': False})
 
-    assert block_db == block.to_dict()
+    assert block_db == block
 
 
 def test_get_block(signed_create_tx):

--- a/tests/backend/mongodb/test_schema.py
+++ b/tests/backend/mongodb/test_schema.py
@@ -17,8 +17,8 @@ def test_init_creates_db_tables_and_indexes():
 
     init_database()
 
-    collection_names = conn.conn[dbname].collection_names()
-    assert sorted(collection_names) == ['backlog', 'bigchain', 'votes']
+    collection_names = set(conn.conn[dbname].collection_names())
+    assert set(collection_names) == {'backlog', 'bigchain', 'votes', 'block_order'}
 
     indexes = conn.conn[dbname]['bigchain'].index_information().keys()
     assert sorted(indexes) == ['_id_', 'asset_id', 'block_timestamp', 'inputs',
@@ -61,8 +61,8 @@ def test_create_tables():
     schema.create_database(conn, dbname)
     schema.create_tables(conn, dbname)
 
-    collection_names = conn.conn[dbname].collection_names()
-    assert sorted(collection_names) == ['backlog', 'bigchain', 'votes']
+    collection_names = set(conn.conn[dbname].collection_names())
+    assert collection_names == {'backlog', 'bigchain', 'votes', 'block_order'}
 
 
 def test_create_secondary_indexes():

--- a/tests/backend/rethinkdb/test_schema.py
+++ b/tests/backend/rethinkdb/test_schema.py
@@ -59,7 +59,7 @@ def test_create_tables():
     schema.create_tables(conn, dbname)
 
     collection_names = set(conn.run(r.db(dbname).table_list()))
-    assert collection_names == {'bigchain', 'backlog', 'votes', 'block_height'}
+    assert collection_names == {'bigchain', 'backlog', 'votes', 'block_order'}
 
 
 @pytest.mark.bdb

--- a/tests/backend/rethinkdb/test_schema.py
+++ b/tests/backend/rethinkdb/test_schema.py
@@ -19,8 +19,6 @@ def test_init_creates_db_tables_and_indexes():
 
     assert conn.run(r.db_list().contains(dbname)) is True
 
-    assert conn.run(r.db(dbname).table_list().contains('backlog', 'bigchain')) is True
-
     assert conn.run(r.db(dbname).table('bigchain').index_list().contains(
         'block_timestamp')) is True
 
@@ -60,10 +58,8 @@ def test_create_tables():
     schema.create_database(conn, dbname)
     schema.create_tables(conn, dbname)
 
-    assert conn.run(r.db(dbname).table_list().contains('bigchain')) is True
-    assert conn.run(r.db(dbname).table_list().contains('backlog')) is True
-    assert conn.run(r.db(dbname).table_list().contains('votes')) is True
-    assert len(conn.run(r.db(dbname).table_list())) == 3
+    collection_names = set(conn.run(r.db(dbname).table_list()))
+    assert collection_names == {'bigchain', 'backlog', 'votes', 'block_height'}
 
 
 @pytest.mark.bdb

--- a/tests/backend/test_generics.py
+++ b/tests/backend/test_generics.py
@@ -36,6 +36,8 @@ def test_schema(schema_func_name, args_qty):
     ('get_votes_by_block_id_and_voter', 2),
     ('update_transaction', 2),
     ('get_transaction_from_block', 2),
+    ('get_last_block_order', 0),
+    ('write_block_order', 1),
 ))
 def test_query(query_func_name, args_qty):
     from bigchaindb.backend import query

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -1,7 +1,7 @@
 from time import sleep
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 pytestmark = pytest.mark.bdb
 
@@ -1224,3 +1224,52 @@ def test_is_new_transaction(b, genesis_block):
     # Tx is new because it's only found in an invalid block
     assert b.is_new_transaction(tx.id)
     assert b.is_new_transaction(tx.id, exclude_block_id=block.id)
+
+
+@pytest.mark.bdb
+def test_block_order_genesis(b):
+    from bigchaindb.backend import query
+    genesis_block = b.prepare_genesis_block()
+    assert query.get_last_block_order(b.connection) is None
+    b.write_block(genesis_block)
+    assert query.get_last_block_order(b.connection) == {
+        'id': 0,
+        'block_id': genesis_block.id,
+    }
+
+
+@pytest.mark.bdb
+def test_block_order_next(b, genesis_block):
+    from bigchaindb.models import Block
+    from bigchaindb.backend import query
+    assert query.get_last_block_order(b.connection) == {
+        'id': 0,
+        'block_id': genesis_block.id,
+    }
+    block2 = Block.from_dict(genesis_block.to_dict())
+    block2.transactions[0].operation = 'CREATE'
+    b.write_block(block2)
+    assert query.get_last_block_order(b.connection) == {
+        'id': 1,
+        'block_id': block2.id,
+        'prev_block': genesis_block.id,
+    }
+
+
+@pytest.mark.bdb
+def test_block_order_contended(b, genesis_block):
+    from bigchaindb.models import Block
+    from bigchaindb.backend.exceptions import DuplicateKeyError
+    block2 = Block.from_dict(genesis_block.to_dict())
+    block2.transactions[0].operation = 'CREATE'
+    with patch('bigchaindb.core.backend.query') as query_:
+        query_.get_last_block_order.side_effect = (
+                [{'block_id': i, 'id': i} for i in range(9)])
+        query_.write_block_order.side_effect = (
+                [DuplicateKeyError(), DuplicateKeyError(), None])
+        b.write_block(block2)
+    assert query_.write_block_order.mock_calls == [
+        call(b.connection, {'id': 1, 'prev_block': 0, 'block_id': block2.id}),
+        call(b.connection, {'id': 2, 'prev_block': 1, 'block_id': block2.id}),
+        call(b.connection, {'id': 3, 'prev_block': 2, 'block_id': block2.id}),
+    ]

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -1228,6 +1228,7 @@ def test_is_new_transaction(b, genesis_block):
 
 @pytest.mark.bdb
 def test_block_order_genesis(b):
+    """ Test block order when its the first block """
     from bigchaindb.backend import query
     genesis_block = b.prepare_genesis_block()
     assert query.get_last_block_order(b.connection) is None
@@ -1240,6 +1241,7 @@ def test_block_order_genesis(b):
 
 @pytest.mark.bdb
 def test_block_order_next(b, genesis_block):
+    """ Test block order on a subsequent block """
     from bigchaindb.models import Block
     from bigchaindb.backend import query
     assert query.get_last_block_order(b.connection) == {
@@ -1258,6 +1260,7 @@ def test_block_order_next(b, genesis_block):
 
 @pytest.mark.bdb
 def test_block_order_contended(b, genesis_block):
+    """ Test block order when writing is contended """
     from bigchaindb.models import Block
     from bigchaindb.backend.exceptions import DuplicateKeyError
     block2 = Block.from_dict(genesis_block.to_dict())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,6 +32,7 @@ def flush_rethink_db(connection, dbname):
         connection.run(r.db(dbname).table('bigchain').delete())
         connection.run(r.db(dbname).table('backlog').delete())
         connection.run(r.db(dbname).table('votes').delete())
+        connection.run(r.db(dbname).table('block_order').delete())
     except r.ReqlOpFailedError:
         pass
 
@@ -41,6 +42,7 @@ def flush_mongo_db(connection, dbname):
     connection.conn[dbname].bigchain.delete_many({})
     connection.conn[dbname].backlog.delete_many({})
     connection.conn[dbname].votes.delete_many({})
+    connection.conn[dbname].block_order.delete_many({})
 
 
 @singledispatch


### PR DESCRIPTION
This PR introduces a `block_order` table, to add an explicit block order to the system.

It piggybacks on `Bigchain.write_block` in order to write to the `block_order` table whenever a block is written into the `bigchain` table.

The primary key used is the simple numeric block height, and the block id and previous block id are included in the payload. This has the properties:

* Multiple writes with the same block height will fail
* The chain can be validated because each item points to the previous item.