### PR TITLE
Copyedited MongoDB SSL Certificate Setup Docs

### DIFF
--- a/docs/server/source/production-deployment-template/ca-installation.rst
+++ b/docs/server/source/production-deployment-template/ca-installation.rst
@@ -33,15 +33,12 @@ by going to the ``bdb-cluster-ca/easy-rsa-3.0.1/easyrsa3`` directory and using:
         
    ./easyrsa build-ca
 
-You will be prompted to enter the Distinguished Name for this CA. You can hit
-enter to accept the default values or change it at each prompt.
-
-You will also be asked to enter a PEM pass phrase for encrypting the ``ca.key`` file.
+You will also be asked to enter a PEM pass phrase (for encrypting the ``ca.key`` file).
 Make sure to securely store that PEM pass phrase.
 If you lose it, you won't be able to add or remove entities from your PKI infrastructure in the future.
 
-It will ask several other questions.
-You can accept all the defaults [in brackets] by pressing Enter.
+You will be prompted to enter the Distinguished Name (DN) information for this CA.
+For each field, you can accept the default value [in brackets] by pressing Enter.
 While ``Easy-RSA CA`` *is* a valid and acceptable Common Name,
 you should probably enter a name based on the name of the managing organization,
 e.g. ``Omega Ledger CA``.

--- a/docs/server/source/production-deployment-template/ca-installation.rst
+++ b/docs/server/source/production-deployment-template/ca-installation.rst
@@ -39,6 +39,11 @@ If you lose it, you won't be able to add or remove entities from your PKI infras
 
 You will be prompted to enter the Distinguished Name (DN) information for this CA.
 For each field, you can accept the default value [in brackets] by pressing Enter.
+
+.. warning::
+
+   Don't accept the default value of OU (``IT``). Instead, enter the value ``ROOT-CA``.
+
 While ``Easy-RSA CA`` *is* a valid and acceptable Common Name,
 you should probably enter a name based on the name of the managing organization,
 e.g. ``Omega Ledger CA``.

--- a/docs/server/source/production-deployment-template/client-tls-certificate.rst
+++ b/docs/server/source/production-deployment-template/client-tls-certificate.rst
@@ -24,7 +24,7 @@ Step 2: Create the Client Private Key and CSR
 ---------------------------------------------
 
 You can create the client private key and certificate signing request (CSR)
-by going into the directory ``client-cert/easy-rsa-3.0.1/easyrsa``
+by going into the directory ``client-cert/easy-rsa-3.0.1/easyrsa3``
 and using:
 
 .. code:: bash
@@ -33,25 +33,37 @@ and using:
 
    ./easyrsa gen-req bdb-instance-0 nopass
 
-You should change ``bdb-instance-0`` to a value that reflects what the 
-client certificate is being used for.
+You should change the Common Name (e.g. ``bdb-instance-0``)
+to a value that reflects what the 
+client certificate is being used for, e.g. ``mdb-mon-instance-3`` or ``mdb-bak-instance-4``. (The final integer is specific to your BigchainDB node in the BigchainDB cluster.)
 
-Tip: You can get help with the ``easyrsa`` command (and its subcommands)
-by using the subcommand ``./easyrsa help``
+You will be prompted to enter the Distinguished Name (DN) information for this certificate. For each field, you can accept the default value [in brackets] by pressing Enter.
+
+.. warning::
+
+   Don't accept the default value of OU (``IT``). Instead, enter the value
+   ``BigchainDB-Instance``, ``MongoDB-Mon-Instance`` or ``MongoDB-Backup-Instance``
+   as appropriate.
+
+Aside: The ``nopass`` option means "do not encrypt the private key (default is encrypted)". You can get help with the ``easyrsa`` command (and its subcommands)
+by using the subcommand ``./easyrsa help``.
 
 
 Step 3: Get the Client Certificate Signed
 -----------------------------------------
 
-The CSR file (created in the previous step)
-should be located in ``pki/reqs/bdb-instance-0.req``.
+The CSR file created in the previous step
+should be located in ``pki/reqs/bdb-instance-0.req``
+(or whatever Common Name you used in the ``gen-req`` command above).
 You need to send it to the organization managing the cluster
 so that they can use their CA
 to sign the request.
 (The managing organization should already have a self-signed CA.)
 
 If you are the admin of the managing organization's self-signed CA,
