### PR TITLE
Minor docs fixes

### DIFF
--- a/docs/server/source/quickstart.md
+++ b/docs/server/source/quickstart.md
@@ -8,7 +8,7 @@ A. Install MongoDB as the database backend. (There are other options but you can
 
 B. Run MongoDB. Open a Terminal and run the command:
 ```text
-$ mongod --replSet=bigchain-rs
+$ sudo mongod --replSet=bigchain-rs
 ```
 
 C. Ubuntu 16.04 already has Python 3.5, so you don't need to install it, but you do need to install some other things:

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,8 +27,7 @@ BigchainDB from source. The [`CONTRIBUTING.md` file](../CONTRIBUTING.md) has
 instructions for how to do that.
 
 Next, make sure you have RethinkDB or MongoDB running in the background. You
-can run RethinkDB using `rethinkdb --daemon` or MongoDB using `mongod
---replSet=rs0`.
+can run RethinkDB using `rethinkdb --daemon` or MongoDB using `mongod --replSet=bigchain-rs`.
 
 The `pytest` command has many options. If you want to learn about all the
 things you can do with pytest, see [the pytest


### PR DESCRIPTION
1. In `docs/server/source/quickstart.md`, I told them to run MongoDB using `sudo mongod --replSet=bigchain-rs` because if they use `mongod --replSet=bigchain-rs` they will get an error like "exception in initAndListen: 20 Attempted to create a lock file on a read-only directory: /data/db, terminating". There are many ways to avoid that error, but since this is a Quickstart page, I figured running as root would suffice.

2. In `tests/README.md`, I told them to run MongoDB with the default replica set name, `bigchain-rs`, rather than `rs0` (when setting up to run the pytest tests), i.e. `mongod --replSet=bigchain-rs`
