### PR TITLE
Remove an invalid message in the k8s production deployment guide

### DIFF
--- a/docs/server/source/production-deployment-template/node-on-kubernetes.rst
+++ b/docs/server/source/production-deployment-template/node-on-kubernetes.rst
@@ -866,7 +866,7 @@ To test the NGINX instance with HTTPS and 3scale integration:
 
    $ wsc -er wss://<cluster-fqdn>/api/v1/streams/valid_transactions
 
-   $ curl -X GET https://<cluster-fqdn>
+   $ curl -X GET http://<cluster-fqdn>:27017
 
 The above curl command should result in the response
 ``It looks like you are trying to access MongoDB over HTTP on the native driver port.``


### PR DESCRIPTION
- The guide is outdated and expects and error message when the following command is run on the toolbox container in the nginx with https+3scale integration section:
$ curl -X GET https://<cluster-fqdn>
The above command should not return an error since this workflow is supported