### PR TITLE
Update bigchaindb default deployment version

### DIFF
--- a/k8s/bigchaindb/bigchaindb-dep.yaml
+++ b/k8s/bigchaindb/bigchaindb-dep.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: bigchaindb
-        image: bigchaindb/bigchaindb:0.10.1
+        image: bigchaindb/bigchaindb:0.10.2
         imagePullPolicy: IfNotPresent
         args:
         - start


### PR DESCRIPTION
Updated to the latest release, version 0.10.2.