### PR TITLE
Consolidate root urls

### DIFF
--- a/bigchaindb/web/views/info.py
+++ b/bigchaindb/web/views/info.py
@@ -15,12 +15,11 @@ class RootIndex(Resource):
             'https://docs.bigchaindb.com/projects/server/en/v',
             version.__version__ + '/'
         ]
-        api_v1_url = base_url() + 'api/v1/'
         return flask.jsonify({
-            '_links': {
-                'docs': ''.join(docs_url),
-                'api_v1': api_v1_url,
+            'api': {
+                'v1': get_api_v1_info()
             },
+            'docs': ''.join(docs_url),
             'software': 'BigchainDB',
             'version': version.__version__,
             'public_key': bigchaindb.config['keypair']['public'],
@@ -30,19 +29,27 @@ class RootIndex(Resource):
 
 class ApiV1Index(Resource):
     def get(self):
-        api_root = base_url() + 'api/v1/'
-        websocket_root = base_ws_uri() + EVENTS_ENDPOINT
-        docs_url = [
-            'https://docs.bigchaindb.com/projects/server/en/v',
-            version.__version__,
-            '/http-client-server-api.html',
-        ]
-        return flask.jsonify({
-            '_links': {
-                'docs': ''.join(docs_url),
-                'self': api_root,
-                'statuses': api_root + 'statuses/',
-                'transactions': api_root + 'transactions/',
-                'streams_v1': websocket_root,
-            },
-        })
+        return flask.jsonify(get_api_v1_info())
+
+
+def get_api_v1_info():
+    """
+    Return a dict with all the information specific for the v1 of the
+    api.
+    """
+    api_root = base_url() + 'api/v1/'
+    websocket_root = base_ws_uri() + EVENTS_ENDPOINT
+    docs_url = [
+        'https://docs.bigchaindb.com/projects/server/en/v',
+        version.__version__,
+        '/http-client-server-api.html',
+    ]
+
+    return {
+        'docs': ''.join(docs_url),
+        'transactions': api_root + 'transactions/',
+        'statuses': api_root + 'statuses/',
+        'assets': api_root + 'assets/',
+        'outputs': api_root + 'outputs/',
+        'streams_v1': websocket_root
+    }

--- a/bigchaindb/web/views/info.py
+++ b/bigchaindb/web/views/info.py
@@ -51,5 +51,5 @@ def get_api_v1_info():
         'statuses': api_root + 'statuses/',
         'assets': api_root + 'assets/',
         'outputs': api_root + 'outputs/',
-        'streams_v1': websocket_root
+        'streams': websocket_root
     }

--- a/docs/server/source/websocket-event-stream-api.rst
+++ b/docs/server/source/websocket-event-stream-api.rst
@@ -26,16 +26,14 @@ It's a good idea to make sure that the node you're connecting with
 has advertised support for the Event Stream API. To do so, send a HTTP GET
 request to the node's :ref:`API Root Endpoint` 
 (e.g. ``http://localhost:9984/api/v1/``) and check that the
-response contains a ``streams_<version>`` property in ``_links``:
+response contains a ``streams`` property:
 
 .. code:: JSON
 
     {
-      "_links": {
-         ...,
-         "streams_v1": "ws://example.com:9985/api/v1/streams/valid_tx",
-         ...
-      }
+     ...,
+     "streams": "ws://example.com:9985/api/v1/streams/valid_tx",
+     ...
     }
 
 

--- a/tests/web/test_info.py
+++ b/tests/web/test_info.py
@@ -14,7 +14,7 @@ def api_v1_info():
         'statuses': 'http://localhost/api/v1/statuses/',
         'assets': 'http://localhost/api/v1/assets/',
         'outputs': 'http://localhost/api/v1/outputs/',
-        'streams_v1': 'ws://localhost:9985/api/v1/streams/valid_tx',
+        'streams': 'ws://localhost:9985/api/v1/streams/valid_tx',
     }
 
 

--- a/tests/web/test_info.py
+++ b/tests/web/test_info.py
@@ -1,16 +1,33 @@
 from unittest import mock
 
+import pytest
+
+
+@pytest.fixture
+def api_v1_info():
+    docs_url = ['https://docs.bigchaindb.com/projects/server/en/vtsttst',
+                '/http-client-server-api.html',
+                ]
+    return {
+        'docs': ''.join(docs_url),
+        'transactions': 'http://localhost/api/v1/transactions/',
+        'statuses': 'http://localhost/api/v1/statuses/',
+        'assets': 'http://localhost/api/v1/assets/',
+        'outputs': 'http://localhost/api/v1/outputs/',
+        'streams_v1': 'ws://localhost:9985/api/v1/streams/valid_tx',
+    }
+
 
 @mock.patch('bigchaindb.version.__short_version__', 'tst')
 @mock.patch('bigchaindb.version.__version__', 'tsttst')
 @mock.patch('bigchaindb.config', {'keyring': ['abc'], 'keypair': {'public': 'def'}})
-def test_api_root_endpoint(client):
+def test_api_root_endpoint(client, api_v1_info):
     res = client.get('/')
     assert res.json == {
-        '_links': {
-            'docs': 'https://docs.bigchaindb.com/projects/server/en/vtsttst/',
-            'api_v1': 'http://localhost/api/v1/',
+        'api': {
+            'v1': api_v1_info
         },
+        'docs': 'https://docs.bigchaindb.com/projects/server/en/vtsttst/',
         'version': 'tsttst',
         'keyring': ['abc'],
         'public_key': 'def',
@@ -20,17 +37,6 @@ def test_api_root_endpoint(client):
 
 @mock.patch('bigchaindb.version.__short_version__', 'tst')
 @mock.patch('bigchaindb.version.__version__', 'tsttst')
-def test_api_v1_endpoint(client):
+def test_api_v1_endpoint(client, api_v1_info):
     res = client.get('/api/v1')
-    docs_url = ['https://docs.bigchaindb.com/projects/server/en/vtsttst',
-                '/http-client-server-api.html',
-                ]
-    assert res.json == {
-        '_links': {
-            'docs': ''.join(docs_url),
-            'self': 'http://localhost/api/v1/',
-            'statuses': 'http://localhost/api/v1/statuses/',
-            'transactions': 'http://localhost/api/v1/transactions/',
-            'streams_v1': 'ws://localhost:9985/api/v1/streams/valid_tx',
-        }
-    }
+    assert res.json == api_v1_info


### PR DESCRIPTION
resolves #1147 

This pr consolidates the root urls:
- All information added to root url `/`
- Information specific to v1 under `/api/v1`
- Removed `_links`
- Removed `self`

For reference here is the output of a running server:
- `/`
```json
{
  "api": {
    "v1": {
      "assets": "http://localhost:9984/api/v1/assets/", 
      "docs": "https://docs.bigchaindb.com/projects/server/en/v0.11.0.dev/http-client-server-api.html", 
      "outputs": "http://localhost:9984/api/v1/outputs/", 
      "statuses": "http://localhost:9984/api/v1/statuses/", 
      "streams": "ws://localhost:9985/api/v1/streams/valid_tx", 
      "transactions": "http://localhost:9984/api/v1/transactions/"
    }
  }, 
  "docs": "https://docs.bigchaindb.com/projects/server/en/v0.11.0.dev/", 
  "keyring": [
    "6qHyZew94NMmUTYyHnkZsB8cxJYuRNEiEpXHe1ih9QX3", 
    "AdDuyrTyjrDt935YnFu4VBCVDhHtY2Y6rcy7x2TFeiRi"
  ], 
  "public_key": "2jgLdJsTjQ6uGUReuTt25e2ZJd7eMYZSjfxeEbVyrYkK", 
  "software": "BigchainDB", 
  "version": "0.11.0.dev"
}
```

- `/api/v1`:

```json
{
  "assets": "http://localhost:9984/api/v1/assets/", 
  "docs": "https://docs.bigchaindb.com/projects/server/en/v0.11.0.dev/http-client-server-api.html", 
  "outputs": "http://localhost:9984/api/v1/outputs/", 
  "statuses": "http://localhost:9984/api/v1/statuses/", 
  "streams": "ws://localhost:9985/api/v1/streams/valid_tx", 
  "transactions": "http://localhost:9984/api/v1/transactions/"
}
```