### PR TITLE
Bug/1343/double spent critical on voting

### DIFF
--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -325,9 +325,9 @@ class Bigchain(object):
         """Check if a `txid` was already used as an input.
 
         A transaction can be used as an input for another transaction. Bigchain
-        needs to make sure that a given `txid` is only used once.
+        needs to make sure that a given `(txid, output)` is only used once.
 
-        This method will check if the `txid` and `output` has already been
+        This method will check if the `(txid, output)` has already been
         spent in a transaction that is in either the `VALID`, `UNDECIDED` or
         `BACKLOG` state.
 
@@ -336,11 +336,11 @@ class Bigchain(object):
             output (num): the index of the output in the respective transaction
 
         Returns:
-            The transaction (Transaction) that used the `txid` as an input else
-            `None`
+            The transaction (Transaction) that used the `(txid, output)` as an
+            input else `None`
 
         Raises:
-            CriticalDoubleSpend: If the given `txid` and `output` was spent in
+            CriticalDoubleSpend: If the given `(txid, output)` was spent in
             more than one valid transaction.
         """
         # checks if an input was already spent
@@ -372,10 +372,9 @@ class Bigchain(object):
 
         if non_invalid_transactions:
             return Transaction.from_dict(non_invalid_transactions[0])
-        else:
-            # Either no transaction was returned spending the `txid` as
-            # input or the returned transactions are not valid.
-            return None
+
+        # Either no transaction was returned spending the `(txid, output)` as
+        # input or the returned transactions are not valid.
 
     def get_outputs(self, owner):
         """Retrieve a list of links to transaction outputs for a given public

--- a/bigchaindb/models.py
+++ b/bigchaindb/models.py
@@ -187,6 +187,11 @@ class Block(object):
         if not self.is_signature_valid():
             raise InvalidSignature('Invalid block signature')
 
+        # Check that the block contains no duplicated transactions
+        txids = [tx.id for tx in self.transactions]
+        if len(txids) != len(set(txids)):
+            raise DuplicateTransaction('Block has duplicate transaction')
+
     def _validate_block_transactions(self, bigchain):
         """Validate Block transactions.
 
@@ -196,10 +201,6 @@ class Block(object):
         Raises:
             ValidationError: If an invalid transaction is found
         """
-        txids = [tx.id for tx in self.transactions]
-        if len(txids) != len(set(txids)):
-            raise DuplicateTransaction('Block has duplicate transaction')
-
         for tx in self.transactions:
             # If a transaction is not valid, `validate_transactions` will
             # throw an an exception and block validation will be canceled.

--- a/tests/pipelines/test_vote.py
+++ b/tests/pipelines/test_vote.py
@@ -112,6 +112,18 @@ def test_validate_block_with_invalid_id(b):
 
 
 @pytest.mark.genesis
+def test_validate_block_with_duplicated_transactions(b):
+    from bigchaindb.pipelines import vote
+
+    tx = dummy_tx(b)
+    block = b.create_block([tx, tx]).to_dict()
+
+    vote_obj = vote.Vote()
+    block_id, invalid_dummy_tx = vote_obj.validate_block(block)
+    assert invalid_dummy_tx == [vote_obj.invalid_dummy_tx]
+
+
+@pytest.mark.genesis
 def test_validate_block_with_invalid_signature(b):
     from bigchaindb.pipelines import vote
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -152,4 +152,4 @@ class TestBlockModel(object):
         tx = Transaction.create([b.me], [([b.me], 1)])
         block = b.create_block([tx, tx])
         with raises(DuplicateTransaction):
-            block._validate_block_transactions(b)
+            block._validate_block(b)


### PR DESCRIPTION
resolves #1343 

This pr fixes two problems: block creation was not checking for duplicated transactions, and get_spent wasn't raising `CriticalDoubleSpend` correctly.
More info in https://github.com/bigchaindb/bigchaindb/issues/1343#issuecomment-291512084