-then you can import the CSR and use Easy-RSA to sign it. For example:
+then you can import the CSR and use Easy-RSA to sign it.
+Go to your ``bdb-cluster-ca/easy-rsa-3.0.1/easyrsa3/``
+directory and do something like:
 
 .. code:: bash
         

--- a/docs/server/source/production-deployment-template/easy-rsa.rst
+++ b/docs/server/source/production-deployment-template/easy-rsa.rst
@@ -66,17 +66,15 @@ The comments in the file explain what each of the variables mean.
    echo 'set_var EASYRSA_REQ_PROVINCE "Berlin"' >> vars
    echo 'set_var EASYRSA_REQ_CITY "Berlin"' >> vars
    echo 'set_var EASYRSA_REQ_ORG "BigchainDB GmbH"' >> vars
+   echo 'set_var EASYRSA_REQ_OU "IT"' >> vars
    echo 'set_var EASYRSA_REQ_EMAIL "dev@bigchaindb.com"' >> vars
 
-We follow the convention of setting the OU to ``ROOT-CA``,
+Note: Later, when building a CA or generating a certificate signing request, you will be prompted to enter a value for the OU (or to accept the default). You should change the default OU from ``IT`` to one of the following, as appropriate:
+``ROOT-CA``,
 ``MongoDB-Instance``, ``BigchainDB-Instance``, ``MongoDB-Mon-Instance`` or
-``MongoDB-Backup-Instance`` as appropriate.
-Replace ``insert-name-here`` with the appropriate name
-(e.g. ``ROOT-CA``) in:
-
-.. code:: bash
-
-   echo 'set_var EASYRSA_REQ_OU "insert-name-here"' >> vars
+``MongoDB-Backup-Instance``.
+To understand why, see `the MongoDB Manual <https://docs.mongodb.com/manual/tutorial/configure-x509-client-authentication/>`_.
+There are reminders to do this in the relevant docs.
 
 
 Step 4: Maybe Edit x509-types/server

--- a/docs/server/source/production-deployment-template/easy-rsa.rst
+++ b/docs/server/source/production-deployment-template/easy-rsa.rst
@@ -66,12 +66,17 @@ The comments in the file explain what each of the variables mean.
    echo 'set_var EASYRSA_REQ_PROVINCE "Berlin"' >> vars
    echo 'set_var EASYRSA_REQ_CITY "Berlin"' >> vars
    echo 'set_var EASYRSA_REQ_ORG "BigchainDB GmbH"' >> vars
-   echo 'set_var EASYRSA_REQ_OU "IT"' >> vars
    echo 'set_var EASYRSA_REQ_EMAIL "dev@bigchaindb.com"' >> vars
 
-We follow the convention of modifying the OU to ``ROOT-CA``,
-``MongoDB-Instance``, ``BigchainDB-Instance``, ``MongoDB-Mon-Instance`` and
-``MongoDB-Backup-Instance`` while issuing certificates.
+We follow the convention of setting the OU to ``ROOT-CA``,
+``MongoDB-Instance``, ``BigchainDB-Instance``, ``MongoDB-Mon-Instance`` or
+``MongoDB-Backup-Instance`` as appropriate.
+Replace ``insert-name-here`` with the appropriate name
+(e.g. ``ROOT-CA``) in:
+
+.. code:: bash
+
+   echo 'set_var EASYRSA_REQ_OU "insert-name-here"' >> vars
 
 
 Step 4: Maybe Edit x509-types/server
@@ -81,7 +86,7 @@ Step 4: Maybe Edit x509-types/server
 
    Only do this step if you are setting up a self-signed CA.
 
-Edit the file ``x509-types/server`` and change
-``extendedKeyUsage = serverAuth`` to 
-``extendedKeyUsage = serverAuth,clientAuth``.
-See `the MongoDB documentation about x.509 authentication <https://docs.mongodb.com/manual/core/security-x.509/>`_ to understand why.
+   Edit the file ``x509-types/server`` and change
+   ``extendedKeyUsage = serverAuth`` to
+   ``extendedKeyUsage = serverAuth,clientAuth``.
+   See `the MongoDB documentation about x.509 authentication <https://docs.mongodb.com/manual/core/security-x.509/>`_ to understand why.

