### PR TITLE
[proposal] Fixture for acceptance tests

### DIFF
--- a/tests/web/test_integration.py
+++ b/tests/web/test_integration.py
@@ -1,0 +1,28 @@
+def test_integration_web_api(bigchaindb_blackbox):
+    import random
+    import time
+
+    from bigchaindb_driver import BigchainDB, exceptions
+    from bigchaindb_driver.crypto import generate_keypair
+
+    bdb = BigchainDB('http://localhost:9984')
+    alice = generate_keypair()
+
+    asset = {'data': {'random': random.random()}}
+    tx = bdb.transactions.prepare(operation='CREATE',
+                                  signers=alice.public_key,
+                                  asset=asset)
+    fftx = bdb.transactions.fulfill(tx, private_keys=alice.private_key)
+    bdb.transactions.send(fftx)
+
+    remote_tx = None
+
+    for trial in range(10):
+        try:
+            remote_tx = bdb.transactions.retrieve(tx['id'])
+        except exceptions.NotFoundError:
+            time.sleep(1)
+        else:
+            break
+
+    assert remote_tx['id'] == tx['id']


### PR DESCRIPTION
I was trying to build an integration test for the Events API (see [`test integration from webapi to websocket`](https://github.com/bigchaindb/bigchaindb/pull/1349/files#diff-fa4976ef7face09bacee7b51842924fcR169) in  #1349) but I soon noticed that it was quite a different test from the ones we have in our code base, and that's the reason why I'm creating a PR for that.

The idea was to test the new Events API using BigchainDB as a *blackbox*:
 1. connect to the web socket endpoint
 2. create a transaction
 3. push the transaction to the API
 4. check if the transaction pops up in the web socket

This kind of testing can be defined in many ways:
- Acceptance testing
- Black box testing
- Integration testing
- Validation testing

This kind of testing also doesn't increment code coverage, but it might be useful to describe and test the behavior of BigchainDB.

Thoughts?

Update: *works on my machine™* but Travis-ci is complaining.