### PR TITLE
[proposal] Add basic CLI to generate transactions

### DIFF
--- a/bigchaindb/commands/benchmark.py
+++ b/bigchaindb/commands/benchmark.py
@@ -1,0 +1,84 @@
+import sys
+import argparse
+import logging
+import webbrowser
+
+import coloredlogs
+
+from bigchaindb.commands import utils
+
+
+logger = logging.getLogger(__name__)
+
+
+def run_send(args):
+    from bigchaindb_driver import BigchainDB
+    from bigchaindb_driver.crypto import generate_keypair
+
+    alice = generate_keypair()
+    bdb = BigchainDB(args.peer)
+    asset = None
+
+    if args.size:
+        asset = {'data': {'_': 'x' * args.size}}
+
+    prepared_creation_tx = bdb.transactions.prepare(
+            operation='CREATE',
+            signers=alice.public_key,
+            asset=asset,
+            metadata=None)
+
+    fulfilled_creation_tx = bdb.transactions.fulfill(
+            prepared_creation_tx,
+            private_keys=alice.private_key)
+
+    sent_creation_tx = bdb.transactions.send(fulfilled_creation_tx)
+    logger.info('Create transaction sent. Id: %s', sent_creation_tx['id'])
+
+    if args.open:
+        webbrowser.open('{}/api/v1/transactions/{}'.format(args.peer, sent_creation_tx['id']))
+
+
+def create_parser():
+    parser = argparse.ArgumentParser(
+            description='[experimental] Benchmarking tools for BigchainDB.')
+
+    parser.add_argument('-l', '--log-level',
+                        default='INFO')
+
+    parser.add_argument('-p', '--peer',
+                        default='http://localhost:9984')
+
+    # all the commands are contained in the subparsers object,
+    # the command selected by the user will be stored in `args.command`
+    # that is used by the `main` function to select which other
+    # function to call.
+    subparsers = parser.add_subparsers(title='Commands',
+                                       dest='command')
+
+    send_parser = subparsers.add_parser('send',
+                                        help='Send a single create transaction '
+                                        'from a random keypair')
+
+    send_parser.add_argument('--open',
+                             help='Open the transaction in the browser',
+                             default=False,
+                             action='store_true')
+
+    send_parser.add_argument('--size',
+                             help='Asset size in bytes',
+                             type=int,
+                             default=0)
+
+    return parser
+
+
+def configure(args):
+    coloredlogs.install(level=args.log_level, logger=logger)
+
+
+def main():
+    utils.start(create_parser(),
+                sys.argv[1:],
+                globals(),
+                callback_before=configure)

--- a/bigchaindb/commands/utils.py
+++ b/bigchaindb/commands/utils.py
@@ -163,7 +163,7 @@ def start_rethinkdb():
     raise StartupError(line)
 
 
-def start(parser, argv, scope):
+def start(parser, argv, scope, callback_before=None):
     """Utility function to execute a subcommand.
 
     The function will look up in the ``scope``
@@ -200,6 +200,9 @@ def start(parser, argv, scope):
         args.multiprocess = 1
     elif args.multiprocess is None:
         args.multiprocess = mp.cpu_count()
+
+    if callback_before:
+        callback_before(args)
 
     return func(args)
 

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ install_requires = [
     'aiohttp~=2.0',
     'python-rapidjson-schema==0.1.1',
     'statsd==3.2.1',
+    'coloredlogs~=7.3.0',
 ]
 
 setup(
@@ -124,7 +125,8 @@ setup(
 
     entry_points={
         'console_scripts': [
-            'bigchaindb=bigchaindb.commands.bigchaindb:main'
+            'bigchaindb=bigchaindb.commands.bigchaindb:main',
+            'bigchaindb-benchmark=bigchaindb.commands.benchmark:main',
         ],
     },
     install_requires=install_requires,


### PR DESCRIPTION
Sometimes I've to quickly generate some random transactions for some tests. This PR adds a new **experimental** command line interface called `bigchaindb-benchmark`. Right now it implements one command, `send`. It can be easily extended to do more things.

A benchmark should display also stats, and this tool will eventually do it. I can do one of those two things:

1. leave it like this, and ¯\\\_(ツ)\_/¯
2. change the name from `benchmark` to `tools`

TBH I think we don't need tests here, it's just a dumb tool to quickly generate traffic, and it's not core.

##  `bigchaindb-benchmark`
```
 ~/a/r/bigchaindb git:(benchmarking-tools) ➜ bigchaindb-benchmark -h
usage: bigchaindb-benchmark [-h] [-l LOG_LEVEL] [-p PEER] {send} ...

[experimental] Benchmarking tools for BigchainDB.

optional arguments:
  -h, --help            show this help message and exit
  -l LOG_LEVEL, --log-level LOG_LEVEL
  -p PEER, --peer PEER

Commands:
  {send}
    send                Send a single create transaction from a random keypair
```

## `bigchaindb-benchmark send`
```
 ~/a/r/bigchaindb git:(benchmarking-tools) ➜ bigchaindb-benchmark send -h
usage: bigchaindb-benchmark send [-h] [--open] [--size SIZE]

optional arguments:
  -h, --help   show this help message and exit
  --open       Open the transaction in the browser
  --size SIZE  Asset size in bytes
```

## Usage
```
 ~/a/r/bigchaindb git:(benchmarking-tools) ➜ bigchaindb-benchmark send --size 10000 --open
2017-08-18 13:45:48 pulp bigchaindb.commands.benchmark[4511] INFO Create transaction sent. Id: 16989bafa67811ef39eaa7e8b18fc4dfdbdff356db8369fc7b74f3a1c9a6c35d
```