### PR TITLE
check output conditions with single statement

### DIFF
--- a/bigchaindb/utils.py
+++ b/bigchaindb/utils.py
@@ -114,16 +114,11 @@ def condition_details_has_owner(condition_details, owner):
 
 
 def output_has_owner(output, owner):
-    # TODO
-    # Check whether it is really necessary to treat the single key case
-    # differently from the multiple keys case, and why not just use the same
-    # function for both cases.
-    if len(output['public_keys']) > 1:
+    if len(output['public_keys']) > 0:
         return condition_details_has_owner(
             output['condition']['details'], owner)
-    elif len(output['public_keys']) == 1:
-        return output['condition']['details']['public_key'] == owner
-    # TODO raise proper exception, e.g. invalid tx payload?
+    return False
+    # # TODO raise proper exception, e.g. invalid tx payload?
 
 
 def is_genesis_block(block):


### PR DESCRIPTION
`GET /outputs` fails for specific transactions with thresholds

Invoked on the fastquery branch - but probably also on current master

## Stacktrace

```
  File "/home/dimi/code_ascribe/kyber/bigchaindb-server/bigchaindb/web/views/outputs.py", line 26, in ge
t                                                                                                       
    include_spent)                                                                                      
  File "/home/dimi/code_ascribe/kyber/bigchaindb-server/bigchaindb/core.py", line 400, in get_outputs_fi
ltered                                                                                                  
    outputs = self.fastquery.get_outputs_by_pubkey(owner)                                               
  File "/home/dimi/code_ascribe/kyber/bigchaindb-server/bigchaindb/fastquery.py", line 45, in get_output
s_by_pubkey                                                                                             
    for tx in txs                                                                                       
  File "/home/dimi/code_ascribe/kyber/bigchaindb-server/bigchaindb/fastquery.py", line 47, in <listcomp>
    if output_has_owner(o, pubkey)]                                                                     
  File "/home/dimi/code_ascribe/kyber/bigchaindb-server/bigchaindb/utils.py", line 125, in output_has_ow
ner                                                                                                     
    return output['condition']['details']['public_key'] == owner                                        
KeyError: 'public_key'                                                                                  
```

## Testvector

```
{"id":"c6de675dfef4411c37c2adef80c8ece82740fb48f991613f3d8222029297e3a7","operation":"CREATE","outputs":[{"amount":"1","condition":{"details":{"type_id":2,"type":"fulfillment","bitmask":43,"threshold":2,"subfulfillments":[{"type_id":4,"bitmask":32,"signature":null,"public_key":"79K8SPZbeSDYXBrWgt3dsNmYTZbKNtdYQ5XrjA9XEWfG","type":"fulfillment","weight":1},{"type_id":2,"type":"fulfillment","bitmask":11,"threshold":3,"subfulfillments":[{"type_id":0,"bitmask":3,"hash":"5wbD6GsVBReHetMUw17QcNne8BjB1xSKRoU4JYpafEx5","max_fulfillment_length":5,"type":"condition","weight":1},{"type_id":0,"bitmask":3,"hash":"EuNEkS8TUYaTngMPGiS3DHdApYBf2YYQVdg3hHHTnPDx","max_fulfillment_length":11,"type":"condition","weight":1},{"type_id":0,"bitmask":3,"hash":"Ay3VvUjfEnEhCWxJMGLGBpWTS5iu2nVB64wcsYkPnCqd","max_fulfillment_length":5,"type":"condition","weight":1},{"type_id":0,"bitmask":3,"hash":"H7nD6xkFRm99GzAxvA5JG8DQSZBEGdiUdnYuh7714vMW","max_fulfillment_length":10,"type":"condition","weight":1},{"type_id":0,"bitmask":3,"hash":"8EmZwLhhFAZ9QgHgHfgMokfQ2CfzXaLbyEz4uaXaJyq4","max_fulfillment_length":7,"type":"condition","weight":1},{"type_id":0,"bitmask":3,"hash":"DFf8KSmzgHEarJ2RPJmyDGTvnS8E8MjxkDNVjNsUN8Hr","max_fulfillment_length":8,"type":"condition","weight":1},{"type_id":0,"bitmask":3,"hash":"3qUBtEhzGazLRTM9c3JWKGPTnrkgxbtEoezh7WaJuJBS","max_fulfillment_length":3,"type":"condition","weight":1},{"type_id":0,"bitmask":3,"hash":"4w6YMt6nH3oSsA1uTk6Vmqvqsa9eSquKSAxWtDWPrzTg","max_fulfillment_length":4,"type":"condition","weight":1}],"weight":1}]},"uri":"cc:2:2b:VC7Jv-cUz8xcnSSR11K4nGe0myDWrmOaf3LFfwYPOwQ:358"},"public_keys":["79K8SPZbeSDYXBrWgt3dsNmYTZbKNtdYQ5XrjA9XEWfG"]}],"inputs":[{"fulfillment":"cf:4:W0dEBH4MFkphXyUzeuY04q8z2visobk5dtiggDfGdOeEzY975pWXZ-nIUHHZ-XDKHha-hiWFs-ido88fPS_fCOmskfpbaB_-yhkVGlc-bdx6irzpD6fWkuRHoe5V0usH","fulfills":null,"owners_before":["79K8SPZbeSDYXBrWgt3dsNmYTZbKNtdYQ5XrjA9XEWfG"]}],"metadata":null,"asset":{"data":{"item":"shirt","frequency":5,"timestamp":"1493639461"}},"version":"0.9"}
```

## TODO

- [ ] check why the statement for a single list item was there
- [ ] write test to reproduce stacktrace above with testvector
- [ ] @sbellem shim cryptoconditions-specific utils ie `condition_details_has_owner` (see also [CC utils in Kyber](https://github.com/bigchaindb/kyber/blob/master/tutorials/utils/cryptoconditions_utils.py))