### PR TITLE
Repaired broken hyperlinks in the server docs

### DIFF
--- a/docs/server/source/appendices/aws-setup.md
+++ b/docs/server/source/appendices/aws-setup.md
@@ -18,7 +18,7 @@ pip install awscli
 
 ## Create an AWS Access Key
 
-The next thing you'll need is an AWS access key. If you don't have one, you can create one using the [instructions in the AWS documentation](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html). You should get an access key ID (e.g. AKIAIOSFODNN7EXAMPLE) and a secret access key (e.g. wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY).
+The next thing you'll need is AWS access keys (access key ID and secret access key). If you don't have those, see [the AWS documentation about access keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys).
 
 You should also pick a default AWS region name (e.g. `eu-central-1`). That's where your cluster will run. The AWS documentation has [a list of them](http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region).
 

--- a/docs/server/source/appendices/json-serialization.md
+++ b/docs/server/source/appendices/json-serialization.md
@@ -24,7 +24,7 @@ deserialize(serialize(data)) == data
 True
 ```
 
-Since BigchainDB performs a lot of serialization we decided to use [python-rapidjson](https://github.com/kenrobbins/python-rapidjson)
+Since BigchainDB performs a lot of serialization we decided to use [python-rapidjson](https://github.com/python-rapidjson/python-rapidjson)
 which is a python wrapper for [rapidjson](https://github.com/miloyip/rapidjson) a fast and fully RFC complient JSON parser.
 
 ```python