--- a/docs/server/source/production-deployment-template/revoke-tls-certificate.rst
+++ b/docs/server/source/production-deployment-template/revoke-tls-certificate.rst
@@ -39,3 +39,5 @@ Generate a new CRL for your infrastructure using:
 
 The generated ``crl.pem`` file needs to be uploaded to your infrastructure to
 prevent the revoked certificate from being used again.
+
+In particlar, the generated ``crl.pem`` file should be sent to all BigchainDB node operators in your BigchainDB cluster, so that they can update it in their MongoDB instance and their BigchainDB Server instance.

--- a/docs/server/source/production-deployment-template/server-tls-certificate.rst
+++ b/docs/server/source/production-deployment-template/server-tls-certificate.rst
@@ -26,7 +26,7 @@ Step 2: Create the Server Private Key and CSR
 ---------------------------------------------
 
 You can create the server private key and certificate signing request (CSR)
-by going into the directory ``member-cert/easy-rsa-3.0.1/easyrsa``
+by going into the directory ``member-cert/easy-rsa-3.0.1/easyrsa3``
 and using something like:
 
 .. code:: bash
@@ -35,15 +35,17 @@ and using something like:
 
    ./easyrsa --req-cn=mdb-instance-0 --subject-alt-name=DNS:localhost,DNS:mdb-instance-0 gen-req mdb-instance-0 nopass
 
-You will be prompted to enter the Distinguished Name for this certificate. You
-can hit enter to accept the default values or change them at each prompt.
+You should replace the Common Name (``mdb-instance-0`` above) with the correct name for *your* MongoDB instance in the cluster, e.g. ``mdb-instance-5`` or ``mdb-instance-12``. (This name is decided by the organization managing the cluster.)
 
-You can replace the common name (``mdb-instance-0`` above) with any other name
-so long as the instance can verify that it is the hostname.
+You will be prompted to enter the Distinguished Name (DN) information for this certificate.
+For each field, you can accept the default value [in brackets] by pressing Enter.
 
-You need to provide the ``DNS:localhost`` SAN during certificate generation
+.. warning::
+
+   Don't accept the default value of OU (``IT``). Instead, enter the value ``MongoDB-Instance``.
+
+Aside: You need to provide the ``DNS:localhost`` SAN during certificate generation
 for using the ``localhost exception`` in the MongoDB instance.
-
 All certificates can have this attribute without compromising security as the
 ``localhost exception`` works only the first time.
 
@@ -51,15 +53,18 @@ All certificates can have this attribute without compromising security as the
 Step 3: Get the Server Certificate Signed
 -----------------------------------------
 
-The CSR file (created in the last step)
-should be located in ``pki/reqs/mdb-instance-0.req``.
+The CSR file created in the last step
+should be located in ``pki/reqs/mdb-instance-0.req``
+(where the integer ``0`` may be different for you).
 You need to send it to the organization managing the cluster
 so that they can use their CA
 to sign the request.
 (The managing organization should already have a self-signed CA.)
 
 If you are the admin of the managing organization's self-signed CA,
-then you can import the CSR and use Easy-RSA to sign it. For example:
+then you can import the CSR and use Easy-RSA to sign it.
+Go to your ``bdb-cluster-ca/easy-rsa-3.0.1/easyrsa3/``
+directory and do something like:
 
 .. code:: bash
         

--- a/docs/server/source/production-deployment-template/workflow.rst
+++ b/docs/server/source/production-deployment-template/workflow.rst
@@ -119,9 +119,13 @@ allow easier periodic rotation of the ``Agent API Key`` with a constant
 #. Client Certificate for BigchainDB Server to identify itself to MongoDB
 #. Client Certificate for MongoDB Monitoring Agent to identify itself to MongoDB
 #. Client Certificate for MongoDB Backup Agent to identify itself to MongoDB
-#. CRL for the infrastructure to not accept revoked certificates.
 
-Ask the managing organization to use its self-signed CA to sign those certificates.
+Ask the managing organization to use its self-signed CA to sign those four certificates.
+They should send you:
+
+* Signed versions of your four certificates.
+* One ``ca.crt`` file: their CA certificate.
+* One ``crl.pem`` file: a certificate revocation list.
 
 For help, see the pages:
 

--- a/docs/server/source/production-deployment-template/workflow.rst
+++ b/docs/server/source/production-deployment-template/workflow.rst
@@ -53,6 +53,26 @@ Similarly, other instances must also have unique names in the cluster.
 #. Name of the MongoDB backup agent instance (``mdb-bak-instance-*``)
 
 
