### PR TITLE
persist mongo data between system restarts (don't use /tmp)

### DIFF
--- a/docs/server/source/appendices/run-with-docker.md
+++ b/docs/server/source/appendices/run-with-docker.md
@@ -104,8 +104,8 @@ docker run \
   --name=mongodb \
   --publish=172.17.0.1:27017:27017 \
   --restart=always \
-  --volume=/tmp/mongodb_docker/db:/data/db \
-  --volume=/tmp/mongodb_docker/configdb:/data/configdb \
+  --volume=$HOME/mongodb_docker/db:/data/db \
+  --volume=$HOME/mongodb_docker/configdb:/data/configdb \
   mongo:3.4.1 --replSet=bigchain-rs
 ```
 


### PR DESCRIPTION
fixes #1730 