### PR TITLE
Removed the link to the Google Group from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ BigchainDB is a scalable blockchain database. [The whitepaper](https://www.bigch
 * [Roadmap](https://github.com/bigchaindb/org/blob/master/ROADMAP.md)
 * [Blog](https://medium.com/the-bigchaindb-blog)
 * [Twitter](https://twitter.com/BigchainDB)
-* [Google Group](https://groups.google.com/forum/#!forum/bigchaindb)
 
 ## Links for Developers
 


### PR DESCRIPTION
We stopped using [the BigchainDB Google Group](https://groups.google.com/forum/#!forum/bigchaindb) a while ago. I just noticed there was still a link to it in the `README.md` file (i.e. on the home page of this repo), so I removed that link.