### PR TITLE
Remove 3scale port number from configs

### DIFF
--- a/docs/server/source/production-deployment-template/node-on-kubernetes.rst
+++ b/docs/server/source/production-deployment-template/node-on-kubernetes.rst
@@ -173,18 +173,6 @@ Step 4.2: NGINX with HTTPS + 3scale
      ``public-mdb-port`` in the file which specifies where MongoDB is
      available.
 
-   * Set ``ports[2].port`` and ``ports[2].targetPort`` to the value set in the
-     ``threescale-api-port`` in the ConfigMap above. This is the
-     ``public-threescale-port`` in the file which specifies where OpenResty is
-     available.
-
-   * Set ``threescale-api-port`` to 27017, or the port number on which you
-     want to expose MongoDB service.
-     Set the ``ngx-public-mdb-port.targetPort`` to the port number on which the
-     Kubernetes MongoDB service will be present.
-     Note: This is only used for testing with 3scale, and will be removed in
-     the future.
-
    * Start the Kubernetes Service:
    
      .. code:: bash
@@ -340,9 +328,9 @@ Step 9.2: NGINX with HTTPS + 3scale
 
    * Set the ports to be exposed from the pod in the
      ``spec.containers[0].ports`` section. We currently expose 4 ports -
-     ``mongodb-frontend-port``, ``cluster-frontend-port``,
-     ``threescale-api-port`` and ``cluster-health-check-port``. Set them to
-     the values specified in the ConfigMap.
+     ``mongodb-frontend-port``, ``cluster-frontend-port`` and
+     ``cluster-health-check-port``. Set them to the values specified in the
+     ConfigMap.
 
    * Start the Kubernetes Deployment:
 
@@ -849,8 +837,6 @@ To test the NGINX instance with HTTPS and 3scale integration:
    $ dig +noall +answer _public-secure-cluster-port._.tcp.ngx-https-instance-0.default.svc.cluster.local SRV
 
    $ dig +noall +answer _public-mdb-port._.tcp.ngx-https-instance-0.default.svc.cluster.local SRV
-
-   $ dig +noall +answer _public-threescale-port._.tcp.ngx-https-instance-0.default.svc.cluster.local SRV
 
    $ dig +noall +answer _public-insecure-cluster-port._.tcp.ngx-https-instance-0.default.svc.cluster.local SRV
 

--- a/docs/server/source/production-deployment-template/node-on-kubernetes.rst
+++ b/docs/server/source/production-deployment-template/node-on-kubernetes.rst
@@ -327,7 +327,7 @@ Step 9.2: NGINX with HTTPS + 3scale
      ``ngx-https-instance-0``, set the fields to ``ngx-https-instance-0-dep``.
 
    * Set the ports to be exposed from the pod in the
-     ``spec.containers[0].ports`` section. We currently expose 4 ports -
+     ``spec.containers[0].ports`` section. We currently expose 3 ports -
      ``mongodb-frontend-port``, ``cluster-frontend-port`` and
      ``cluster-health-check-port``. Set them to the values specified in the
      ConfigMap.

--- a/k8s/configuration/config-map.yaml
+++ b/k8s/configuration/config-map.yaml
@@ -78,10 +78,6 @@ data:
   # for Websocket requests.
   bigchaindb-ws-port: "9985"
 
-  # threescale-api-port is the port number on which 3scale can communicate with
-  # OpenResty backend.
-  threescale-api-port: "44433"
-
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/k8s/dev-setup/nginx-https.yaml
+++ b/k8s/dev-setup/nginx-https.yaml
@@ -39,10 +39,6 @@ spec:
     targetPort: 27017
     name: public-mdb-port
     protocol: TCP
-  - port: 44433
-    targetPort: 44433
-    name: public-threescale-port
-    protocol: TCP
   type: LoadBalancer
 ---
 apiVersion: extensions/v1beta1
@@ -80,8 +76,6 @@ spec:
           value: "80"
         - name: OPENRESTY_BACKEND_HOST
           value: "openresty.default.svc.cluster.local"
-        - name: THREESCALE_API_PORT
-          value: "44433"
         - name: BIGCHAINDB_BACKEND_HOST
           value: "bdb.default.svc.cluster.local"
         - name: BIGCHAINDB_API_PORT

--- a/k8s/nginx-https/container/nginx.conf.template
+++ b/k8s/nginx-https/container/nginx.conf.template
@@ -139,17 +139,6 @@ http {
         return 426 'Consider using the HTTPS protocol next time!';
     }
   }
