### PR TITLE
Use rapidjson-schema

### DIFF
--- a/bigchaindb/common/schema/__init__.py
+++ b/bigchaindb/common/schema/__init__.py
@@ -1,5 +1,6 @@
 """ Schema validation related functions and data """
 import os.path
+import logging
 
 import jsonschema
 import yaml
@@ -7,6 +8,9 @@ import rapidjson
 import rapidjson_schema
 
 from bigchaindb.common.exceptions import SchemaValidationError
+
+
+logger = logging.getLogger(__name__)
 
 
 def drop_schema_descriptions(node):
@@ -58,8 +62,8 @@ def _validate_schema(schema, body):
             jsonschema.validate(body, schema[0])
         except jsonschema.ValidationError as exc2:
             raise SchemaValidationError(str(exc2)) from exc2
-        raise Exception('jsonschema did not raise an exception, wheras rapidjson raised',
-                        exc)
+        logger.warning('code problem: jsonschema did not raise an exception, wheras rapidjson raised %s', exc)
+        raise SchemaValidationError(str(exc)) from exc
 
 
 def validate_transaction_schema(tx):

--- a/bigchaindb/common/schema/__init__.py
+++ b/bigchaindb/common/schema/__init__.py
@@ -3,6 +3,8 @@ import os.path
 
 import jsonschema
 import yaml
+import rapidjson
+import rapidjson_schema
 
 from bigchaindb.common.exceptions import SchemaValidationError
 
@@ -25,7 +27,8 @@ def _load_schema(name):
     with open(path) as handle:
         schema = yaml.safe_load(handle)
     drop_schema_descriptions(schema)
-    return path, schema
+    fast_schema = rapidjson_schema.loads(rapidjson.dumps(schema))
+    return path, (schema, fast_schema)
 
 
 TX_SCHEMA_PATH, TX_SCHEMA_COMMON = _load_schema('transaction')
@@ -36,10 +39,27 @@ VOTE_SCHEMA_PATH, VOTE_SCHEMA = _load_schema('vote')
 
 def _validate_schema(schema, body):
     """ Validate data against a schema """
+
+    # Note
+    #
+    # Schema validation is currently the major CPU bottleneck of
+    # BigchainDB. the `jsonschema` library validates python data structures
+    # directly and produces nice error messages, but validation takes 4+ ms
+    # per transaction which is pretty slow. The rapidjson library validates
+    # much faster at 1.5ms, however it produces _very_ poor error messages.
+    # For this reason we use both, rapidjson as an optimistic pathway and
+    # jsonschema as a fallback in case there is a failure, so we can produce
+    # a helpful error message.
+
     try:
-        jsonschema.validate(body, schema)
-    except jsonschema.ValidationError as exc:
-        raise SchemaValidationError(str(exc)) from exc
+        schema[1].validate(rapidjson.dumps(body))
+    except ValueError as exc:
+        try:
+            jsonschema.validate(body, schema[0])
+        except jsonschema.ValidationError as exc2:
+            raise SchemaValidationError(str(exc2)) from exc2
+        raise Exception('jsonschema did not raise an exception, wheras rapidjson raised',
+                        exc)
 
 
 def validate_transaction_schema(tx):

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ install_requires = [
     'jsonschema~=2.5.1',
     'pyyaml~=3.12',
     'aiohttp~=2.0',
+    'python-rapidjson-schema==0.1.1',
 ]
 
 setup(

--- a/tests/common/test_schema.py
+++ b/tests/common/test_schema.py
@@ -4,6 +4,7 @@ properties related to validation.
 """
 
 from pytest import raises
+from unittest.mock import patch
 
 from bigchaindb.common.exceptions import SchemaValidationError
 from bigchaindb.common.schema import (
@@ -100,6 +101,12 @@ def test_validate_transaction_signed_transfer(signed_transfer_tx):
 def test_validate_transaction_fails():
     with raises(SchemaValidationError):
         validate_transaction_schema({})
+
+
+def test_validate_failure_inconsistent():
+    with patch('jsonschema.validate'):
+        with raises(SchemaValidationError):
+            validate_transaction_schema({})
 
 
 ################################################################################


### PR DESCRIPTION
Pretty big speedup, reduces validation time from ~4.5ms to ~1.5ms.

Below images are transactions per 10 seconds, before and after.

**Question**: I left the old schema validation in as a fallback, since the rapidjson validation does not produce nice error messages (for example: `ValueError: ('pattern', '#/definitions/sha3_hexdigest', '#/vote/previous_block')`, they can be more ambiguous though...). Is this worthwhile? It has the side effect that submitting invalid transactions will trigger the old validation and thus use alot more CPU time.

Pypi link: https://pypi.python.org/pypi/python-rapidjson-schema/0.1.1

![screenshot from 2017-05-22 16-49-54](https://cloud.githubusercontent.com/assets/125019/26351855/81967a18-3fb9-11e7-9057-5d92095fae28.png)

![benchmark](https://cloud.githubusercontent.com/assets/125019/26351852/807a754e-3fb9-11e7-9564-5b97c53d4f27.png)