### PR TITLE
Remove relative links

### DIFF
--- a/bigchaindb/web/views/outputs.py
+++ b/bigchaindb/web/views/outputs.py
@@ -24,5 +24,5 @@ class OutputListApi(Resource):
         with pool() as bigchain:
             outputs = bigchain.get_outputs_filtered(args['public_key'],
                                                     include_spent)
-            # NOTE: We pass '..' as a path to create a valid relative URI
-            return [u.to_uri('..') for u in outputs]
+            return [{'transaction_id': output.txid, 'output': output.output}
+                    for output in outputs]

--- a/bigchaindb/web/views/statuses.py
+++ b/bigchaindb/web/views/statuses.py
@@ -29,32 +29,17 @@ class StatusApi(Resource):
             return make_error(400, 'Provide exactly one query parameter. Choices are: block_id, tx_id')
 
         pool = current_app.config['bigchain_pool']
-        status, links = None, None
+        status = None
 
         with pool() as bigchain:
             if tx_id:
                 status = bigchain.get_status(tx_id)
-                links = {
-                    'tx': '/transactions/{}'.format(tx_id)
-                }
-
             elif block_id:
                 _, status = bigchain.get_block(block_id=block_id, include_status=True)
-                # TODO: enable once blocks endpoint is available
-                # links = {
-                #     "block": "/blocks/{}".format(args['block_id'])
-                # }
 
         if not status:
             return make_error(404)
 
-        response = {
+        return {
             'status': status
         }
-
-        if links:
-            response.update({
-                '_links': links
-            })
-
-        return response

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -97,10 +97,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-  "status": "valid",
-  "_links": {
-    "tx": "/transactions/%(txid)s"
-  }
+  "status": "valid"
 }
 """
 
@@ -127,10 +124,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-  "status": "valid",
-  "_links": {
-    "block": "/blocks/%(blockid)s"
-  }
+  "status": "valid"
 }
 """
 

--- a/docs/server/source/http-client-server-api.rst
+++ b/docs/server/source/http-client-server-api.rst
@@ -176,7 +176,7 @@ not already been spent.
    a base58 encoded ed25519 public key associated with transaction output
    ownership.
 
-   Returns a list of links to transaction outputs.
+   Returns a list of transaction outputs.
 
    :param public_key: Base58 encoded public key associated with output ownership. This parameter is mandatory and without it the endpoint will return a ``400`` response code.
    :param unspent: Boolean value ("true" or "false") indicating if the result set should be limited to outputs that are available to spend. Defaults to "false".
@@ -197,8 +197,14 @@ not already been spent.
      Content-Type: application/json
 
      [
-       "../transactions/2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e/outputs/0",
-       "../transactions/2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e/outputs/1"
+       {
+         "output": 0,
+         "transaction_id": "2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e"
+       },
+       {
+         "output": 1,
+         "transaction_id": "2d431073e1477f3073a4693ac7ff9be5634751de1b8abaa1f4e19548ef0b4b0e"
+       }
      ]
 
    :statuscode 200: A list of outputs were found and returned in the body of the response.

--- a/docs/server/source/http-client-server-api.rst
+++ b/docs/server/source/http-client-server-api.rst
@@ -218,9 +218,6 @@ Statuses
 
    Get the status of an asynchronously written transaction or block by their id.
 
-   A link to the resource is also provided in the returned payload under
-   ``_links``.
-
    :query string transaction_id: transaction ID
    :query string block_id: block ID
 
@@ -252,7 +249,6 @@ Statuses
       :language: http
 
    :resheader Content-Type: ``application/json``
-   :resheader Location: Once the transaction has been persisted, this header will link to the actual resource.
 
    :statuscode 200: A transaction with that ID was found.
    :statuscode 404: A transaction with that ID was not found.
@@ -271,16 +267,10 @@ Statuses
 
    **Example response**:
 
-   .. literalinclude:: http-samples/get-statuses-block-invalid-response.http
-      :language: http
-
-   **Example response**:
-
    .. literalinclude:: http-samples/get-statuses-block-valid-response.http
       :language: http
 
    :resheader Content-Type: ``application/json``
-   :resheader Location: Once the block has been persisted, this header will link to the actual resource.
 
    :statuscode 200: A block with that ID was found.
    :statuscode 404: A block with that ID was not found.

--- a/tests/web/test_outputs.py
+++ b/tests/web/test_outputs.py
@@ -8,23 +8,28 @@ OUTPUTS_ENDPOINT = '/api/v1/outputs/'
 
 def test_get_outputs_endpoint(client, user_pk):
     m = MagicMock()
-    m.to_uri.side_effect = lambda s: 'a%sb' % s
+    m.txid = 'a'
+    m.output = 0
     with patch('bigchaindb.core.Bigchain.get_outputs_filtered') as gof:
         gof.return_value = [m, m]
         res = client.get(OUTPUTS_ENDPOINT + '?public_key={}'.format(user_pk))
-    assert res.json == ['a..b', 'a..b']
+        assert res.json == [
+            {'transaction_id': 'a', 'output': 0},
+            {'transaction_id': 'a', 'output': 0}
+        ]
     assert res.status_code == 200
     gof.assert_called_once_with(user_pk, True)
 
 
 def test_get_outputs_endpoint_unspent(client, user_pk):
     m = MagicMock()
-    m.to_uri.side_effect = lambda s: 'a%sb' % s
+    m.txid = 'a'
+    m.output = 0
     with patch('bigchaindb.core.Bigchain.get_outputs_filtered') as gof:
         gof.return_value = [m]
         params = '?unspent=true&public_key={}'.format(user_pk)
         res = client.get(OUTPUTS_ENDPOINT + params)
-    assert res.json == ['a..b']
+    assert res.json == [{'transaction_id': 'a', 'output': 0}]
     assert res.status_code == 200
     gof.assert_called_once_with(user_pk, False)
 

--- a/tests/web/test_statuses.py
+++ b/tests/web/test_statuses.py
@@ -12,7 +12,6 @@ def test_get_transaction_status_endpoint(b, client, user_pk):
     tx, status = b.get_transaction(input_tx.txid, include_status=True)
     res = client.get(STATUSES_ENDPOINT + '?transaction_id=' + input_tx.txid)
     assert status == res.json['status']
-    assert res.json['_links']['tx'] == '/transactions/{}'.format(input_tx.txid)
     assert res.status_code == 200
 
 
@@ -34,7 +33,6 @@ def test_get_block_status_endpoint_undecided(b, client):
 
     res = client.get(STATUSES_ENDPOINT + '?block_id=' + block.id)
     assert status == res.json['status']
-    assert '_links' not in res.json
     assert res.status_code == 200
 
 
@@ -55,7 +53,6 @@ def test_get_block_status_endpoint_valid(b, client):
 
     res = client.get(STATUSES_ENDPOINT + '?block_id=' + block.id)
     assert status == res.json['status']
-    assert '_links' not in res.json
     assert res.status_code == 200
 
 
@@ -76,7 +73,6 @@ def test_get_block_status_endpoint_invalid(b, client):
 
     res = client.get(STATUSES_ENDPOINT + '?block_id=' + block.id)
     assert status == res.json['status']
-    assert '_links' not in res.json
     assert res.status_code == 200
 
 


### PR DESCRIPTION
resolves #1525 

- Outputs now return and object with `{'txid': 'aaa', 'output': 0}` instead of links
- Statuses endpoints only returns the status
- Remove the documented Location HTTP headers since they are not implemented