### PR TITLE
Common secret for CA in secret.yaml

### DIFF
--- a/k8s/bigchaindb/bigchaindb-dep.yaml
+++ b/k8s/bigchaindb/bigchaindb-dep.yaml
@@ -99,9 +99,9 @@ spec:
         - name: BIGCHAINDB_DATABASE_SSL
           value: "true"
         - name: BIGCHAINDB_DATABASE_CA_CERT
-          value: /etc/bigchaindb/ssl/ca.pem
+          value: /etc/bigchaindb/ca/ca.pem
         - name: BIGCHAINDB_DATABASE_CRLFILE
-          value: /etc/bigchaindb/ssl/crlfile
+          value: /etc/bigchaindb/ca/crl.pem
         - name: BIGCHAINDB_DATABASE_CERTFILE
           value: /etc/bigchaindb/ssl/bdb-instance.pem
         - name: BIGCHAINDB_DATABASE_KEYFILE
@@ -128,6 +128,9 @@ spec:
         - name: bdb-certs
           mountPath: /etc/bigchaindb/ssl/
           readOnly: true
+        - name: ca-auth
+          mountPath: /etc/bigchaindb/ca/
+          readOnly: true
         resources:
           limits:
             cpu: 200m
@@ -151,4 +154,8 @@ spec:
       - name: bdb-certs
         secret:
           secretName: bdb-certs
+          defaultMode: 0400
+      - name: ca-auth
+        secret:
+          secretName: ca-auth
           defaultMode: 0400

--- a/k8s/configuration/secret.yaml
+++ b/k8s/configuration/secret.yaml
@@ -40,10 +40,6 @@ type: Opaque
 data:
   # Base64-encoded, concatenated certificate and private key
   mdb-instance.pem: "<b64 encoded, concatenated certificate and private key>"
-  # Base64-encoded CA certificate (ca.crt)
-  ca.pem: "<b64 encoded CA certificate>"
-  # Base64-encoded MongoDB CRL
-  mdb-crl.pem: "<b64 encoded CRL data>"
 ---
 apiVersion: v1
 kind: Secret
@@ -54,8 +50,6 @@ type: Opaque
 data:
   # Base64-encoded, concatenated certificate and private key
   mdb-mon-instance.pem: "<b64 encoded, concatenated certificate and private key>"
-  # Base64-encoded CA certificate (ca.crt)
-  ca.pem: "<b64 encoded CA certificate>" 
 ---
 apiVersion: v1
 kind: Secret
@@ -66,8 +60,6 @@ type: Opaque
 data:
   # Base64-encoded, concatenated certificate and private key
   mdb-bak-instance.pem: "<b64 encoded, concatenated certificate and private key>"
-  # Base64-encoded CA certificate (ca.crt)
-  ca.pem: "<b64 encoded CA certificate>"
 ---
 apiVersion: v1
 kind: Secret
@@ -76,10 +68,6 @@ metadata:
   namespace: default
 type: Opaque
 data:
-  # Base64-encoded CA certificate (ca.crt)
-  ca.pem: "<b64 encoded CA certificate>"
-  # Base64-encoded CRL file
-  crlfile: "<b64 encoded CRL>"
   # Base64-encoded BigchainDB instance certificate
   bdb-instance.pem: "<b64 encoded certificate>"
   # Base64-encoded private key (<bdb-instance-name>.key)
@@ -111,3 +99,15 @@ data:
   service-id: "<b64 encoded 3scale service-id>"
   version-header: "<b64 encoded 3scale version-header>"
   service-token: "<b64 encoded 3scale service-token>"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ca-auth
+  namespace: default
+type: Opaque
+data:
+  # CA used to issue members/client certificates
+  # Base64-encoded CA certificate (ca.crt)
+  ca.pem: "<b64 encoded CA certificate>"
+  crl.pem: "<b64 encoded CRL>"

--- a/k8s/mongodb-backup-agent/container/Dockerfile
+++ b/k8s/mongodb-backup-agent/container/Dockerfile
@@ -19,6 +19,6 @@ RUN apt update \
     && apt clean
 COPY mongodb_backup_agent_entrypoint.bash /
 RUN chown -R mongodb-mms-agent:mongodb-mms-agent /etc/mongodb-mms/
-VOLUME /etc/mongod/ssl
+VOLUME /etc/mongod/ssl /etc/mongod/ca
 #USER mongodb-mms-agent - BUG(Krish) Uncomment after tests are complete
 ENTRYPOINT ["/mongodb_backup_agent_entrypoint.bash"]

--- a/k8s/mongodb-backup-agent/mongo-backup-dep.yaml
+++ b/k8s/mongodb-backup-agent/mongo-backup-dep.yaml
@@ -41,10 +41,10 @@ spec:
             memory: 768Mi
         volumeMounts:
         - name: mdb-bak-certs
-          mountPath: /etc/mongod/ca/
-          readOnly: true
-        - name: mdb-ca
           mountPath: /etc/mongod/ssl/
+          readOnly: true
+        - name: ca-auth
+          mountPath: /etc/mongod/ca/
           readOnly: true
         - name: cloud-manager-credentials
           mountPath: /etc/mongod/cloud/

--- a/k8s/mongodb-backup-agent/mongo-backup-dep.yaml
+++ b/k8s/mongodb-backup-agent/mongo-backup-dep.yaml
@@ -32,7 +32,7 @@ spec:
         - name: MMS_GROUPID_KEYFILE_PATH
           value: /etc/mongod/cloud/group-id
         - name: CA_CRT_PATH
