### PR TITLE
Bump up nginx-3scale version number

### DIFF
--- a/k8s/nginx-3scale/nginx-3scale-dep.yaml
+++ b/k8s/nginx-3scale/nginx-3scale-dep.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: nginx-3scale
-        image: bigchaindb/nginx_3scale:1.4
+        image: bigchaindb/nginx_3scale:1.5
         imagePullPolicy: Always
         env:
         - name: MONGODB_FRONTEND_PORT


### PR DESCRIPTION
The newer container includes support for CORS.
Corresponding changes located  [here](https://github.com/bigchaindb/nginx_3scale/pull/15).