### PR TITLE
Updated Drivers & Clients docs page, including link to Ruby driver

### DIFF
--- a/docs/server/source/drivers-clients/index.rst
+++ b/docs/server/source/drivers-clients/index.rst
@@ -1,29 +1,27 @@
 Drivers & Clients
 =================
 
-Currently, the only language-native driver is written in the Python language.
+Libraries and Tools Maintained by the BigchainDB Team
+-----------------------------------------------------
 
-We also provide the Transaction CLI to be able to script the building of
-transactions. You may be able to wrap this tool inside the language of
-your choice, and then use the HTTP API directly to post transactions.
-
-If you use a language other than Python, you may want to look at the current
-community projects listed below.
-
-
-.. toctree::
-   :maxdepth: 1
-
-   The Python Driver <https://docs.bigchaindb.com/projects/py-driver/en/latest/index.html>
-   Transaction CLI <https://docs.bigchaindb.com/projects/cli/en/latest/>
+* `The Python Driver <https://docs.bigchaindb.com/projects/py-driver/en/latest/index.html>`_
+* `The Transaction CLI <https://docs.bigchaindb.com/projects/cli/en/latest/>`_ is
+  a command-line interface for building BigchainDB transactions.
+  You may be able to call it from inside the language of
+  your choice, and then use :ref:`the HTTP API <The HTTP Client-Server API>`
+  to post transactions.
 
 
 Community-Driven Libraries and Tools
 ------------------------------------
-Please note that some of these projects may be work in progress, but may
-nevertheless be very useful.
+
+.. note::
+
+   Some of these projects are a work in progress,
+   but may still be useful.
 
 * `Javascript transaction builder <https://github.com/sohkai/js-bigchaindb-quickstart>`_
 * `Haskell transaction builder <https://github.com/bigchaindb/bigchaindb-hs>`_
 * `Go driver <https://github.com/zbo14/envoke/blob/master/bigchain/bigchain.go>`_
 * `Java driver <https://github.com/mgrand/bigchaindb-java-driver>`_
+* `Ruby driver <https://github.com/LicenseRocks/bigchaindb_ruby>`_


### PR DESCRIPTION
Updated the Drivers & Clients docs page, including a link to the Ruby driver by license.rocks.

Also edited the top of the page too, to simplify it and make it clear that the "BigchainDB Team" maintains the Python Driver and the Transaction CLI.

It's a bit goofy to have a directory with a single index.rst file in it, with no "toc" but I'm keeping it that way because it will keep existing links unbroken and in the future we may want to have separate pages for different libraries, tools, clients or drivers.