### PR TITLE
Updated the root docs page titled "Production-Ready?"

### DIFF
--- a/docs/root/source/production-ready.md
+++ b/docs/root/source/production-ready.md
@@ -1,7 +1,14 @@
 # Production-Ready?
 
 BigchainDB is not production-ready. You can use it to build a prototype or proof-of-concept (POC); many people are already doing that.
+Once BigchainDB is production-ready, we'll make an announcement.
 
-BigchainDB Server is currently in version 0.X. ([The Releases page on GitHub](https://github.com/bigchaindb/bigchaindb/releases) has the exact version number.) Once BigchainDB Server is production-ready, we'll issue an announcement.
+BigchainDB version numbers follow the conventions of *Semantic Versioning* as documented at [semver.org](http://semver.org/). This means, among other things:
+
+* Before version 1.0, breaking API changes could happen in any new version, even in a change from version 0.Y.4 to 0.Y.5.
+
+* Starting with version 1.0.0, breaking API changes will only happen when the MAJOR version changes (e.g. from 1.7.4 to 2.0.0, or from 4.9.3 to 5.0.0).
+
+To review the release history of some particular BigchainDB software, go to the GitHub repository of that software and click on "Releases". For example, the release history of BigchainDB Server can be found at [https://github.com/bigchaindb/bigchaindb/releases](https://github.com/bigchaindb/bigchaindb/releases).
 
 [The BigchainDB Roadmap](https://github.com/bigchaindb/org/blob/master/ROADMAP.md) will give you a sense of the things we intend to do with BigchainDB in the near term and the long term.


### PR DESCRIPTION
In preparation for the release of version 1.0.0, which is significant mostly because of what it means in terms of API changes, I made some changes to the **Production-Ready?** page in the root docs.

* I made it explicit that we are following Semantic Versioning, as documented at semver.org (and I included a link there). I outlined two implications of that, with example version numbers.
* I also explained how to find the release history of software on GitHub (for those who don't know), with a link to an example: the BigchainDB Server release history.