### PR TITLE
Fix for MongoDB hitting memory limit on k8s

### DIFF
--- a/k8s/mongodb/mongo-ss.yaml
+++ b/k8s/mongodb/mongo-ss.yaml
@@ -72,7 +72,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 768Mi
+            memory: 3.5G
         livenessProbe:
           tcpSocket:
             port: mdb-port


### PR DESCRIPTION
- MongoDB StatefulSet hitting memory limit, so k8s restarts it.
We have had multiple instances of restarts lately.
-  Changing it to 3.5 GB, data and reasoning to back it up
is mentioned in the ticket #1655