### PR TITLE
Edited root docs regarding transaction validity

### DIFF
--- a/docs/root/source/assets.rst
+++ b/docs/root/source/assets.rst
@@ -9,7 +9,7 @@ BigchainDB can store data of any kind (within reason), but it's designed to be p
 * The owners of an asset can specify (crypto-)conditions which must be satisified by anyone wishing transfer the asset to new owners. For example, a condition might be that at least 3 of the 5 current owners must cryptographically sign a transfer transaction.
 * BigchainDB verifies that the conditions have been satisified as part of checking the validity of transfer transactions. (Moreover, anyone can check that they were satisfied.)
 * BigchainDB prevents double-spending of an asset.
-* Validated transactions are strongly tamper-resistant; see [the section about immutability / tamper-resistance](immutable.html).
+* Validated transactions are strongly tamper-resistant; see :doc:`the page about immutability / tamper-resistance <immutable>`.
 
 
 BigchainDB Integration with Other Blockchains

--- a/docs/root/source/transaction-concepts.md
+++ b/docs/root/source/transaction-concepts.md
@@ -1,10 +1,11 @@
 # Transaction Concepts
 
-In BigchainDB, _Transactions_ are used to register, issue, create or transfer
+In BigchainDB, _transactions_ are used to register, issue, create or transfer
 things (e.g. assets).
 
 Transactions are the most basic kind of record stored by BigchainDB. There are
 two kinds: CREATE transactions and TRANSFER transactions.
+
 
 ## CREATE Transactions
 
@@ -26,6 +27,7 @@ transfer must be signed (cryptographically) by the private key associated with a
 given public key. More sophisticated conditions are possible. BigchainDB's
 conditions are based on the crypto-conditions of the [Interledger Protocol
 (ILP)](https://interledger.org/).
+
 
 ## TRANSFER Transactions
 
@@ -53,9 +55,10 @@ transferred if both Jack and Kelly sign.
 Note how the sum of the incoming paperclips must equal the sum
 of the outgoing paperclips (100).
 
+
 ## Transaction Validity
 
 When a node is asked to check if a transaction is valid, it checks several
-things. We documented those things in a post on the BigchainDB Blog.
-
-TODO (Troy): Hyperlink to the actual post, once it's published.
+things. We documented those things in a post on *The BigchainDB Blog*:
+["What is a Valid Transaction in BigchainDB?"](https://blog.bigchaindb.com/what-is-a-valid-transaction-in-bigchaindb-9a1a075a9598)
+(Note: That post was about BigchainDB Server v1.0.0.)

--- a/docs/root/source/transaction-concepts.md
+++ b/docs/root/source/transaction-concepts.md
@@ -56,30 +56,6 @@ of the outgoing paperclips (100).
 ## Transaction Validity
 
 When a node is asked to check if a transaction is valid, it checks several
-things. Some things it checks are:
+things. We documented those things in a post on the BigchainDB Blog.
 
-* Are all the fulfillments valid? (Do they correctly satisfy the conditions
-  they claim to satisfy?)
-* If it's a creation transaction, is the asset valid?
-* If it's a transfer transaction:
-   * Is it trying to fulfill a condition in a nonexistent transaction?
-   * Is it trying to fulfill a condition that's not in a valid transaction?
-     (It's okay if the condition is in a transaction in an invalid block; those
-     transactions are ignored. Transactions in the backlog or undecided blocks
-     are not ignored.)
-   * Is it trying to fulfill a condition that has already been fulfilled, or
-     that some other pending transaction (in the backlog or an undecided block)
-     also aims to fulfill?
-   * Is the asset ID in the transaction the same as the asset ID in all
-     transactions whose conditions are being fulfilled?
-   * Is the sum of the amounts in the fulfillments equal
-     to the sum of the amounts in the new conditions?
-
-If you're curious about the details of transaction validation, the code is in
-the `validate` method of the `Transaction` class, in `bigchaindb/models.py` (at
-the time of writing).
-
-Note: The check to see if the transaction ID is equal to the hash of the
-transaction body is actually done whenever the transaction is converted from a
-Python dict to a Transaction object, which must be done before the `validate`
-method can be called (since it's called on a Transaction object).
+TODO (Troy): Hyperlink to the actual post, once it's published.


### PR DESCRIPTION
Don't merge until 1) the blog post about transaction validity has been published and 2) a hyperlink to that post has been added to the `transaction-concepts.rst` page.

* The section outlining all the tests done to check transaction validity was removed and replaced with a link to a blog post on the BigchainDB Blog.
* Fixed an old error that I noticed: a hyperlink in the `assets.rst` page was still using Markdown. I changed it to RST.


