### PR TITLE
More prod depl template copyedits

### DIFF
--- a/docs/server/source/production-deployment-template/node-config-map-and-secrets.rst
+++ b/docs/server/source/production-deployment-template/node-config-map-and-secrets.rst
@@ -29,8 +29,8 @@ where all data values must be base64-encoded.
 This is true of all Kubernetes ConfigMaps and Secrets.)
 
 
-vars
-~~~~
+vars.mdb-instance-name and Similar
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Your BigchainDB cluster organization should have a standard way
 of naming instances, so the instances in your BigchainDB node
@@ -59,11 +59,14 @@ of all *other* nodes in your BigchainDB cluster
 * If you're deploying the first node in the cluster,
   the value should be ``""`` (an empty string).
 * If you're deploying the second node in the cluster,
-  the value should be one public key inside double quotes.
+  the value should be the BigchainDB public key of the first/original
+  node in the cluster, inside double quotes.
   For example,
   ``"EPQk5i5yYpoUwGVM8VKZRjM8CYxB6j8Lu8i8SG7kGGce"``
 * If there are two or more other nodes already in the cluster,
-  the value should be a colon-separated list of public keys
+  the value should be a colon-separated list
+  of the BigchainDB public keys
+  of those other nodes,
   inside double quotes.
   For example,
   ``"DPjpKbmbPYPKVAuf6VSkqGCf5jzrEh69Ldef6TrLwsEQ:EPQk5i5yYpoUwGVM8VKZRjM8CYxB6j8Lu8i8SG7kGGce"``

--- a/docs/server/source/production-deployment-template/node-config-map-and-secrets.rst
+++ b/docs/server/source/production-deployment-template/node-config-map-and-secrets.rst
@@ -122,6 +122,31 @@ field (``bdb-certs.bdb-user``), i.e.
    emailAddress=dev@bigchaindb.com,CN=test-bdb-ssl,OU=BigchainDB-Instance,O=BigchainDB GmbH,L=Berlin,ST=Berlin,C=DE
 
 
+threescale-credentials.*
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can delete the ``threescale-credentials`` Secret if you're not using 3scale.
+
+If you *are* using 3scale, you can get the value for ``frontend-api-dns-name``
+using something like ``echo "your.nodesubdomain.net" | base64 -w 0``
+
+To get the values for ``secret-token``, ``service-id``,
+``version-header`` and ``provider-key``, login to your 3scale admin,
+then click **APIs** and click on **Integration** for the relevant API.
+Scroll to the bottom of the page and click the small link
+in the lower right corner, labelled **Download the NGINX Config files**.
+You'll get a ``.zip`` file.
+Unzip it, then open the ``.conf`` file and the ``.lua`` file.
+You should be able to find all the values in those files.
+You have to be careful because it will have values for *all* your APIs,
+and some values vary from API to API.
+The ``version-header`` is the timestamp in a line that looks like:
+
+.. code::
+
+    proxy_set_header  X-3scale-Version "2017-06-28T14:57:34Z";
+
+
 Deploy Your config-map.yaml and secret.yaml
 -------------------------------------------
 

--- a/docs/server/source/production-deployment-template/node-config-map-and-secrets.rst
+++ b/docs/server/source/production-deployment-template/node-config-map-and-secrets.rst
@@ -124,7 +124,9 @@ field (``bdb-certs.bdb-user``), i.e.
 threescale-credentials.*
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can delete the ``threescale-credentials`` Secret if you're not using 3scale.
+If you're not using 3scale,
+you can delete the ``threescale-credentials`` Secret
+or leave all the values blank (``""``).
 
 If you *are* using 3scale, you can get the value for ``frontend-api-dns-name``
 using something like ``echo "your.nodesubdomain.net" | base64 -w 0``

--- a/docs/server/source/production-deployment-template/node-config-map-and-secrets.rst
+++ b/docs/server/source/production-deployment-template/node-config-map-and-secrets.rst
@@ -60,14 +60,13 @@ of all *other* nodes in your BigchainDB cluster
   the value should be ``""`` (an empty string).
 * If you're deploying the second node in the cluster,
   the value should be the BigchainDB public key of the first/original
-  node in the cluster, inside double quotes.
+  node in the cluster.
   For example,
   ``"EPQk5i5yYpoUwGVM8VKZRjM8CYxB6j8Lu8i8SG7kGGce"``
 * If there are two or more other nodes already in the cluster,
   the value should be a colon-separated list
   of the BigchainDB public keys
-  of those other nodes,
-  inside double quotes.
+  of those other nodes.
   For example,
   ``"DPjpKbmbPYPKVAuf6VSkqGCf5jzrEh69Ldef6TrLwsEQ:EPQk5i5yYpoUwGVM8VKZRjM8CYxB6j8Lu8i8SG7kGGce"``
 

--- a/docs/server/source/production-deployment-template/template-kubernetes-azure.rst
+++ b/docs/server/source/production-deployment-template/template-kubernetes-azure.rst
@@ -102,7 +102,7 @@ Finally, you can deploy an ACS using something like:
    --agent-vm-size Standard_D2_v2 \
    --dns-prefix <make up a name> \
    --ssh-key-value ~/.ssh/<name>.pub \
-   --orchestrator-type kubernetes
+   --orchestrator-type kubernetes \
    --debug --output json
 
 

--- a/k8s/configuration/secret.yaml
+++ b/k8s/configuration/secret.yaml
@@ -94,8 +94,9 @@ type: Opaque
 data:
   # Base64-encoded HTTPS private key
   cert.key: "<b64 encoded HTTPS private key>"
-  # Base64-encoded HTTPS Signed Certificate or Certificate Chain
-  cert.pem: "<b64 encoded HTTPS Signed Certificate or Certificate Chain>"
+  # Base64-encoded HTTPS certificate chain
+  # including all intermediate certificates and the actual certificate
+  cert.pem: "<b64 encoded HTTPS certificate chain"
 ---
 apiVersion: v1
 kind: Secret

--- a/k8s/configuration/secret.yaml
+++ b/k8s/configuration/secret.yaml
@@ -77,7 +77,7 @@ data:
   # Base64-encoded CA certificate (ca.crt)
   ca.pem: "<b64 encoded CA certificate>"
   # Base64-encoded CRL file
-  crlfile: "<b64 encoded CRL>",
+  crlfile: "<b64 encoded CRL>"
   # Base64-encoded BigchainDB instance certificate
   bdb-instance.pem: "<b64 encoded certificate>"
   # Base64-encoded private key

--- a/k8s/configuration/secret.yaml
+++ b/k8s/configuration/secret.yaml
@@ -95,7 +95,9 @@ data:
   # Base64-encoded HTTPS private key
   cert.key: "<b64 encoded HTTPS private key>"
   # Base64-encoded HTTPS certificate chain
-  # including all intermediate certificates and the actual certificate
+  # starting with your primary SSL cert (e.g. your_domain.crt)
+  # followed by all intermediate certs.
+  # If cert if from DigiCert, download "Best format for nginx".
   cert.pem: "<b64 encoded HTTPS certificate chain"
 ---
 apiVersion: v1


### PR DESCRIPTION
Fixes:

* Added missing `\` to the end of a line in the `az acs create` command
* Removed an unnecessary trailing comma from `secret.yaml`

Also:

* Added a subsection about where to find the 3scale credentials
* In `secret.yaml` comments: Clarified that the entire certificate chain (i.e. all intermediate certs in addition to the actual cert) is needed for `https-certs.cert.pem`
* Other minor clarifications.