### PR TITLE
Parametrize websocket api tests for docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       BIGCHAINDB_DATABASE_HOST: mdb
       BIGCHAINDB_DATABASE_PORT: 27017
       BIGCHAINDB_SERVER_BIND: 0.0.0.0:9984
+      BIGCHAINDB_WSSERVER_HOST: 0.0.0.0
     ports:
       - "9984"
     command: bigchaindb start

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -480,3 +480,29 @@ def mocked_setup_sub_logger(mocker):
 def certs_dir():
     cwd = os.environ.get('TRAVIS_BUILD_DIR', os.getcwd())
     return cwd + '/tests/backend/mongodb-ssl/certs'
+
+
+@pytest.fixture
+def wsserver_config():
+    from bigchaindb import config
+    return config['wsserver']
+
+
+@pytest.fixture
+def wsserver_scheme(wsserver_config):
+    return wsserver_config['scheme']
+
+
+@pytest.fixture
+def wsserver_host(wsserver_config):
+    return wsserver_config['host']
+
+
+@pytest.fixture
+def wsserver_port(wsserver_config):
+    return wsserver_config['port']
+
+
+@pytest.fixture
+def wsserver_base_url(wsserver_scheme, wsserver_host, wsserver_port):
+    return '{}://{}:{}'.format(wsserver_scheme, wsserver_host, wsserver_port)

--- a/tests/web/test_info.py
+++ b/tests/web/test_info.py
@@ -4,7 +4,7 @@ from unittest import mock
 @mock.patch('bigchaindb.version.__short_version__', 'tst')
 @mock.patch('bigchaindb.version.__version__', 'tsttst')
 @mock.patch('bigchaindb.config', {'keyring': ['abc'], 'keypair': {'public': 'def'}})
-def test_api_root_endpoint(client):
+def test_api_root_endpoint(client, wsserver_base_url):
     res = client.get('/')
     docs_url = ['https://docs.bigchaindb.com/projects/server/en/vtsttst',
                 '/http-client-server-api.html']
@@ -16,7 +16,8 @@ def test_api_root_endpoint(client):
                 'statuses': '/api/v1/statuses/',
                 'assets': '/api/v1/assets/',
                 'outputs': '/api/v1/outputs/',
-                'streams': 'ws://localhost:9985/api/v1/streams/valid_transactions',
+                'streams': '{}/api/v1/streams/valid_transactions'.format(
+                    wsserver_base_url),
             }
         },
         'docs': 'https://docs.bigchaindb.com/projects/server/en/vtsttst/',
@@ -29,7 +30,7 @@ def test_api_root_endpoint(client):
 
 @mock.patch('bigchaindb.version.__short_version__', 'tst')
 @mock.patch('bigchaindb.version.__version__', 'tsttst')
-def test_api_v1_endpoint(client):
+def test_api_v1_endpoint(client, wsserver_base_url):
     docs_url = ['https://docs.bigchaindb.com/projects/server/en/vtsttst',
                 '/http-client-server-api.html']
     api_v1_info = {
@@ -38,7 +39,8 @@ def test_api_v1_endpoint(client):
         'statuses': '/statuses/',
         'assets': '/assets/',
         'outputs': '/outputs/',
-        'streams': 'ws://localhost:9985/api/v1/streams/valid_transactions',
+                'streams': '{}/api/v1/streams/valid_transactions'.format(
+                    wsserver_base_url),
     }
     res = client.get('/api/v1')
     assert res.json == api_v1_info


### PR DESCRIPTION
Without this the two tests (parametrized via this PR), fail when running the tests with docker.