### PR TITLE
Fix /transactions/id endpoint

### DIFF
--- a/bigchaindb/web/views/transactions.py
+++ b/bigchaindb/web/views/transactions.py
@@ -4,7 +4,7 @@ For more information please refer to the documentation: http://bigchaindb.com/ht
 """
 import logging
 
-from flask import current_app, request
+from flask import current_app, request, jsonify
 from flask_restful import Resource, reqparse
 
 from bigchaindb.common.exceptions import SchemaValidationError, ValidationError
@@ -87,4 +87,16 @@ class TransactionListApi(Resource):
             else:
                 bigchain.write_transaction(tx_obj)
 
-        return tx, 202
+        response = jsonify(tx)
+        response.status_code = 202
+
+        # NOTE: According to W3C, sending a relative URI is not allowed in the
+        # Location Header:
+        #   - https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+        #
+        # Flask is autocorrecting relative URIs. With the following command,
+        # we're able to prevent this.
+        response.autocorrect_location_header = False
+        status_monitor = '../statuses?transaction_id={}'.format(tx_obj.id)
+        response.headers['Location'] = status_monitor
+        return response

--- a/bigchaindb/web/views/transactions.py
+++ b/bigchaindb/web/views/transactions.py
@@ -28,9 +28,9 @@ class TransactionApi(Resource):
         pool = current_app.config['bigchain_pool']
 
         with pool() as bigchain:
-            tx = bigchain.get_transaction(tx_id)
+            tx, status = bigchain.get_transaction(tx_id, include_status=True)
 
-        if not tx:
+        if not tx or status is not bigchain.TX_VALID:
             return make_error(404)
 
         return tx.to_dict()

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -68,6 +68,7 @@ Content-Type: application/json
 
 TPLS['post-tx-response'] = """\
 HTTP/1.1 202 Accepted
+Location: ../statuses?transaction_id=%(txid)s
 Content-Type: application/json
 
 %(tx)s

--- a/docs/server/source/http-client-server-api.rst
+++ b/docs/server/source/http-client-server-api.rst
@@ -46,12 +46,12 @@ Transactions
 
    Get the transaction with the ID ``tx_id``.
 
-   This endpoint returns a transaction if it was included in a ``VALID`` block,
-   if it is still waiting to be processed (``BACKLOG``) or is still in an
-   undecided block (``UNDECIDED``). All instances of a transaction in invalid
-   blocks are ignored and treated as if they don't exist. If a request is made
-   for a transaction and instances of that transaction are found only in
-   invalid blocks, then the response will be ``404 Not Found``.
+   This endpoint returns a transaction if it was included in a ``VALID`` block.
+   All instances of a transaction in invalid/undecided blocks or the backlog
+   are ignored and treated as if they don't exist. If a request is made for a
+   transaction and instances of that transaction are found only in
+   invalid/undecided blocks or the backlog, then the response will be ``404 Not
+   Found``.
 
    :param tx_id: transaction ID
    :type tx_id: hex string

--- a/docs/server/source/http-client-server-api.rst
+++ b/docs/server/source/http-client-server-api.rst
@@ -147,6 +147,14 @@ Transactions
    .. literalinclude:: http-samples/post-tx-response.http
       :language: http
 
+   .. note::
+       If the server is returning a ``202`` HTTP status code, then the
+       transaction has been accepted for processing. To check the status of the
+       transaction, poll the link to the `status monitor
+       <https://docs.bigchaindb.com/projects/server/en/latest/http-client-server-api.html#get--api-v1-statuses?tx_id=tx_id>`_
+       provided in the ``Location`` header or listen to server's
+       :ref:`WebSocket Event Stream API <The WebSocket Event Stream API>`.
+
    :resheader Content-Type: ``application/json``
    :resheader Location: Relative link to a status monitor for the submitted transaction.
 

--- a/docs/server/source/http-client-server-api.rst
+++ b/docs/server/source/http-client-server-api.rst
@@ -148,6 +148,7 @@ Transactions
       :language: http
 
    :resheader Content-Type: ``application/json``
+   :resheader Location: Relative link to a status monitor for the submitted transaction.
 
    :statuscode 202: The pushed transaction was accepted in the ``BACKLOG``, but the processing has not been completed.
    :statuscode 400: The transaction was malformed and not accepted in the ``BACKLOG``.

--- a/docs/server/source/http-client-server-api.rst
+++ b/docs/server/source/http-client-server-api.rst
@@ -150,8 +150,8 @@ Transactions
    .. note::
        If the server is returning a ``202`` HTTP status code, then the
        transaction has been accepted for processing. To check the status of the
-       transaction, poll the link to the `status monitor
-       <https://docs.bigchaindb.com/projects/server/en/latest/http-client-server-api.html#get--api-v1-statuses?tx_id=tx_id>`_
+       transaction, poll the link to the
+       :ref:`status monitor <get_status_of_transaction>`
        provided in the ``Location`` header or listen to server's
        :ref:`WebSocket Event Stream API <The WebSocket Event Stream API>`.
 
@@ -225,6 +225,7 @@ Statuses
         statuses <#get--statuses?tx_id=tx_id>`_ and `block statuses
         <#get--statuses?block_id=block_id>`_).
 
+.. _get_status_of_transaction:
 
 .. http:get:: /api/v1/statuses?tx_id={tx_id}
 

--- a/tests/web/test_transactions.py
+++ b/tests/web/test_transactions.py
@@ -40,6 +40,9 @@ def test_post_create_transaction_endpoint(b, client):
 
     assert res.status_code == 202
 
+    assert '../statuses?transaction_id={}'.format(tx.id) in \
+        res.headers['Location']
+
     assert res.json['inputs'][0]['owners_before'][0] == user_pub
     assert res.json['outputs'][0]['public_keys'][0] == user_pub
 


### PR DESCRIPTION
Fixes: #1038

As was summarized [here](https://github.com/bigchaindb/bigchaindb/issues/1038#issuecomment-307831678):

- /transactions/id only returns valid transactions
- Location header included in response
- Add strategy for polling or listening to notes


Docs:

- GET /transactions/id
![tx_docs1](https://user-images.githubusercontent.com/2758453/27139821-4aa2652c-5124-11e7-8ad5-d5ebff730aa6.png)


- POST /transactions response
![tx_docs2](https://user-images.githubusercontent.com/2758453/27139837-557718b2-5124-11e7-968f-1fbb77aba88e.png)
