### PR TITLE
Updated BDB Docker tag from 1.0.0rc1 to 1.0.0 in k8s deployment

### DIFF
--- a/k8s/bigchaindb/bigchaindb-dep.yaml
+++ b/k8s/bigchaindb/bigchaindb-dep.yaml
@@ -12,7 +12,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: bigchaindb
-        image: bigchaindb/bigchaindb:1.0.0rc1
+        image: bigchaindb/bigchaindb:1.0.0
         imagePullPolicy: IfNotPresent
         args:
         - start


### PR DESCRIPTION
This is part of the release process as we release BigchainDB Server version 1.0.0.