### PR TITLE
Fix broken travis build

### DIFF
--- a/.ci/travis-before-script.sh
+++ b/.ci/travis-before-script.sh
@@ -2,33 +2,33 @@
 
 set -e -x
 
-if [[ "${TOXENV}" == *-rdb ]]; then
-    rethinkdb --daemon
+if [[ "${BIGCHAINDB_DATABASE_BACKEND}" == rethinkdb ]]; then
+    docker pull rethinkdb:2.3.5
+    docker run -d --publish=28015:28015 --name rdb rethinkdb:2.3.5
 elif [[ "${BIGCHAINDB_DATABASE_BACKEND}" == mongodb && \
         -z "${BIGCHAINDB_DATABASE_SSL}" ]]; then
     # Connect to MongoDB on port 27017 via a normal, unsecure connection if
     # BIGCHAINDB_DATABASE_SSL is unset.
     # It is unset in this case in .travis.yml.
-    wget https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1404-3.4.4.tgz -O /tmp/mongodb.tgz
-    tar -xvf /tmp/mongodb.tgz
-    mkdir /tmp/mongodb-data
-    ${PWD}/mongodb-linux-x86_64-ubuntu1404-3.4.4/bin/mongod \
-        --dbpath=/tmp/mongodb-data --replSet=bigchain-rs &> /dev/null &
+    docker pull mongo:3.4.4
+    docker run -d --publish=27017:27017 --name mdb-without-ssl mongo:3.4.4 \
+        --replSet=bigchain-rs
 elif [[ "${BIGCHAINDB_DATABASE_BACKEND}" == mongodb && \
         "${BIGCHAINDB_DATABASE_SSL}" == true ]]; then
     # Connect to MongoDB on port 27017 via TLS/SSL connection if
     # BIGCHAINDB_DATABASE_SSL is set.
     # It is set to 'true' here in .travis.yml. Dummy certificates for testing
     # are stored under bigchaindb/tests/backend/mongodb-ssl/certs/ directory.
-    wget https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1404-3.4.4.tgz -O /tmp/mongodb-ssl.tgz
-    tar -xvf /tmp/mongodb-ssl.tgz
-    mkdir /tmp/mongodb-ssl-data
-    ${PWD}/mongodb-linux-x86_64-ubuntu1404-3.4.4/bin/mongod \
-        --dbpath=/tmp/mongodb-ssl-data \
+    docker pull mongo:3.4.4
+    docker run -d \
+        --name mdb-with-ssl \
+        --publish=27017:27017 \
+        --volume=${TRAVIS_BUILD_DIR}/tests/backend/mongodb-ssl/certs:/certs \
+        mongo:3.4.4 \
         --replSet=bigchain-rs \
         --sslAllowInvalidHostnames \
         --sslMode=requireSSL \
-        --sslCAFile=$TRAVIS_BUILD_DIR/tests/backend/mongodb-ssl/certs/ca.crt \
-        --sslCRLFile=$TRAVIS_BUILD_DIR/tests/backend/mongodb-ssl/certs/crl.pem \
-        --sslPEMKeyFile=$TRAVIS_BUILD_DIR/tests/backend/mongodb-ssl/certs/test_mdb_ssl_cert_and_key.pem &> /dev/null &
+        --sslCAFile=/certs/ca.crt \
+        --sslCRLFile=/certs/crl.pem \
+        --sslPEMKeyFile=/certs/test_mdb_ssl_cert_and_key.pem
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+sudo: required
+
+dist: trusty
+
+services:
+  - docker
+
 language: python
 cache: pip
 
@@ -21,16 +28,12 @@ matrix:
     env: TOXENV=docsserver
   include:
   - python: 3.5
-    addons: 
-      rethinkdb: '2.3.5'
     env: BIGCHAINDB_DATABASE_BACKEND=rethinkdb
   - python: 3.5
     env:
     - BIGCHAINDB_DATABASE_BACKEND=mongodb
     - BIGCHAINDB_DATABASE_SSL=
   - python: 3.6
-    addons: 
-      rethinkdb: '2.3.5'
     env: BIGCHAINDB_DATABASE_BACKEND=rethinkdb
   - python: 3.6
     env:


### PR DESCRIPTION
- Use RethinkDB and MongoDB docker containers rather than manually
install packages.

- Fixes #1683