### PR TITLE
Renamed 'Drivers & Clients' section 'Drivers & Tools'

### DIFF
--- a/docs/server/source/drivers-clients/index.rst
+++ b/docs/server/source/drivers-clients/index.rst
@@ -1,5 +1,5 @@
-Drivers & Clients
-=================
+Drivers & Tools
+===============
 
 Libraries and Tools Maintained by the BigchainDB Team
 -----------------------------------------------------


### PR DESCRIPTION
This idea came up in the discussion of issue #1534 

The "Get Started" page on the new bigchaindb.com website will refer to them as "Drivers & Tools" as well.

I _didn't_ change the name of the underlying directory (which is still `drivers-clients/`) because that would break many links.