### PR TITLE
tx version break step with server version

### DIFF
--- a/bigchaindb/common/schema/transaction.yaml
+++ b/bigchaindb/common/schema/transaction.yaml
@@ -56,7 +56,7 @@ properties:
       See: `Metadata`_.
   version:
     type: string
-    pattern: "^1.0$"
+    pattern: "^1\\.0$"
     description: |
         BigchainDB transaction schema version.
 definitions:

--- a/bigchaindb/common/schema/transaction.yaml
+++ b/bigchaindb/common/schema/transaction.yaml
@@ -56,7 +56,7 @@ properties:
       See: `Metadata`_.
   version:
     type: string
-    pattern: "^0\\."
+    pattern: "^1.0$"
     description: |
         BigchainDB transaction schema version.
 definitions:

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -414,7 +414,7 @@ class Transaction(object):
                 ``id`` property.
             metadata (dict):
                 Metadata to be stored along with the Transaction.
-            version (int): Defines the version number of a Transaction.
+            version (string): Defines the version number of a Transaction.
     """
     CREATE = 'CREATE'
     TRANSFER = 'TRANSFER'
@@ -440,6 +440,7 @@ class Transaction(object):
                     lock.
                 metadata (dict): Metadata to be stored along with the
                     Transaction.
+                version (string): Defines the version number of a Transaction.
         """
         if operation not in Transaction.ALLOWED_OPERATIONS:
             allowed_ops = ', '.join(self.__class__.ALLOWED_OPERATIONS)

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -10,7 +10,6 @@ from bigchaindb.common.exceptions import (KeypairMismatchException,
                                           InvalidHash, InvalidSignature,
                                           AmountError, AssetIdMismatch)
 from bigchaindb.common.utils import serialize, gen_timestamp
-import bigchaindb.version
 
 
 class Input(object):
@@ -421,7 +420,7 @@ class Transaction(object):
     TRANSFER = 'TRANSFER'
     GENESIS = 'GENESIS'
     ALLOWED_OPERATIONS = (CREATE, TRANSFER, GENESIS)
-    VERSION = '.'.join(bigchaindb.version.__short_version__.split('.')[:2])
+    VERSION = '1.0'
 
     def __init__(self, operation, asset, inputs=None, outputs=None,
                  metadata=None, version=None):
@@ -441,7 +440,6 @@ class Transaction(object):
                     lock.
                 metadata (dict): Metadata to be stored along with the
                     Transaction.
-                version (int): Defines the version number of a Transaction.
         """
         if operation not in Transaction.ALLOWED_OPERATIONS:
             allowed_ops = ', '.join(self.__class__.ALLOWED_OPERATIONS)

--- a/tests/validation/test_transaction_structure.py
+++ b/tests/validation/test_transaction_structure.py
@@ -165,6 +165,8 @@ def test_high_amounts(create_tx):
 # Version
 
 def test_validate_version(create_tx):
+    create_tx.version = '1.0'
+    validate(create_tx)
     create_tx.version = '0.10'
     validate_raises(create_tx)
     create_tx.version = '110'

--- a/tests/validation/test_transaction_structure.py
+++ b/tests/validation/test_transaction_structure.py
@@ -167,3 +167,5 @@ def test_high_amounts(create_tx):
 def test_validate_version(create_tx):
     create_tx.version = '0.10'
     validate_raises(create_tx)
+    create_tx.version = '110'
+    validate_raises(create_tx)

--- a/tests/validation/test_transaction_structure.py
+++ b/tests/validation/test_transaction_structure.py
@@ -165,14 +165,5 @@ def test_high_amounts(create_tx):
 # Version
 
 def test_validate_version(create_tx):
-    import re
-    import bigchaindb.version
-
-    short_ver = bigchaindb.version.__short_version__
-    assert create_tx.version == re.match(r'^(.*\d)', short_ver).group(1)
-
-    validate(create_tx)
-
-    # At version 1, transaction version will break step with server version.
-    create_tx.version = '1.0.0'
+    create_tx.version = '0.10'
     validate_raises(create_tx)


### PR DESCRIPTION
Transaction now has its own version and it must be `1.0` to validate.

Part of the resolution of #1558 