### PR TITLE
Keep minimal number of os-level deps for server quickstart

### DIFF
--- a/docs/server/source/appendices/install-os-level-deps.md
+++ b/docs/server/source/appendices/install-os-level-deps.md
@@ -5,7 +5,7 @@ BigchainDB Server has some OS-level dependencies that must be installed.
 On Ubuntu 16.04, we found that the following was enough:
 ```text
 sudo apt-get update
-sudo apt-get install g++ python3-dev libffi-dev build-essential libssl-dev
+sudo apt-get install libffi-dev libssl-dev
 ```
 
 On Fedora 23–25, we found that the following was enough:

--- a/docs/server/source/quickstart.md
+++ b/docs/server/source/quickstart.md
@@ -24,7 +24,7 @@ $ sudo mongod --replSet=bigchain-rs
 E. Ubuntu 16.04 already has Python 3.5, so you don't need to install it, but you do need to install some other things:
 ```text
 $ sudo apt-get update
-$ sudo apt-get install g++ python3-dev libffi-dev build-essential libssl-dev
+$ sudo apt-get install libffi-dev libssl-dev
 ```
 
 F. Get the latest version of pip and setuptools:


### PR DESCRIPTION
- Only libffi-dev and libssl-dev are enough for the bdb server
quickstart installation and they pull any dependant packages
recursively via apt.