-
-  # Frontend server to respond to requests from 3scale; forward directly to
-  # OpenResty instance.
-  server {
-    sendfile on;
-    listen THREESCALE_API_PORT;
-
-    location / {
-      proxy_pass http://$openresty_backend:OPENRESTY_BACKEND_PORT;
-    }
-  }
 }
 
 # NGINX stream block for TCP and UDP proxies. Used to proxy MDB TCP

--- a/k8s/nginx-https/container/nginx_entrypoint.bash
+++ b/k8s/nginx-https/container/nginx_entrypoint.bash
@@ -20,7 +20,6 @@ mongo_backend_port=`printenv MONGODB_BACKEND_PORT`
 # OpenResty vars
 openresty_backend_host=`printenv OPENRESTY_BACKEND_HOST`
 openresty_backend_port=`printenv OPENRESTY_BACKEND_PORT`
-threescale_api_port=`printenv THREESCALE_API_PORT`
 
 
 # BigchainDB vars
@@ -36,7 +35,6 @@ if [[ -z "${cluster_frontend_port}" || \
       -z "${mongo_backend_port}" || \
       -z "${openresty_backend_port}" || \
       -z "${openresty_backend_host}" || \
-      -z "${threescale_api_port}" || \
       -z "${bdb_backend_host}" || \
       -z "${bdb_api_port}" || \
       -z "${bdb_ws_port}" || \
@@ -57,7 +55,6 @@ sed -i "s|MONGODB_BACKEND_HOST|${mongo_backend_host}|g" ${NGINX_CONF_FILE}
 sed -i "s|MONGODB_BACKEND_PORT|${mongo_backend_port}|g" ${NGINX_CONF_FILE}
 sed -i "s|OPENRESTY_BACKEND_PORT|${openresty_backend_port}|g" ${NGINX_CONF_FILE}
 sed -i "s|OPENRESTY_BACKEND_HOST|${openresty_backend_host}|g" ${NGINX_CONF_FILE}
-sed -i "s|THREESCALE_API_PORT|${threescale_api_port}|g" ${NGINX_CONF_FILE}
 sed -i "s|BIGCHAINDB_BACKEND_HOST|${bdb_backend_host}|g" ${NGINX_CONF_FILE}
 sed -i "s|BIGCHAINDB_API_PORT|${bdb_api_port}|g" ${NGINX_CONF_FILE}
 sed -i "s|BIGCHAINDB_WS_PORT|${bdb_ws_port}|g" ${NGINX_CONF_FILE}

--- a/k8s/nginx-https/nginx-https-dep.yaml
+++ b/k8s/nginx-https/nginx-https-dep.yaml
@@ -60,11 +60,6 @@ spec:
             configMapKeyRef:
               name: vars
               key: openresty-backend-host
-        - name: THREESCALE_API_PORT
-          valueFrom:
-            configMapKeyRef:
-              name: vars
-              key: threescale-api-port
         - name: BIGCHAINDB_BACKEND_HOST
           valueFrom:
             configMapKeyRef:
@@ -88,8 +83,6 @@ spec:
         - containerPort: "<mongodb-frontend-port from ConfigMap>"
           protocol: TCP
         - containerPort: "<cluster-frontend-port from ConfigMap>"
-          protocol: TCP
-        - containerPort: "<threescale-api-port from ConfigMap>"
           protocol: TCP
         - containerPort: "<cluster-health-check-port from ConfigMap>"
           protocol: TCP

--- a/k8s/nginx-https/nginx-https-svc.yaml
+++ b/k8s/nginx-https/nginx-https-svc.yaml
@@ -21,10 +21,6 @@ spec:
     targetPort: "<mongodb-frontend-port from ConfigMap>"
     name: public-mdb-port
     protocol: TCP
-  - port: "<threescale-api-port from ConfigMap>"
-    targetPort: "<threescale-api-port from ConfigMap>"
-    name: public-threescale-port
-    protocol: TCP
   - port: 80
     targetPort: 80
     name: public-insecure-cluster-port


### PR DESCRIPTION
As we no longer use 3scale GET requests to test the setup, we can safely remove this configuration from our setup.

In case we need to check if 3scale has been configured correctly, the best way today would be to send some `POST` requests to our HTTP API and check the error message, if any.

We can think about including this code in case we decide to meter `GET`s in the future.