### PR TITLE
Add exception handling

### DIFF
--- a/bigchaindb/web/websocket_server.py
+++ b/bigchaindb/web/websocket_server.py
@@ -111,10 +111,15 @@ def websocket_handler(request):
 
     while True:
         # Consume input buffer
-        msg = yield from websocket.receive()
+        try:
+            msg = yield from websocket.receive()
+        except RuntimeError as e:
+            logger.debug('Websocket exception: %s', str(e))
+            return websocket
+
         if msg.type == aiohttp.WSMsgType.ERROR:
             logger.debug('Websocket exception: %s', websocket.exception())
-            return
+            return websocket
 
 
 def init_app(event_source, *, loop=None):


### PR DESCRIPTION
@r-marques found that closing a WS connection using [wscat](https://github.com/websockets/wscat) generates an error on the WebSocket server. The error is not critical, but it looks bad in the logs.

This PR is to have a less alarming error when an exception occurs.