### PR TITLE
Made the consensus plugin an undocumented feature

### DIFF
--- a/docs/server/source/appendices/consensus.rst
+++ b/docs/server/source/appendices/consensus.rst
@@ -1,5 +1,0 @@
-#########
-Consensus
-#########
-
-.. automodule:: bigchaindb.consensus

--- a/docs/server/source/appendices/index.rst
+++ b/docs/server/source/appendices/index.rst
@@ -13,7 +13,6 @@ Appendices
    json-serialization
    cryptography
    the-Bigchain-class
-   consensus
    pipelines
    backend
    commands

--- a/docs/server/source/server-reference/configuration.md
+++ b/docs/server/source/server-reference/configuration.md
@@ -21,7 +21,6 @@ For convenience, here's a list of all the relevant environment variables (docume
 `BIGCHAINDB_SERVER_THREADS`<br>
 `BIGCHAINDB_CONFIG_PATH`<br>
 `BIGCHAINDB_BACKLOG_REASSIGN_DELAY`<br>
-`BIGCHAINDB_CONSENSUS_PLUGIN`<br>
 `BIGCHAINDB_LOG`<br>
 `BIGCHAINDB_LOG_FILE`<br>
 `BIGCHAINDB_LOG_LEVEL_CONSOLE`<br>
@@ -169,21 +168,9 @@ export BIGCHAINDB_BACKLOG_REASSIGN_DELAY=30
 "backlog_reassign_delay": 120
 ```
 
-## consensus_plugin
-
-The [consensus plugin](../appendices/consensus.html) to use.
-
-**Example using an environment variable**
-```text
-export BIGCHAINDB_CONSENSUS_PLUGIN=default
-```
-
-**Example config file snippet: the default**
-```js
-"consensus_plugin": "default"
-```
 
 ## log
+
 The `log` key is expected to point to a mapping (set of key/value pairs)
 holding the logging configuration.
 


### PR DESCRIPTION
because we don't want people using it unless they know what they're doing.