### PR TITLE
Publish port 80 publicly in nginx-3scale.

### DIFF
--- a/k8s/nginx-3scale/nginx-3scale-dep.yaml
+++ b/k8s/nginx-3scale/nginx-3scale-dep.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: nginx-3scale
-        image: bigchaindb/nginx_3scale:1.0
+        image: bigchaindb/nginx_3scale:1.1
         # TODO(Krish): Change later to IfNotPresent
         imagePullPolicy: Always
         env:
@@ -67,6 +67,10 @@ spec:
         - containerPort: 443
           hostPort: 443
           name: public-bdb-port
+          protocol: TCP
+        - containerPort: 80
+          hostPort: 80
+          name: https-msg-port
           protocol: TCP
         - containerPort: 8888
           hostPort: 8888

--- a/k8s/nginx-3scale/nginx-3scale-svc.yaml
+++ b/k8s/nginx-3scale/nginx-3scale-svc.yaml
@@ -14,6 +14,10 @@ spec:
   selector:
     app: ngx-instance-0-dep
   ports:
+  - port: 80
+    targetPort: 80
+    name: ngx-public-bdb-port-http
+    protocol: TCP
   - port: 443
     targetPort: 443
     name: ngx-public-bdb-port


### PR DESCRIPTION
Upgrade docker image tag to `1.1` as the corresponding config changes for displaying error message are built in the `1.1` container image.