### PR TITLE
Benchmark compose file

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -7,10 +7,6 @@ RUN apt-get update \
     && apt-get autoremove \
     && apt-get clean
 
-VOLUME ["/data"]
-WORKDIR /data
-
-ENV BIGCHAINDB_CONFIG_PATH /data/.bigchaindb
 ENV BIGCHAINDB_SERVER_BIND 0.0.0.0:9984
 ENV BIGCHAINDB_WSSERVER_HOST 0.0.0.0
 

--- a/benchmark.yml
+++ b/benchmark.yml
@@ -1,0 +1,37 @@
+version: '2'
+
+services:
+  bdb:
+    build:
+      context: .
+      dockerfile: Dockerfile-dev
+      args:
+        backend: mongodb
+    volumes:
+      - ./bigchaindb:/usr/src/app/bigchaindb
+      - ./tests:/usr/src/app/tests
+      - ./docs:/usr/src/app/docs
+      - ./k8s:/usr/src/app/k8s
+      - ./setup.py:/usr/src/app/setup.py
+      - ./setup.cfg:/usr/src/app/setup.cfg
+      - ./pytest.ini:/usr/src/app/pytest.ini
+      - ./tox.ini:/usr/src/app/tox.ini
+      - ./scripts:/usr/src/app/scripts
+    environment:
+      BIGCHAINDB_DATABASE_BACKEND: mongodb
+      BIGCHAINDB_DATABASE_HOST: mdb
+      BIGCHAINDB_DATABASE_PORT: 27017
+      BIGCHAINDB_SERVER_BIND: 0.0.0.0:9984
+      BIGCHAINDB_GRAPHITE_HOST: graphite
+    ports:
+      - "9984"
+    command: bigchaindb start
+
+  graphite:
+    image: hopsoft/graphite-statsd
+    ports:
+      - "2003-2004"
+      - "2023-2024"
+      - "8125/udp"
+      - "8126"
+      - "80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,22 +68,11 @@ services:
       - ./setup.cfg:/usr/src/app/setup.cfg
       - ./pytest.ini:/usr/src/app/pytest.ini
       - ./tox.ini:/usr/src/app/tox.ini
-      - ./scripts:/usr/src/app/scripts
     environment:
       BIGCHAINDB_DATABASE_BACKEND: mongodb
       BIGCHAINDB_DATABASE_HOST: mdb
       BIGCHAINDB_DATABASE_PORT: 27017
       BIGCHAINDB_SERVER_BIND: 0.0.0.0:9984
-      BIGCHAINDB_GRAPHITE_HOST: graphite
     ports:
       - "9984"
-    command: bash -c 'bigchaindb -y configure mongodb && bigchaindb start'
-
-  graphite:
-    image: hopsoft/graphite-statsd
-    ports:
-      - "2003-2004"
-      - "2023-2024"
-      - "8125/udp"
-      - "8126"
-      - "80"
+    command: bigchaindb start

--- a/scripts/benchmarks/create_thoughtput.py
+++ b/scripts/benchmarks/create_thoughtput.py
@@ -7,17 +7,17 @@ import multiprocessing
 
 
 def main():
-    cmd('docker-compose up -d mdb')
-    cmd('docker-compose up -d bdb')
-    cmd('docker-compose up -d graphite')
+    cmd('docker-compose -f docker-compose.yml -f benchmark.yml up -d mdb')
+    cmd('docker-compose -f docker-compose.yml -f benchmark.yml up -d bdb')
+    cmd('docker-compose -f docker-compose.yml -f benchmark.yml up -d graphite')
 
-    out = cmd('docker-compose port graphite 80', capture=True)
+    out = cmd('docker-compose -f benchmark.yml port graphite 80', capture=True)
     graphite_web = 'http://localhost:%s/' % out.strip().split(':')[1]
     print('Graphite web interface at: ' + graphite_web)
 
     start = time.time()
 
-    cmd('docker-compose exec bdb python %s load' % sys.argv[0])
+    cmd('docker-compose -f docker-compose.yml -f benchmark.yml exec bdb python %s load' % sys.argv[0])
 
     mins = math.ceil((time.time() - start) / 60) + 1
 


### PR DESCRIPTION
Since we ("we" as in @sbellem :smile: ) currently use the `docker-compose.yml` for development purposes (e.g. running the unittests, and troubleshooting non-performance related issues), the benchmark service (graphite) has been moved into its own compose file along with a modified bigchaindb service.

This solves #1533 