### PR TITLE
Changed from Alpha to Beta in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
     zip_safe=False,
 
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'Topic :: Database',
         'Topic :: Database :: Database Engines/Servers',


### PR DESCRIPTION
In `setup.py`, I changed the classifier `'Development Status :: 3 - Alpha'` to `'Development Status :: 4 - Beta'` as per the list of classifiers here: https://pypi.python.org/pypi?%3Aaction=list_classifiers

This is in preparation for the version 1.0 release but I think it's probably fine to have it in master now.