### PR TITLE
Update MongoDB Backup Agent to v5.7.0.641

### DIFF
--- a/k8s/mongodb-backup-agent/container/docker_build_and_push.bash
+++ b/k8s/mongodb-backup-agent/container/docker_build_and_push.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-docker build -t bigchaindb/mongodb-backup-agent:3.1 .
+docker build -t bigchaindb/mongodb-backup-agent:3.2 .
 
-docker push bigchaindb/mongodb-backup-agent:3.1
+docker push bigchaindb/mongodb-backup-agent:3.2

--- a/k8s/mongodb-backup-agent/mongo-backup-dep.yaml
+++ b/k8s/mongodb-backup-agent/mongo-backup-dep.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: mdb-backup
-        image: bigchaindb/mongodb-backup-agent:3.1
+        image: bigchaindb/mongodb-backup-agent:3.2
         imagePullPolicy: IfNotPresent
         env:
         - name: MMS_API_KEYFILE_PATH


### PR DESCRIPTION
MongoDB Cloud Manager had a warning again as hey have updated their Backup agent to version 5.7.X and we were using version 5.6.X.
This PR contains changes to update the docker container and use the newer/latest version.