### PR TITLE
Added link to new Java driver in the docs

### DIFF
--- a/docs/server/source/drivers-clients/index.rst
+++ b/docs/server/source/drivers-clients/index.rst
@@ -23,6 +23,7 @@ Community-Driven Libraries and Tools
 
 * `Haskell transaction builder <https://github.com/bigchaindb/bigchaindb-hs>`_
 * `Go driver <https://github.com/zbo14/envoke/blob/master/bigchain/bigchain.go>`_
-* `Java driver <https://github.com/mgrand/bigchaindb-java-driver>`_
+* `Java driver (newer, working) <https://github.com/authenteq/java-bigchaindb-driver>`_
+* `Java driver (old, not working) <https://github.com/mgrand/bigchaindb-java-driver>`_
 * `Ruby driver <https://github.com/LicenseRocks/bigchaindb_ruby>`_
 * `Ruby library for preparing/signing transactions and submitting them or querying a BigchainDB/IPDB node (MIT licensed) <https://rubygems.org/gems/bigchaindb>`_

--- a/docs/server/source/drivers-clients/index.rst
+++ b/docs/server/source/drivers-clients/index.rst
@@ -23,7 +23,6 @@ Community-Driven Libraries and Tools
 
 * `Haskell transaction builder <https://github.com/bigchaindb/bigchaindb-hs>`_
 * `Go driver <https://github.com/zbo14/envoke/blob/master/bigchain/bigchain.go>`_
-* `Java driver (newer, working) <https://github.com/authenteq/java-bigchaindb-driver>`_
-* `Java driver (old, not working) <https://github.com/mgrand/bigchaindb-java-driver>`_
+* `Java driver <https://github.com/authenteq/java-bigchaindb-driver>`_
 * `Ruby driver <https://github.com/LicenseRocks/bigchaindb_ruby>`_
 * `Ruby library for preparing/signing transactions and submitting them or querying a BigchainDB/IPDB node (MIT licensed) <https://rubygems.org/gems/bigchaindb>`_


### PR DESCRIPTION
This PR adds a link to the Java driver written by Authenteq.

I kept the link to the old and not-working Java driver, but noted those characteristics in its description. Some folks might find it interesting. Anyone wanting a Java driver will go for the one labelled "newer, working" (I hope!). 