-          value: /etc/mongod/ssl/ca.pem
+          value: /etc/mongod/ca/ca.pem
         - name: BACKUP_PEM_PATH
           value: /etc/mongod/ssl/mdb-bak-instance.pem
         resources:
@@ -41,6 +41,9 @@ spec:
             memory: 768Mi
         volumeMounts:
         - name: mdb-bak-certs
+          mountPath: /etc/mongod/ca/
+          readOnly: true
+        - name: mdb-ca
           mountPath: /etc/mongod/ssl/
           readOnly: true
         - name: cloud-manager-credentials
@@ -51,6 +54,10 @@ spec:
       - name: mdb-bak-certs
         secret:
           secretName: mdb-bak-certs
+          defaultMode: 0400
+      - name: ca-auth
+        secret:
+          secretName: ca-auth
           defaultMode: 0400
       - name: cloud-manager-credentials
         secret:

--- a/k8s/mongodb-monitoring-agent/container/Dockerfile
+++ b/k8s/mongodb-monitoring-agent/container/Dockerfile
@@ -53,6 +53,6 @@ RUN apt update \
 
 COPY mongodb_mon_agent_entrypoint.bash /
 RUN chown -R mongodb-mms-agent:mongodb-mms-agent /etc/mongodb-mms/
-VOLUME /etc/mongod/ssl
+VOLUME /etc/mongod/ssl /etc/mongod/ca
 #USER mongodb-mms-agent - BUG(Krish) Uncomment after tests are complete
 ENTRYPOINT ["/mongodb_mon_agent_entrypoint.bash"]

--- a/k8s/mongodb-monitoring-agent/mongo-mon-dep.yaml
+++ b/k8s/mongodb-monitoring-agent/mongo-mon-dep.yaml
@@ -32,7 +32,7 @@ spec:
         - name: MMS_GROUPID_KEYFILE_PATH
           value: /etc/mongod/cloud/group-id
         - name: CA_CRT_PATH
-          value: /etc/mongod/ssl/ca.pem
+          value: /etc/mongod/ca/ca.pem
         - name: MONITORING_PEM_PATH
           value: /etc/mongod/ssl/mdb-mon-instance.pem
         resources:
@@ -41,6 +41,9 @@ spec:
             memory: 768Mi
         volumeMounts:
         - name: mdb-mon-certs
+          mountPath: /etc/mongod/ca/
+          readOnly: true
+        - name: ca-auth
           mountPath: /etc/mongod/ssl/
           readOnly: true
         - name: cloud-manager-credentials
@@ -51,6 +54,10 @@ spec:
       - name: mdb-mon-certs
         secret:
           secretName: mdb-mon-certs
+          defaultMode: 0400
+      - name: ca-auth
+        secret:
+          secretName: ca-auth
           defaultMode: 0400
       - name: cloud-manager-credentials
         secret:

--- a/k8s/mongodb-monitoring-agent/mongo-mon-dep.yaml
+++ b/k8s/mongodb-monitoring-agent/mongo-mon-dep.yaml
@@ -41,10 +41,10 @@ spec:
             memory: 768Mi
         volumeMounts:
         - name: mdb-mon-certs
-          mountPath: /etc/mongod/ca/
+          mountPath: /etc/mongod/ssl/
           readOnly: true
         - name: ca-auth
-          mountPath: /etc/mongod/ssl/
+          mountPath: /etc/mongod/ca/
           readOnly: true
         - name: cloud-manager-credentials
           mountPath: /etc/mongod/cloud/

--- a/k8s/mongodb/container/Dockerfile
+++ b/k8s/mongodb/container/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update \
     && apt-get clean
 COPY mongod.conf.template /etc/mongod.conf
 COPY mongod_entrypoint.bash /
-VOLUME /data/db /data/configdb /etc/mongod/ssl
+VOLUME /data/db /data/configdb /etc/mongod/ssl /etc/mongod/ca
 EXPOSE 27017
 ENTRYPOINT ["/mongod_entrypoint.bash"]

--- a/k8s/mongodb/mongo-ss.yaml
+++ b/k8s/mongodb/mongo-ss.yaml
@@ -5,7 +5,7 @@
 ########################################################################
 
 apiVersion: apps/v1beta1
-kind: StatefulSet 
+kind: StatefulSet
 metadata:
   name: mdb-instance-0-ss
   namespace: default
@@ -49,9 +49,9 @@ spec:
         - --mongodb-key-file-path
         - /etc/mongod/ssl/mdb-instance.pem
         - --mongodb-ca-file-path
-        - /etc/mongod/ssl/ca.pem
+        - /etc/mongod/ca/ca.pem
         - --mongodb-crl-file-path
-        - /etc/mongod/ssl/mdb-crl.pem
+        - /etc/mongod/ca/crl.pem
         - --replica-set-name
         - $(MONGODB_REPLICA_SET_NAME)
         - --mongodb-fqdn
@@ -73,6 +73,9 @@ spec:
           mountPath: /data/configdb
         - name: mdb-certs
           mountPath: /etc/mongod/ssl/
+          readOnly: true
+        - name: ca-auth
+          mountPath: /etc/mongod/ca/
           readOnly: true
         resources:
           limits:
@@ -97,4 +100,8 @@ spec:
       - name: mdb-certs
         secret:
           secretName: mdb-certs
+          defaultMode: 0400
+      - name: ca-auth
+        secret:
+          secretName: ca-auth
           defaultMode: 0400


### PR DESCRIPTION
- Creating a common secret for CA, since all the members of the replica set
and the clients need to have a common CA, moving all the relevant configuration
to a common secret.
- Modifying Dockerfiles for some components, once changes are approved
we will publish the new images.
- No documentation changes required.