### PR TITLE
Require asset.data for CREATE and asset.id for TRANSFER in the schemas

### DIFF
--- a/bigchaindb/common/schema/transaction_create.yaml
+++ b/bigchaindb/common/schema/transaction_create.yaml
@@ -14,6 +14,8 @@ properties:
         - type: object
           additionalProperties: true
         - type: 'null'
+    required:
+    - data
   inputs:
     type: array
     title: "Transaction inputs"

--- a/bigchaindb/common/schema/transaction_transfer.yaml
+++ b/bigchaindb/common/schema/transaction_transfer.yaml
@@ -12,6 +12,8 @@ properties:
         "$ref": "#/definitions/sha3_hexdigest"
         description: |
           ID of the transaction that created the asset.
+    required:
+    - id
   inputs:
     type: array
     title: "Transaction inputs"

--- a/tests/validation/test_transaction_structure.py
+++ b/tests/validation/test_transaction_structure.py
@@ -101,6 +101,15 @@ def test_create_tx_asset_type(create_tx):
     validate_raises(create_tx)
 
 
+def test_create_tx_no_asset_data(create_tx):
+    tx_body = create_tx.to_dict()
+    del tx_body['asset']['data']
+    tx_body_no_signatures = Transaction._remove_signatures(tx_body)
+    tx_body_serialized = Transaction._to_str(tx_body_no_signatures)
+    tx_body['id'] = Transaction._to_hash(tx_body_serialized)
+    validate_raises(tx_body)
+
+
 ################################################################################
 # Inputs
 


### PR DESCRIPTION
Troy asked me about this, turns out we were not validating the presence of the asset properties in the schemas. This PR fixes.