--- a/docs/server/source/appendices/run-with-docker.md
+++ b/docs/server/source/appendices/run-with-docker.md
@@ -45,7 +45,7 @@ Let's analyze that command:
  `$HOME/bigchaindb_docker` to the container directory `/data`;
  this allows us to have the data persisted on the host machine,
  you can read more in the [official Docker
- documentation](https://docs.docker.com/engine/tutorials/dockervolumes/#/mount-a-host-directory-as-a-data-volume)
+ documentation](https://docs.docker.com/engine/tutorials/dockervolumes)
 * `bigchaindb/bigchaindb` the image to use. All the options after the container name are passed on to the entrypoint inside the container.
 * `-y configure` execute the `configure` sub-command (of the `bigchaindb`
  command) inside the container, with the `-y` option to automatically use all the default config values
@@ -80,9 +80,9 @@ docker run \
   rethinkdb:2.3
 ```
 
+<!-- Don't hyperlink http://172.17.0.1:58080/ because Sphinx will fail when you do "make linkcheck" -->
 
-You can also access the RethinkDB dashboard at
-[http://172.17.0.1:58080/](http://172.17.0.1:58080/)
+You can also access the RethinkDB dashboard at http://172.17.0.1:58080/
 
 
 #### For MongoDB

--- a/docs/server/source/cloud-deployment-templates/node-on-kubernetes.rst
+++ b/docs/server/source/cloud-deployment-templates/node-on-kubernetes.rst
@@ -157,7 +157,7 @@ Step 5: Create the Config Map - Optional
 
 This step is required only if you are planning to set up multiple
 `BigchainDB nodes
-<https://docs.bigchaindb.com/en/latest/terminology.html#node>`_.
+<https://docs.bigchaindb.com/en/latest/terminology.html>`_.
 
 MongoDB reads the local ``/etc/hosts`` file while bootstrapping a replica set
 to resolve the hostname provided to the ``rs.initiate()`` command. It needs to
@@ -268,7 +268,7 @@ Step 7: Initialize a MongoDB Replica Set - Optional
 
 This step is required only if you are planning to set up multiple
 `BigchainDB nodes
-<https://docs.bigchaindb.com/en/latest/terminology.html#node>`_.
+<https://docs.bigchaindb.com/en/latest/terminology.html>`_.
 
 
 Login to the running MongoDB instance and access the mongo shell using:
@@ -315,7 +315,7 @@ Step 8: Create a DNS record - Optional
 
 This step is required only if you are planning to set up multiple
 `BigchainDB nodes
-<https://docs.bigchaindb.com/en/latest/terminology.html#node>`_.
+<https://docs.bigchaindb.com/en/latest/terminology.html>`_.
 
 **Azure.** Select the current Azure resource group and look for the ``Public IP``
 resource. You should see at least 2 entries there - one for the Kubernetes
@@ -426,9 +426,8 @@ on the cluster and query the internal DNS and IP endpoints.
    $ kubectl run -it toolbox -- image <docker image to run> --restart=Never --rm
 
 There is a generic image based on alpine:3.5 with the required utilities
-hosted at Docker Hub under ``bigchaindb/toolbox``.
-The corresponding Dockerfile is `here
-<https://github.com/bigchaindb/bigchaindb/k8s/toolbox/Dockerfile>`_.
+hosted at Docker Hub under `bigchaindb/toolbox <https://hub.docker.com/r/bigchaindb/toolbox/>`_.
+The corresponding Dockerfile is in the bigchaindb/bigchaindb repository on GitHub, at `https://github.com/bigchaindb/bigchaindb/blob/master/k8s/toolbox/Dockerfile <https://github.com/bigchaindb/bigchaindb/blob/master/k8s/toolbox/Dockerfile>`_.
 
 You can use it as below to get started immediately:
 

--- a/docs/server/source/cloud-deployment-templates/upgrade-on-kubernetes.rst
+++ b/docs/server/source/cloud-deployment-templates/upgrade-on-kubernetes.rst
@@ -53,7 +53,7 @@ on the node and mark it as unscheduleable
 
    kubectl drain $NODENAME
 
-There are `more details in the Kubernetes docs <https://kubernetes.io/docs/admin/cluster-management/#maintenance-on-a-node>`_,
+There are `more details in the Kubernetes docs <https://kubernetes.io/docs/concepts/cluster-administration/cluster-management/#maintenance-on-a-node>`_,
 including instructions to make the node scheduleable again.
 
 To manually upgrade the host OS,
@@ -82,13 +82,13 @@ A typical upgrade workflow for a single Deployment would be:
 
    $ KUBE_EDITOR=nano kubectl edit deployment/<name of Deployment>
 
-The `kubectl edit <https://kubernetes.io/docs/user-guide/kubectl/kubectl_edit/>`_ 
-command opens the specified editor (nano in the above example),
+The ``kubectl edit`` command
+opens the specified editor (nano in the above example),
 allowing you to edit the specified Deployment *in the Kubernetes cluster*.
 You can change the version tag on the Docker image, for example. 
 Don't forget to save your edits before exiting the editor.
 The Kubernetes docs have more information about
-`updating a Deployment <https://kubernetes.io/docs/user-guide/deployments/#updating-a-deployment>`_.
+`Deployments <https://kubernetes.io/docs/concepts/workloads/controllers/deployment/>`_ (including updating them).
 
 
 The upgrade story for the MongoDB StatefulSet is *different*.

--- a/docs/server/source/dev-and-test/setup-run-node.md
+++ b/docs/server/source/dev-and-test/setup-run-node.md
@@ -23,7 +23,9 @@ Start RethinkDB using:
 $ rethinkdb
 ```
 
-You can verify that RethinkDB is running by opening the RethinkDB web interface in your web browser. It should be at [http://localhost:8080/](http://localhost:8080/).
+You can verify that RethinkDB is running by opening the RethinkDB web interface in your web browser. It should be at http://localhost:8080/
+
+<!-- Don't hyperlink http://localhost:8080/ because Sphinx will fail when you do "make linkcheck" -->
 
 To run BigchainDB Server, do:
 ```text
@@ -87,11 +89,11 @@ Start RethinkDB:
 docker-compose up -d rdb
 ```
 
-The RethinkDB web interface should be accessible at <http://localhost:58080/>.
+The RethinkDB web interface should be accessible at http://localhost:58080/.
 Depending on which platform, and/or how you are running docker, you may need
 to change `localhost` for the `ip` of the machine that is running docker. As a
 dummy example, if the `ip` of that machine was `0.0.0.0`, you would access the
-web interface at: <http://0.0.0.0:58080/>.
+web interface at: http://0.0.0.0:58080/.
 
 Start a BigchainDB node:
 

--- a/docs/server/source/drivers-clients/http-client-server-api.rst
+++ b/docs/server/source/drivers-clients/http-client-server-api.rst
@@ -406,7 +406,7 @@ Determining the API Root URL
 When you start BigchainDB Server using ``bigchaindb start``,
 an HTTP API is exposed at some address. The default is:
 
-`http://localhost:9984/api/v1/ <http://localhost:9984/api/v1/>`_
+``http://localhost:9984/api/v1/``
 
 It's bound to ``localhost``,
 so you can access it from the same machine,

--- a/docs/server/source/drivers-clients/index.rst
+++ b/docs/server/source/drivers-clients/index.rst
@@ -26,6 +26,6 @@ Please note that some of these projects may be work in progress, but may
 nevertheless be very useful.
 
 * `Javascript transaction builder <https://github.com/sohkai/js-bigchaindb-quickstart>`_
-* `Haskell transaction builder <https://github.com/libscott/bigchaindb-hs>`_
+* `Haskell transaction builder <https://github.com/bigchaindb/bigchaindb-hs>`_
 * `Go driver <https://github.com/zbo14/envoke/blob/master/bigchain/bigchain.go>`_
 * `Java driver <https://github.com/mgrand/bigchaindb-java-driver>`_


### PR DESCRIPTION
I fixed all the errors caused by Sphinx's `make linkcheck`, and also updated some of the hyperlinks that were redirecting (but not causing errors).