+☐ Generate four keys and corresponding certificate signing requests (CSRs):
+
+#. Server Certificate (a.k.a. Member Certificate) for the MongoDB instance
+#. Client Certificate for BigchainDB Server to identify itself to MongoDB
+#. Client Certificate for MongoDB Monitoring Agent to identify itself to MongoDB
+#. Client Certificate for MongoDB Backup Agent to identify itself to MongoDB
+
+Ask the managing organization to use its self-signed CA to sign those four CSRs.
+They should send you:
+
+* Four certificates (one for each CSR you sent them).
+* One ``ca.crt`` file: their CA certificate.
+* One ``crl.pem`` file: a certificate revocation list.
+
+For help, see the pages:
+
+* :ref:`How to Generate a Server Certificate for MongoDB`
+* :ref:`How to Generate a Client Certificate for MongoDB`
+
+
 ☐ Every node in a BigchainDB cluster needs its own
 BigchainDB keypair (i.e. a public key and corresponding private key).
 You can generate a BigchainDB keypair for your node, for example,
@@ -73,28 +93,15 @@ Don't share your private key.
 That list of public keys is known as the BigchainDB "keyring."
 
 
-☐ Ask the managing organization
-for the FQDN used to serve the BigchainDB APIs
-(e.g. ``api.orgname.net`` or ``bdb.clustername.com``).
-
-
 ☐ Make up an FQDN for your BigchainDB node (e.g. ``mynode.mycorp.com``).
 Make sure you've registered the associated domain name (e.g. ``mycorp.com``),
 and have an SSL certificate for the FQDN.
-(You can get an SSL certificate from any SSL certificate provider).
-
-
-☐ Share your BigchaindB *public* key with all the other nodes
-in the BigchainDB cluster.
-Don't share your private key.
-
-
-☐ Get the BigchainDB public keys of all the other nodes in the cluster.
-That list of public keys is known as the BigchainDB "keyring."
+(You can get an SSL certificate from any SSL certificate provider.)
 
 
 ☐ Ask the managing organization
 for the FQDN used to serve the BigchainDB APIs
+(e.g. ``api.orgname.net`` or ``bdb.clustername.com``)
 and for a copy of the associated SSL/TLS certificate.
 Also, ask for the user name to use for authenticating to MongoDB.
 
@@ -113,41 +120,11 @@ allow easier periodic rotation of the ``Agent API Key`` with a constant
 ``Group ID``)
 
 
-☐ Generate four keys and corresponding certificate signing requests (CSRs):
-
-#. Server Certificate (a.k.a. Member Certificate) for the MongoDB instance
-#. Client Certificate for BigchainDB Server to identify itself to MongoDB
-#. Client Certificate for MongoDB Monitoring Agent to identify itself to MongoDB
-#. Client Certificate for MongoDB Backup Agent to identify itself to MongoDB
-
-Ask the managing organization to use its self-signed CA to sign those four certificates.
-They should send you:
-
-* Signed versions of your four certificates.
-* One ``ca.crt`` file: their CA certificate.
-* One ``crl.pem`` file: a certificate revocation list.
-
-For help, see the pages:
-
-* :ref:`How to Generate a Server Certificate for MongoDB`
-* :ref:`How to Generate a Client Certificate for MongoDB`
-
-
 ☐ :doc:`Deploy a Kubernetes cluster on Azure <template-kubernetes-azure>`.
 
 
-☐ Create the Kubernetes Configuration for this node. 
-We will use Kubernetes ConfigMaps and Secrets to hold all the information
-gathered above.
-
-
-☐ Deploy your BigchainDB node on your Kubernetes cluster.
-
-Next Steps To Set Up a Node
----------------------------
-
-You can now proceed to set up your BigchainDB node based on whether it is the
-:ref:`first node in you cluster
+☐ You can now proceed to set up your BigchainDB node based on whether it is the
+:ref:`first node in a new cluster
 <Kubernetes Template: Deploy a Single BigchainDB Node>` or a
 :ref:`node that will be added to an existing cluster
 <Kubernetes Template: Add a BigchainDB Node to an Existing BigchainDB Cluster>`.


### PR DESCRIPTION
A bunch of minor clarifications, fixes, and edits to the Production Deployment Template documentation about how to create the SSL certificates used for MongoDB auth.

There will be more copyedits as I go through the Production Deployment Template docs but I will put those in a separate pull request.