### PR TITLE
Remove `editable` flag in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /usr/src/app/
 WORKDIR /usr/src/app
 RUN apt-get -qq update \
     && apt-get -y upgrade \
-    && pip install --no-cache-dir -e . \
+    && pip install --no-cache-dir . \
     && apt-get autoremove \
     && apt-get clean
 VOLUME ["/data"]


### PR DESCRIPTION
From `pip install --help`:
```
-e, --editable <path/url>   Install a project in editable mode (i.e.
setuptools "develop mode") from a local project path or a VCS url.
```