### PR TITLE
Remove persistentVolumeReclaimPolicy from the pvc request

### DIFF
--- a/k8s/mongodb/mongo-pvc.yaml
+++ b/k8s/mongodb/mongo-pvc.yaml
@@ -10,8 +10,6 @@ metadata:
 spec:
   accessModes:
   - ReadWriteOnce
-  # FIXME(Uncomment when ACS supports this!)
-  # persistentVolumeReclaimPolicy: Retain
   resources:
     requests:
       storage: 20Gi
@@ -28,8 +26,6 @@ metadata:
 spec:
   accessModes:
   - ReadWriteOnce
-  # FIXME(Uncomment when ACS supports this!)
-  # persistentVolumeReclaimPolicy: Retain
   resources:
     requests:
       storage: 1Gi


### PR DESCRIPTION
- Reclaim policy can only be specified when we explicitly create
a persistent Volume. Removing this from a persistent volume claim
request yaml.