### PR TITLE
Disable threads in web workers

### DIFF
--- a/bigchaindb/__init__.py
+++ b/bigchaindb/__init__.py
@@ -62,7 +62,6 @@ config = {
         'loglevel': logging.getLevelName(
             log_config['handlers']['console']['level']).lower(),
         'workers': None,  # if none, the value will be cpu_count * 2 + 1
-        'threads': None,  # if none, the value will be cpu_count * 2 + 1
     },
     'wsserver': {
         'host': os.environ.get('BIGCHAINDB_WSSERVER_HOST') or 'localhost',

--- a/bigchaindb/web/server.py
+++ b/bigchaindb/web/server.py
@@ -48,7 +48,7 @@ class StandaloneApplication(gunicorn.app.base.BaseApplication):
         return self.application
 
 
-def create_app(*, debug=False, threads=4):
+def create_app(*, debug=False, threads=1):
     """Return an instance of the Flask application.
 
     Args:
@@ -102,7 +102,10 @@ def create_server(settings):
         settings['workers'] = (multiprocessing.cpu_count() * 2) + 1
 
     if not settings.get('threads'):
-        settings['threads'] = (multiprocessing.cpu_count() * 2) + 1
+        # Note: Threading is not recommended currently, as the frontend workload
+        # is largely CPU bound and parallisation across Python threads makes it
+        # slower.
+        settings['threads'] = 1
 
     settings['logger_class'] = 'bigchaindb.log.loggers.HttpServerLogger'
     app = create_app(debug=settings.get('debug', False),

--- a/docs/server/source/server-reference/configuration.md
+++ b/docs/server/source/server-reference/configuration.md
@@ -152,7 +152,7 @@ These settings are for the [Gunicorn HTTP server](http://gunicorn.org/), which i
 [Gunicorn's documentation](http://docs.gunicorn.org/en/latest/settings.html#loglevel)
 for more information.
 
-`server.workers` is [the number of worker processes](http://docs.gunicorn.org/en/stable/settings.html#workers) for handling requests. If `None` (the default), the value will be (cpu_count * 2 + 1). If `None` (the default), the value will be 1. The HTTP server will be able to handle `server.workers` requests simultaneously.
+`server.workers` is [the number of worker processes](http://docs.gunicorn.org/en/stable/settings.html#workers) for handling requests. If `None` (the default), the value will be (cpu_count * 2 + 1). Each worker process has a single thread. The HTTP server will be able to handle `server.workers` requests simultaneously.
 
 **Example using environment variables**
 ```text

--- a/docs/server/source/server-reference/configuration.md
+++ b/docs/server/source/server-reference/configuration.md
@@ -142,7 +142,7 @@ If you used `bigchaindb -y configure mongodb` to create a default local config f
 ```
 
 
-## server.bind, server.loglevel, server.workers & server.threads
+## server.bind, server.loglevel & server.workers
 
 These settings are for the [Gunicorn HTTP server](http://gunicorn.org/), which is used to serve the [HTTP client-server API](../http-client-server-api.html).
 
@@ -152,7 +152,7 @@ These settings are for the [Gunicorn HTTP server](http://gunicorn.org/), which i
 [Gunicorn's documentation](http://docs.gunicorn.org/en/latest/settings.html#loglevel)
 for more information.
 
-`server.workers` is [the number of worker processes](http://docs.gunicorn.org/en/stable/settings.html#workers) for handling requests. If `None` (the default), the value will be (cpu_count * 2 + 1). `server.threads` is [the number of threads-per-worker](http://docs.gunicorn.org/en/stable/settings.html#threads) for handling requests. If `None` (the default), the value will be (cpu_count * 2 + 1). The HTTP server will be able to handle `server.workers` * `server.threads` requests simultaneously.
+`server.workers` is [the number of worker processes](http://docs.gunicorn.org/en/stable/settings.html#workers) for handling requests. If `None` (the default), the value will be (cpu_count * 2 + 1). If `None` (the default), the value will be 1. The HTTP server will be able to handle `server.workers` requests simultaneously.
 
 **Example using environment variables**
 ```text
@@ -168,7 +168,6 @@ export BIGCHAINDB_SERVER_THREADS=5
     "bind": "0.0.0.0:9984",
     "loglevel": "debug",
     "workers": 5,
-    "threads": 5
 }
 ```
 
@@ -178,7 +177,6 @@ export BIGCHAINDB_SERVER_THREADS=5
     "bind": "localhost:9984",
     "loglevel": "info",
     "workers": null,
-    "threads": null
 }
 ```
 

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -209,7 +209,6 @@ def test_autoconfigure_read_both_from_file_and_env(monkeypatch, request):
             'loglevel': logging.getLevelName(
                 log_config['handlers']['console']['level']).lower(),
             'workers': None,
-            'threads': None,
         },
         'wsserver': {
             'host': WSSERVER_HOST,


### PR DESCRIPTION
Threading in the frontend negatively impacts performance due to transaction validation and the GIL; it is advantageous to have one thread per web worker process and parallelise requests across processes.