### PR TITLE
Run mongodb monitoring and backup agents as non-root user

### DIFF
--- a/k8s/mongodb-backup-agent/container/Dockerfile
+++ b/k8s/mongodb-backup-agent/container/Dockerfile
@@ -20,5 +20,5 @@ RUN apt update \
 COPY mongodb_backup_agent_entrypoint.bash /
 RUN chown -R mongodb-mms-agent:mongodb-mms-agent /etc/mongodb-mms/
 VOLUME /etc/mongod/ssl
-#USER mongodb-mms-agent - BUG(Krish) Uncomment after tests are complete
+USER mongodb-mms-agent
 ENTRYPOINT ["/mongodb_backup_agent_entrypoint.bash"]

--- a/k8s/mongodb-backup-agent/mongo-backup-dep.yaml
+++ b/k8s/mongodb-backup-agent/mongo-backup-dep.yaml
@@ -51,8 +51,8 @@ spec:
       - name: mdb-bak-certs
         secret:
           secretName: mdb-bak-certs
-          defaultMode: 0400
+          defaultMode: 0404
       - name: cloud-manager-credentials
         secret:
           secretName: cloud-manager-credentials
-          defaultMode: 0400
+          defaultMode: 0404

--- a/k8s/mongodb-monitoring-agent/container/Dockerfile
+++ b/k8s/mongodb-monitoring-agent/container/Dockerfile
@@ -54,5 +54,5 @@ RUN apt update \
 COPY mongodb_mon_agent_entrypoint.bash /
 RUN chown -R mongodb-mms-agent:mongodb-mms-agent /etc/mongodb-mms/
 VOLUME /etc/mongod/ssl
-#USER mongodb-mms-agent - BUG(Krish) Uncomment after tests are complete
+USER mongodb-mms-agent
 ENTRYPOINT ["/mongodb_mon_agent_entrypoint.bash"]

--- a/k8s/mongodb-monitoring-agent/mongo-mon-dep.yaml
+++ b/k8s/mongodb-monitoring-agent/mongo-mon-dep.yaml
@@ -51,8 +51,8 @@ spec:
       - name: mdb-mon-certs
         secret:
           secretName: mdb-mon-certs
-          defaultMode: 0400
+          defaultMode: 0404
       - name: cloud-manager-credentials
         secret:
           secretName: cloud-manager-credentials
-          defaultMode: 0400
+          defaultMode: 0404


### PR DESCRIPTION
- We need to modify the read permissions on the secrets and allow
the mongodb-mms-agent to read the credentials.