### PR TITLE
Fail if config file not found

### DIFF
--- a/bigchaindb/config_utils.py
+++ b/bigchaindb/config_utils.py
@@ -238,7 +238,10 @@ def autoconfigure(filename=None, config=None, force=False):
     try:
         newconfig = update(newconfig, file_config(filename=filename))
     except FileNotFoundError as e:
-        logger.warning('Cannot find config file `%s`.' % e.filename)
+        if filename:
+            raise
+        else:
+            logger.info('Cannot find config file `%s`.' % e.filename)
 
     # override configuration with env variables
     newconfig = env_config(newconfig)

--- a/bigchaindb/web/server.py
+++ b/bigchaindb/web/server.py
@@ -62,7 +62,7 @@ def create_app(*, debug=False, threads=4):
     app = Flask(__name__)
 
     CORS(app,
-         headers=(
+         allow_headers=(
              'x-requested-with',
              'content-type',
              'accept',

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ install_requires = [
     'python-rapidjson==0.0.11',
     'logstats>=0.2.1',
     'flask>=0.10.1',
-    'flask-cors~=2.1.2',
+    'flask-cors~=3.0.0',
     'flask-restful~=0.3.0',
     'requests~=2.9',
     'gunicorn~=19.0',

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -88,11 +88,12 @@ def test_bigchain_show_config(capsys):
     assert output_config == config
 
 
+@pytest.mark.usefixtures('ignore_local_config_file')
 def test_bigchain_export_my_pubkey_when_pubkey_set(capsys, monkeypatch):
     from bigchaindb import config
     from bigchaindb.commands.bigchaindb import run_export_my_pubkey
 
-    args = Namespace(config='dummy')
+    args = Namespace(config=None)
     # so in run_export_my_pubkey(args) below,
     # filename=args.config='dummy' is passed to autoconfigure().
     # We just assume autoconfigure() works and sets
@@ -107,11 +108,12 @@ def test_bigchain_export_my_pubkey_when_pubkey_set(capsys, monkeypatch):
     assert 'Charlie_Bucket' in lines
 
 
+@pytest.mark.usefixtures('ignore_local_config_file')
 def test_bigchain_export_my_pubkey_when_pubkey_not_set(monkeypatch):
     from bigchaindb import config
     from bigchaindb.commands.bigchaindb import run_export_my_pubkey
 
-    args = Namespace(config='dummy')
+    args = Namespace(config=None)
     monkeypatch.setitem(config['keypair'], 'public', None)
     # assert that run_export_my_pubkey(args) raises SystemExit:
     with pytest.raises(SystemExit) as exc_info:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,7 +199,7 @@ def _genesis(_bdb, genesis_block):
 @pytest.fixture
 def ignore_local_config_file(monkeypatch):
     def mock_file_config(filename=None):
-        raise FileNotFoundError()
+        return {}
 
     monkeypatch.setattr('bigchaindb.config_utils.file_config',
                         mock_file_config)

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -257,6 +257,18 @@ def test_autoconfigure_env_precedence(monkeypatch):
     assert bigchaindb.config['server']['bind'] == 'localhost:9985'
 
 
+def test_autoconfigure_explicit_file(monkeypatch):
+    from bigchaindb import config_utils
+
+    def file_config(*args, **kwargs):
+        raise FileNotFoundError()
+
+    monkeypatch.setattr('bigchaindb.config_utils.file_config', file_config)
+
+    with pytest.raises(FileNotFoundError):
+        config_utils.autoconfigure(filename='autoexec.bat')
+
+
 def test_update_config(monkeypatch):
     import bigchaindb
     from bigchaindb import config_utils


### PR DESCRIPTION
`bigchaindb` has an option `-c, --config` to specify the location of the configuration file, but if the file doesn't exist bigchaindb **doesn't** fail to execute:

```
 ~/a/r/bigchaindb git:(master) ➜ bigchaindb -c myconf start
WARNING:bigchaindb.config_utils:Cannot find config file `myconf`.
[2017-05-18 15:34:13] [INFO] (bigchaindb.commands.bigchaindb) BigchainDB Version 0.11.0.dev (MainProcess - pid: 5329)
Can't start BigchainDB, no keypair found. Did you run `bigchaindb configure`?
```

This PR changes the behavior to:

```
 ~/a/r/bigchaindb git:(raise-error-if-explicit-file-not-found) ➜ bigchaindb -c myconf start
Traceback (most recent call last):
  File "/home/vrde/.local/share/virtualenvs/bigchaindb/bin/bigchaindb", line 11, in <module>
    load_entry_point('BigchainDB', 'console_scripts', 'bigchaindb')()
  File "/home/vrde/ascribe/repos/bigchaindb/bigchaindb/commands/bigchaindb.py", line 348, in main
    utils.start(create_parser(), sys.argv[1:], globals())
  File "/home/vrde/ascribe/repos/bigchaindb/bigchaindb/commands/utils.py", line 204, in start
    return func(args)
  File "/home/vrde/ascribe/repos/bigchaindb/bigchaindb/commands/utils.py", line 48, in configure
    filename=args.config, config=config_from_cmdline, force=True)
  File "/home/vrde/ascribe/repos/bigchaindb/bigchaindb/config_utils.py", line 239, in autoconfigure
    newconfig = update(newconfig, file_config(filename=filename))
  File "/home/vrde/ascribe/repos/bigchaindb/bigchaindb/config_utils.py", line 103, in file_config
    with open(filename) as f:
FileNotFoundError: [Errno 2] No such file or directory: 'myconf'
``

I've also changed a `log.warning` to `log.info` if default file cannot be loaded.