### PR TITLE
Add the packaging metadata to build the bigchaindb snap

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -1,0 +1,12 @@
+This is the packaging metadata for the BigchainDB snap.
+
+Snaps and the snap store allows for the secure installation of apps that work
+in most Linux distributions. For more information, go to https://snapcraft.io/
+
+To build and install this snap in Ubuntu 16.04:
+
+    $ sudo apt install git snapcraft
+    $ git clone https://github.com/bigchaindb/bigchaindb
+    $ cd bigchaindb
+    $ snapcraft
+    $ sudo snap install *.snap --dangerous --devmode

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: bigchaindb
+version: master
+summary: a scalable blockchain database
+description: |
+  With high throughput, sub-second latency and powerful functionality to
+  automate business processes, BigchainDB looks, acts and feels like a database
+  with added blockchain characteristics.
+
+# grade must be 'stable' to release into candidate/stable channels
+grade: devel
+# strict confinement requires https://github.com/snapcore/snapd/pull/2749
+confinement: devmode
+
+apps:
+  bigchaindb:
+    command: bigchaindb
+    plugs: [network, network-bind]
+
+parts:
+  bigchaindb:
+    source: .
+    plugin: python
+    build-packages: [g++, libffi-dev]


### PR DESCRIPTION
This package will let you publish the latest bigchaindb in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress.