### PR TITLE
Fixing installation of bigchaindb 1.0.0 pyPackage for quickstart

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ setup(
         ],
     },
     install_requires=install_requires,
-    setup_requires=['pytest-runner', 'cryptoconditions'],
+    setup_requires=['pytest-runner'],
     tests_require=tests_require,
     extras_require={
         'test': tests_require,


### PR DESCRIPTION
- Quick start setup was broken because of a race condition with
using cryptoconditions in setup_requires and install_requires and
for a fresh Ubuntu 16.04 setup initialization of BigchainDB node
the python package installation fails due to package conflicts.
- Rest of the details are captured in the issue #1657