### PR TITLE
Added more docs about the wsserver.scheme config setting

### DIFF
--- a/docs/server/source/server-reference/configuration.md
+++ b/docs/server/source/server-reference/configuration.md
@@ -182,12 +182,14 @@ export BIGCHAINDB_SERVER_THREADS=5
 ```
 
 
-## wsserver.host and wsserver.port
+## wsserver.scheme, wsserver.host and wsserver.port
 
 These settings are for the
 [aiohttp server](https://aiohttp.readthedocs.io/en/stable/index.html), 
 which is used to serve the
 [WebSocket Event Stream API](../websocket-event-stream-api.html).
+`wsserver.scheme` should be either `"ws"` or `"wss"`
+(but setting it to `"wss"` does *not* enable SSL/TLS).
 `wsserver.host` is where to bind the aiohttp server socket and
 `wsserver.port` is the corresponding port.
 If you want to allow connections from anyone, on port 9985,
@@ -195,6 +197,7 @@ set `wsserver.host` to 0.0.0.0 and `wsserver.port` to 9985.
 
 **Example using environment variables**
 ```text
+export BIGCHAINDB_WSSERVER_SCHEME=ws
 export BIGCHAINDB_WSSERVER_HOST=0.0.0.0
 export BIGCHAINDB_WSSERVER_PORT=9985
 ```
@@ -202,6 +205,7 @@ export BIGCHAINDB_WSSERVER_PORT=9985
 **Example config file snippet**
 ```js
 "wsserver": {
+    "scheme": "wss",
     "host": "0.0.0.0",
     "port": 65000
 }
@@ -210,6 +214,7 @@ export BIGCHAINDB_WSSERVER_PORT=9985
 **Default values (from a config file)**
 ```js
 "wsserver": {
+    "scheme": "ws",
     "host": "localhost",
     "port": 9985
 }


### PR DESCRIPTION
This pull request is a follow-up to pull request #1538, which added the `wsserver.scheme` configuration setting. It adds some more documentation about that setting. I'm not exactly sure what it means or how it's used internally. Any additional comments on that would be appreciated.