### PR TITLE
Simpler MongoDB Instance Configuration in K8s

### DIFF
--- a/docs/server/source/production-deployment-template/node-on-kubernetes.rst
+++ b/docs/server/source/production-deployment-template/node-on-kubernetes.rst
@@ -233,6 +233,11 @@ Step 6: Start the MongoDB Kubernetes Service
     the ConfigMap followed by ``-ss``. For example, if the value set in the
     ``mdb-instance-name`` is ``mdb-instance-0``, set  the
     ``spec.selector.app`` to ``mdb-instance-0-ss``.
+
+  * Set ``ports[0].port`` and ``ports[0].targetPort`` to the value set in the
+    ``mongodb-backend-port`` in the ConfigMap above.
+    This is the ``mdb-port`` in the file which specifies where MongoDB listens
+    for API requests.
   
   * Start the Kubernetes Service:
 
@@ -490,6 +495,11 @@ Step 12: Start a Kubernetes StatefulSet for MongoDB
 
   * As we gain more experience running MongoDB in testing and production, we
     will tweak the ``resources.limits.cpu`` and ``resources.limits.memory``.
+
+  * Set the ports to be exposed from the pod in the
+    ``spec.containers[0].ports`` section. We currently only expose the MongoDB
+    backend port. Set it to the value specified for ``mongodb-backend-port``
+    in the ConfigMap.
 
   * Create the MongoDB StatefulSet using:
 

--- a/k8s/bigchaindb/bigchaindb-svc.yaml
+++ b/k8s/bigchaindb/bigchaindb-svc.yaml
@@ -12,8 +12,10 @@ spec:
   - port: "<bigchaindb-api-port from ConfigMap>"
     targetPort: "<bigchaindb-api-port from ConfigMap>"
     name: bdb-api-port
+    protocol: TCP
   - port: "<bigchaindb-ws-port from ConfigMap>"
     targetPort: "<bigchaindb-ws-port from ConfigMap>"
     name: bdb-ws-port
+    protocol: TCP
   type: ClusterIP
   clusterIP: None

--- a/k8s/mongodb/mongo-ss.yaml
+++ b/k8s/mongodb/mongo-ss.yaml
@@ -39,7 +39,10 @@ spec:
              name: vars
              key: mongodb-replicaset-name
         - name: MONGODB_PORT
-          value: "27017"
+          valueFrom:
+            configMapKeyRef:
+             name: vars
+             key: mongodb-backend-port
         args:
         - --mongodb-port
         - $(MONGODB_PORT)
@@ -60,10 +63,9 @@ spec:
             add:
             - FOWNER
         ports:
-        - containerPort: 27017
-          hostPort: 27017
-          name: mdb-port
+        - containerPort: "<mongodb-backend-port from ConfigMap>"
           protocol: TCP
+          name: mdb-api-port
         volumeMounts:
         - name: mdb-db
           mountPath: /data/db
@@ -78,11 +80,12 @@ spec:
             memory: 3.5G
         livenessProbe:
           tcpSocket:
-            port: mdb-port
+            port: mdb-api-port
+          initialDelaySeconds: 15
           successThreshold: 1
           failureThreshold: 3
           periodSeconds: 15
-          timeoutSeconds: 1
+          timeoutSeconds: 10
       restartPolicy: Always
       volumes:
       - name: mdb-db

--- a/k8s/mongodb/mongo-svc.yaml
+++ b/k8s/mongodb/mongo-svc.yaml
@@ -9,8 +9,9 @@ spec:
   selector:
     app: mdb-instance-0-ss
   ports:
-  - port: 27017
-    targetPort: 27017
+  - port: "<mongodb-backend-port from ConfigMap>"
+    targetPort: "<mongodb-backend-port from ConfigMap>"
     name: mdb-port
+    protocol: TCP
   type: ClusterIP
   clusterIP: None


### PR DESCRIPTION
Use values from ConfigMap rather than hardcoded or manually input values.
