### PR TITLE
Add documentation on exposed ports in k8s/nginx

### DIFF
--- a/docs/server/source/production-deployment-template/node-on-kubernetes.rst
+++ b/docs/server/source/production-deployment-template/node-on-kubernetes.rst
@@ -128,7 +128,16 @@ Step 4.1: Vanilla NGINX
      the ConfigMap followed by ``-dep``. For example, if the value set in the
      ``ngx-instance-name`` is ``ngx-instance-0``, set  the
      ``spec.selector.app`` to ``ngx-instance-0-dep``.
-   
+     
+   * Set ``ngx-public-mdb-port`` to 27017, or the port number on which you
+     want to expose MongoDB service.
+
+   * Set ``ngx-public-api-port`` to 80, or the port number on which you want to
+     expose BigchainDB API service.
+
+   * Set ``ngx-public-ws-port`` to 81, or the port number on which you want to
+     expose BigchainDB Websocket service.
+     
    * Start the Kubernetes Service:
 
      .. code:: bash
@@ -152,6 +161,18 @@ Step 4.2: OpenResty NGINX + 3scale
      ``ngx-instance-name`` is ``ngx-instance-0``, set  the
      ``spec.selector.app`` to ``ngx-instance-0-dep``.
    
+   * Set ``ngx-public-mdb-port`` to 27017, or the port number on which you
+     want to expose MongoDB service.
+
+   * Set ``ngx-public-3scale-port`` to 8080, or the port number on which you
+     want to let 3scale communicate with Openresty NGINX for authenctication.
+
+   * Set ``ngx-public-bdb-port`` to 443, or the port number on which you want
+     to expose BigchainDB API service.
+
+   * Set ``ngx-public-bdb-port-http`` to 80, or the port number on which you
+     want to expose BigchainDB Websocket service.
+     
    * Start the Kubernetes Service:
    
      .. code:: bash
@@ -276,12 +297,6 @@ Step 8.1: Vanilla NGINX
     ``BIGCHAINDB_BACKEND_HOST`` env var to
     ``bdb-instance-0.default.svc.cluster.local``.
     
-  * Set ``MONGODB_FRONTEND_PORT`` to 27017, or the port number on which you
-    want to expose MongoDB service.
-    
-  * Set ``BIGCHAINDB_FRONTEND_PORT`` to 80, or the port number on which you
-    want to expose BigchainDB service.
-    
   * Start the Kubernetes Deployment:
 
     .. code:: bash
@@ -314,12 +329,6 @@ Step 8.2: OpenResty NGINX + 3scale
      ``BIGCHAINDB_BACKEND_HOST`` env var to
      ``bdb-instance-0.default.svc.cluster.local``.
      
-   * Set ``MONGODB_FRONTEND_PORT`` to 27017, or the port number on which you
-     want to expose the MongoDB service.
-     
-   * Set ``BIGCHAINDB_FRONTEND_PORT`` to 443, or the port number on which you
-     want to expose the BigchainDB service over HTTPS.
-
    * Start the Kubernetes Deployment:
 
      .. code:: bash

--- a/docs/server/source/production-deployment-template/node-on-kubernetes.rst
+++ b/docs/server/source/production-deployment-template/node-on-kubernetes.rst
@@ -129,14 +129,20 @@ Step 4.1: Vanilla NGINX
      ``ngx-instance-name`` is ``ngx-instance-0``, set  the
      ``spec.selector.app`` to ``ngx-instance-0-dep``.
      
-   * Set ``ngx-public-mdb-port`` to 27017, or the port number on which you
+   * Set ``ngx-public-mdb-port.port`` to 27017, or the port number on which you
      want to expose MongoDB service.
+     Set the ``ngx-public-mdb-port.targetPort`` to the port number on which the
+     Kubernetes MongoDB service will be present.
 
-   * Set ``ngx-public-api-port`` to 80, or the port number on which you want to
+   * Set ``ngx-public-api-port.port`` to 80, or the port number on which you want to
      expose BigchainDB API service.
+     Set the ``ngx-public-api-port.targetPort`` to the port number on which the
+     Kubernetes BigchainDB API service will present.
 
-   * Set ``ngx-public-ws-port`` to 81, or the port number on which you want to
+   * Set ``ngx-public-ws-port.port`` to 81, or the port number on which you want to
      expose BigchainDB Websocket service.
+     Set the ``ngx-public-ws-port.targetPort`` to the port number on which the
+     BigchainDB Websocket service will be present.
      
    * Start the Kubernetes Service:
 
@@ -161,17 +167,26 @@ Step 4.2: OpenResty NGINX + 3scale
      ``ngx-instance-name`` is ``ngx-instance-0``, set  the
      ``spec.selector.app`` to ``ngx-instance-0-dep``.
    
-   * Set ``ngx-public-mdb-port`` to 27017, or the port number on which you
+   * Set ``ngx-public-mdb-port.port`` to 27017, or the port number on which you
      want to expose MongoDB service.
+     Set the ``ngx-public-mdb-port.targetPort`` to the port number on which the
+     Kubernetes MongoDB service will be present.
 
-   * Set ``ngx-public-3scale-port`` to 8080, or the port number on which you
-     want to let 3scale communicate with Openresty NGINX for authenctication.
+   * Set ``ngx-public-3scale-port.port`` to 8080, or the port number on which
+     you want to let 3scale communicate with Openresty NGINX for authenctication.
+     Set the ``ngx-public-3scale-port.targetPort`` to the port number on which
+     this Openresty NGINX service will be listening to for communication with
+     3scale.
 
-   * Set ``ngx-public-bdb-port`` to 443, or the port number on which you want
+   * Set ``ngx-public-bdb-port.port`` to 443, or the port number on which you want
      to expose BigchainDB API service.
+     Set the ``ngx-public-api-port.targetPort`` to the port number on which the
+     Kubernetes BigchainDB API service will present.
 
-   * Set ``ngx-public-bdb-port-http`` to 80, or the port number on which you
+   * Set ``ngx-public-bdb-port-http.port`` to 80, or the port number on which you
      want to expose BigchainDB Websocket service.
+     Set the ``ngx-public-bdb-port-http.targetPort`` to the port number on which the
+     BigchainDB Websocket service will be present.
      
    * Start the Kubernetes Service:
    


### PR DESCRIPTION
While fixing this, I also realized that the parameter names (or port names in the *-svc for both nginx and nginx-3scale) are not consistent. I will open an issue for consistent naming and fix it once we are done with your testing, as we need to change names in quite a few places.

Opened #1611.