### PR TITLE
Automation for single node deployment for quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ BigchainDB is a scalable blockchain database. [The whitepaper](https://www.bigch
 ### [Quickstart](https://docs.bigchaindb.com/projects/server/en/latest/quickstart.html)
 ### [Set Up & Run a Dev/Test Node](https://docs.bigchaindb.com/projects/server/en/latest/dev-and-test/setup-run-node.html)
 ### [Run BigchainDB Server with Docker](https://docs.bigchaindb.com/projects/server/en/latest/appendices/run-with-docker.html)
+### [Run BigchainDB Server with Vagrant](https://docs.bigchaindb.com/projects/server/en/latest/appendices/run-with-vagrant.html)
+### [Run BigchainDB Server with Ansible](https://docs.bigchaindb.com/projects/server/en/latest/appendices/run-with-ansible.html)
 
 ## Links for Everyone
 

--- a/docs/server/source/appendices/index.rst
+++ b/docs/server/source/appendices/index.rst
@@ -27,3 +27,5 @@ Appendices
    rethinkdb-backup
    licenses
    install-with-lxd
+   run-with-vagrant
+   run-with-ansible

--- a/docs/server/source/appendices/run-with-ansible.md
+++ b/docs/server/source/appendices/run-with-ansible.md
@@ -1,0 +1,73 @@
+# Run BigchainDB with Ansible
+
+**NOT for Production Use**
+
+You can use the following instructions to deploy a BigchainDB node for
+dev/test using Ansible. Ansible will setup a BigchainDB node along with
+[Docker](https://www.docker.com/), [Docker Compose](https://docs.docker.com/compose/),
+[MongoDB](https://www.mongodb.com/), [BigchainDB Python driver](https://docs.bigchaindb.com/projects/py-driver/en/latest/).
+
+Currently, this workflow is only supported for the following distributions:
+- Ubuntu >= 16.04
+- CentOS >= 7
+- Fedora >= 24
+
+## Clone the BigchainDB repository | Ansible
+```text
+$ git clone https://github.com/bigchaindb/bigchaindb.git
+```
+
+## Install dependencies | Ansible
+- [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html)
+
+You can also install `ansible` and other dependecies, if any, using the `boostrap.sh` script
+inside the BigchainDB repository.
+Navigate to `bigchaindb/pkg/scripts` and run the `bootstrap.sh` script to install the dependecies
+for your OS. The script also checks if the OS you are running is compatible with the
+supported versions.
+
+```text
+$ cd bigchaindb/pkg/scripts/
+$ sudo ./bootstrap.sh
+```
+
+### Local Setup | Ansible
+You can safely run the `quickstart` playbook now and everything will be taken care of by `ansible` on your host. `quickstart` playbook only supports deployment on your dev/local host. To run the playbook please navigate to the ansible directory inside the BigchainDB repository and run the `quickstart` playbook.
+
+```text
+$ cd bigchaindb/pkg/ansible/
+
+# All the services will be deployed as processes
+$ sudo ansible-playbook quickstart.yml -c local
+
+OR
+
+# To deploy all services inside docker containers
+$ sudo ansible-playbook quickstart.yml --extra-vars "with_docker=true" -c local
+```
+
+After successfull execution of the playbook, you can verify that BigchainDB docker/process is running.
+
+Verify BigchainDB process:
+```text
+$ ps -ef | grep bigchaindb
+```
+
+OR
+
+Verify BigchainDB Docker:
+```text
+$ docker ps | grep bigchaindb
+```
+
+The playbook also installs the BigchainDB python driver, so can instantly make transactions and verify the functionality. The `bdb_root_url` can be be one of the following:
+```text
+# BigchainDB is running as a process
+bdb_root_url = http://<HOST-IP>:9984
+
+OR
+
+# BigchainDB is running inside a docker container
+bdb_root_url = http://<HOST-IP>:<DOCKER-PUBLISHED-PORT>
+```
+For more details on `how to make a transaction?` Please refer to [Basic Usage Examples](https://docs.bigchaindb.com/projects/py-driver/en/latest/connect.html).

--- a/docs/server/source/appendices/run-with-vagrant.md
+++ b/docs/server/source/appendices/run-with-vagrant.md
@@ -1,0 +1,137 @@
+# Run BigchainDB with Vagrant
+
+**NOT for Production Use**
+
+You can use the following instructions to deploy a BigchainDB node
+for dev/test using Vagrant. Vagrant will setup a BigchainDB node with
+all the dependencies along with MongoDB, BigchainDB Python driver. You
+can also tweak the following configurations for the BigchainDB node.
+- Vagrant Box
+  - Currently, we support the following boxes:
+    - `ubuntu/xenial64 # >=16.04`
+    - `centos/7 # >=7`
+    - `fedora/24 # >=24`
+  - **NOTE** : You can choose any other vagrant box of your choice but these are
+  the minimum versioning requirements.
+- Resources and specs for your box.
+  - RAM
+  - VCPUs
+  - Network Type
+    - Currently, only `private_network` is supported.
+  - IP Address
+- Setup type
+  - `quickstart`
+- Deploy node with Docker
+  - Deploy all the services in Docker containers or as processes.
+- Upstart Script
+- Vagrant Provider
+  - Virtualbox
+  - VMware
+
+## Install dependencies | Vagrant
+1. [VirtualBox](https://www.virtualbox.org/wiki/Downloads) >= 5.0.0
+2. [Vagrant](https://www.vagrantup.com/downloads.html) >= 1.16.0
+
+## Clone the BigchainDB repository | Vagrant
+```text
+$ git clone https://github.com/bigchaindb/bigchaindb.git
+```
+
+## Configuration | Vagrant
+Navigate to `bigchaindb/pkg/config/` inside the repository.
+```text
+$ cd bigchaindb/pkg/config/
+```
+
+Edit the `bdb-config.yaml` as per your requirements. Sample `bdb-config.yaml`:
+
+```text
+---
+- name: "bdb-node-01"
+  box:
+    name: "ubuntu/xenial64"
+  ram: "2048"
+  vcpus: "2"
+  setup_type: "quickstart"
+  deploy_docker: false
+  network:
+    ip: "10.20.30.40"
+    type: "private_network"
+  upstart: "/bigchaindb/scripts/bootstrap.sh"
+```
+
+**Note**: You can spawn multiple instances as well using `bdb-config.yaml`. Here is a sample `bdb-config.yaml`:
+```text
+---
+- name: "bdb-node-01"
+  box:
+    name: "ubuntu/xenial64"
+  ram: "2048"
+  vcpus: "2"
+  setup_type: "quickstart"
+  deploy_docker: false
+  network:
+    ip: "10.20.30.40"
+    type: "private_network"
+  upstart: "/bigchaindb/scripts/bootstrap.sh"
+- name: "bdb-node-02"
+  box:
+    name: "ubuntu/xenial64"
+  ram: "4096"
+  vcpus: "3"
+  setup_type: "quickstart"
+  deploy_docker: false
+  network:
+    ip: "10.20.30.50"
+    type: "private_network"
+  upstart: "/bigchaindb/scripts/bootstrap.sh"
+```
+
+
+## Local Setup | Vagrant
+To bring up the BigchainDB node, run the following command:
+
+```text
+$ vagrant up
+```
+
+*Note*: There are some vagrant plugins required for the installation, user will be prompted to install them if they are not present. Instructions to install the plugins can be extracted from the message.
+
+```text
+$ vagrant plugin install <plugin-name>
+```
+
+After successfull execution of Vagrant, you can log in to your fresh BigchainDB node.
+
+```text
+$ vagrant ssh <instance-name>
+```
+
+## Make your first transaction
+Once you are inside the BigchainDB node, you can verify that BigchainDB docker/process is running.
+
+Verify BigchainDB process:
+```text
+$ ps -ef | grep bigchaindb
+```
+
+OR
+
+Verify BigchainDB Docker:
+```text
+$ docker ps | grep bigchaindb
+```
+
+BigchainDB python driver is pre-installed in the instance, so you can instantly make transactions and verify the functionality. The `bdb_root_url` can be one of the following:
+```text
+# BigchainDB is running as a process
+bdb_root_url = http://<HOST-IP>:9984
+
+OR
+
+# BigchainDB is running inside a docker container
+bdb_root_url = http://<HOST-IP>:<DOCKER-PUBLISHED-HOST-PORT>
+```
+For more details on *how to make a transaction?* Please refer to [Basic Usage Examples](https://docs.bigchaindb.com/projects/py-driver/en/latest/connect.html).
+
+*Note*: If you want to make transactions remotely, you need to install the `bigchaindb-driver`. For detailed instructions on how to install the driver and make your first transaction. Please refer to [Quickstart/Installation](https://docs.bigchaindb.com/projects/py-driver/en/latest/quickstart.html) of BigchainDB driver.

--- a/docs/server/source/introduction.md
+++ b/docs/server/source/introduction.md
@@ -22,7 +22,6 @@ Note that there are a few kinds of nodes:
 There are some old RethinkDB-based deployment instructions as well:
 
 * [Deploy a bare-bones RethinkDB-based node on Azure](appendices/azure-quickstart-template.html)
-* [Deploy a bare-bones RethinkDB-based node on any Ubuntu machine with Ansible](appendices/template-ansible.html)
 * [Deploy a RethinkDB-based testing cluster on AWS](appendices/aws-testing-cluster.html)
 
 Instructions for setting up a client will be provided once there's a public test net.

--- a/docs/server/source/quickstart.md
+++ b/docs/server/source/quickstart.md
@@ -1,12 +1,6 @@
 # Quickstart
 
-This page has instructions to set up a single stand-alone BigchainDB node manually for learning or experimenting. Instructions for other cases are [elsewhere](introduction.html). You might try one of the following deployment methods
-as well, depending on your choice:
-- [BigchainDB with Docker](appendices/run-with-docker.html).
-- [BigchainDB with Vagrant](appendices/run-with-vagrant.html).
-- [BigchainDB with Ansible](appendices/run-with-ansible.html).
-
-For manual installation, We will assume you're using Ubuntu 16.04 or similar.
+This page has instructions to set up a single stand-alone BigchainDB node for learning or experimenting. Instructions for other cases are [elsewhere](introduction.html). We will assume you're using Ubuntu 16.04 or similar. If you're not using Linux, then you might try [running BigchainDB with Docker](appendices/run-with-docker.html).
 
 A. Install MongoDB as the database backend. (There are other options but you can ignore them for now.)
 

--- a/docs/server/source/quickstart.md
+++ b/docs/server/source/quickstart.md
@@ -1,6 +1,12 @@
 # Quickstart
 
-This page has instructions to set up a single stand-alone BigchainDB node for learning or experimenting. Instructions for other cases are [elsewhere](introduction.html). We will assume you're using Ubuntu 16.04 or similar. If you're not using Linux, then you might try [running BigchainDB with Docker](appendices/run-with-docker.html).
+This page has instructions to set up a single stand-alone BigchainDB node manually for learning or experimenting. Instructions for other cases are [elsewhere](introduction.html). You might try one of the following deployment methods
+as well, depending on your choice:
+- [BigchainDB with Docker](appendices/run-with-docker.html).
+- [BigchainDB with Vagrant](appendices/run-with-vagrant.html).
+- [BigchainDB with Ansible](appendices/run-with-ansible.html).
+
+For manual installation, We will assume you're using Ubuntu 16.04 or similar.
 
 A. Install MongoDB as the database backend. (There are other options but you can ignore them for now.)
 

--- a/pkg/Vagrantfile
+++ b/pkg/Vagrantfile
@@ -33,7 +33,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         end
       end
       bdb.vm.hostname = instance["name"]
-      bdb.vm.network instance["network"]["type"], ip: instance["network"]["ip"]
+      if instance["network"]["type"] == "private_network"
+        bdb.vm.network instance["network"]["type"], ip: instance["network"]["ip"]
+      elsif instance["network"]["type"] == "public_network"
+        bdb.vm.network instance["network"]["type"], use_dhcp_assigned_default_route: true, bridge: instance["network"]["bridge"]
+      else
+        raise "Invalid network type: Please specify one of the following: [private_network, public_network]"
+      end
       bdb.vm.box = instance["box"]["name"]
       bdb.vm.synced_folder ".", "/bigchaindb"
       bdb.vm.provision :shell, inline: "cd /bigchaindb/scripts;/bin/bash #{instance["upstart"]}"

--- a/pkg/Vagrantfile
+++ b/pkg/Vagrantfile
@@ -1,0 +1,56 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Required modules
+require 'yaml'
+
+# Minimum Requirements
+Vagrant.require_version '>= 1.6.0'
+VAGRANTFILE_API_VERSION = '2'
+
+# Configuration files
+CONFIGURATION_FILE = 'config/bdb-config.yaml'
+
+# Validate if all the required plugins are present
+required_plugins = ["vagrant-cachier"]
+required_plugins.each do |plugin|
+  if not Vagrant.has_plugin?(plugin)
+    raise "Required vagrant plugin #{plugin} not found. Please run `vagrant plugin install #{plugin}`"
+  end
+end
+
+# Read configuration file(s)
+instances_config = YAML.load_file(File.join(File.dirname(__FILE__), CONFIGURATION_FILE))
+
+#TODO: (muawiakh) Add support for Docker, AWS, Azure
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  instances_config.each do |instance|
+    config.vm.define instance['name'] do |bdb|
+      # Workaround until vagrant cachier plugin supports dnf
+      if !(instance["box"]["name"].include? "fedora")
+        if Vagrant.has_plugin?("vagrant-cachier")
+          config.cache.scope = :box
+        end
+      end
+      bdb.vm.hostname = instance["name"]
+      bdb.vm.network instance["network"]["type"], ip: instance["network"]["ip"]
+      bdb.vm.box = instance["box"]["name"]
+      bdb.vm.synced_folder ".", "/bigchaindb"
+      bdb.vm.provision :shell, inline: "cd /bigchaindb/scripts;/bin/bash #{instance["upstart"]}"
+      if instance["setup_type"] == "quickstart"
+        bdb.vm.provision :shell, inline: "PYTHONBUFFERED=1 ansible-playbook \
+          /bigchaindb/ansible/quickstart.yml --extra-vars \"with_docker=#{instance["deploy_docker"]}\" -c local"
+      end
+
+      bdb.vm.provider 'vmware_fusion' do |vmwf, override|
+        vmwf.vmx['memsize'] = instance["ram"]
+        vmwf.vmx['numvcpus'] = instance['vcpus']
+      end
+
+      bdb.vm.provider 'virtualbox' do |vb, override|
+        vb.memory = instance["ram"]
+        vb.cpus = instance['vcpus']
+      end
+    end
+  end
+end

--- a/pkg/ansible/quickstart.yml
+++ b/pkg/ansible/quickstart.yml
@@ -1,0 +1,10 @@
+- hosts: localhost
+  remote_user: vagrant
+  vars:
+    with_docker: "{{ deploy_docker | default(false) }}"
+  roles:
+    - { role: docker, when: with_docker|bool }
+    - { role: docker-compose, when: with_docker|bool }
+    - mongodb
+    - bigchaindb
+    - bigchaindb-driver

--- a/pkg/ansible/roles/bigchaindb-driver/defaults/main.yml
+++ b/pkg/ansible/roles/bigchaindb-driver/defaults/main.yml
@@ -1,0 +1,25 @@
+---
+dependencies_deb:
+  - python3-dev
+  - libffi-dev
+  - libssl-dev
+  - python3-pip
+
+dependencies_yum:
+  - gcc-c++
+  - "@Development Tools"
+  - python34-devel
+  - libffi-devel
+  - openssl-devel
+  - python34-setuptools
+
+dependencies_dnf:
+  - gcc-c++
+  - redhat-rpm-config
+  - "@Development Tools"
+  - python3-devel
+  - libffi-devel
+  - openssl-devel
+
+python_pip_upgrade: true
+python_setuptools_upgrade: true

--- a/pkg/ansible/roles/bigchaindb-driver/defaults/main.yml
+++ b/pkg/ansible/roles/bigchaindb-driver/defaults/main.yml
@@ -8,10 +8,10 @@ dependencies_deb:
 dependencies_yum:
   - gcc-c++
   - "@Development Tools"
-  - python34-devel
+  - python35u-devel
   - libffi-devel
   - openssl-devel
-  - python34-setuptools
+  - python35u-setuptools
 
 dependencies_dnf:
   - gcc-c++
@@ -20,6 +20,7 @@ dependencies_dnf:
   - python3-devel
   - libffi-devel
   - openssl-devel
+  - python3-pip
 
 python_pip_upgrade: true
 python_setuptools_upgrade: true

--- a/pkg/ansible/roles/bigchaindb-driver/tasks/centos.yml
+++ b/pkg/ansible/roles/bigchaindb-driver/tasks/centos.yml
@@ -6,7 +6,7 @@
     update_cache: yes
   with_items: "{{ dependencies_yum }}"
   tags: [bigchaindb-driver]
-
+  
 - name: Install pip
-  shell: "easy_install-3.4 pip"
+  shell: "easy_install-3.5 pip"
   tags: [bigchaindb-driver]

--- a/pkg/ansible/roles/bigchaindb-driver/tasks/centos.yml
+++ b/pkg/ansible/roles/bigchaindb-driver/tasks/centos.yml
@@ -1,0 +1,12 @@
+---
+- name: Install dependencies
+  yum:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+  with_items: "{{ dependencies_yum }}"
+  tags: [bigchaindb-driver]
+
+- name: Install pip
+  shell: "easy_install-3.4 pip"
+  tags: [bigchaindb-driver]

--- a/pkg/ansible/roles/bigchaindb-driver/tasks/common.yml
+++ b/pkg/ansible/roles/bigchaindb-driver/tasks/common.yml
@@ -1,0 +1,14 @@
+---
+- name: Upgrade pip
+  shell: "pip3 install --upgrade pip"
+  when: python_pip_upgrade
+  tags: [bigchaindb-driver]
+
+- name: Upgade setuptools
+  shell: "pip3 install --upgrade setuptools"
+  when: python_setuptools_upgrade
+  tags: [bigchaindb-driver]
+
+- name: Install BigchainDB Driver
+  shell: "pip3 install bigchaindb-driver"
+  tags: [bigchaindb-driver]

--- a/pkg/ansible/roles/bigchaindb-driver/tasks/debian.yml
+++ b/pkg/ansible/roles/bigchaindb-driver/tasks/debian.yml
@@ -1,0 +1,8 @@
+---
+- name: Install dependencies
+  apt:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+  with_items: "{{ dependencies_deb }}"
+  tags: [bigchaindb]

--- a/pkg/ansible/roles/bigchaindb-driver/tasks/fedora.yml
+++ b/pkg/ansible/roles/bigchaindb-driver/tasks/fedora.yml
@@ -1,0 +1,7 @@
+---
+- name: Install dependencies
+  dnf:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ dependencies_dnf }}"
+  tags: [bigchaindb-driver]

--- a/pkg/ansible/roles/bigchaindb-driver/tasks/main.yml
+++ b/pkg/ansible/roles/bigchaindb-driver/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+
+- include: debian.yml
+  when: distribution_name == "debian" or distribution_name == "ubuntu"
+
+- include: centos.yml
+  when: distribution_name == "centos" or distribution_name == "red hat enterprise linux"
+
+- include: fedora.yml
+  when: distribution_name == "fedora"
+
+- include: common.yml

--- a/pkg/ansible/roles/bigchaindb/defaults/main.yml
+++ b/pkg/ansible/roles/bigchaindb/defaults/main.yml
@@ -1,0 +1,46 @@
+---
+dependencies_deb:
+  - g++
+  - python3-dev
+  - libffi-dev
+  - build-essential
+  - libssl-dev
+  - python3-pip
+
+dependencies_yum:
+  - gcc-c++
+  - "@Development Tools"
+  - python34-devel
+  - libffi-devel
+  - openssl-devel
+  - python34-setuptools
+
+dependencies_dnf:
+  - gcc-c++
+  - redhat-rpm-config
+  - "@Development Tools"
+  - python3-devel
+  - libffi-devel
+  - openssl-devel
+
+python_pip_upgrade: true
+python_setuptools_upgrade: true
+
+directories:
+  - /data
+
+backend_db: mongodb #[rethinkdb, mongodb]
+
+bigchaindb_server_bind: "0.0.0.0:9984"
+bigchaindb_database_host: "172.17.0.1"
+bigchaindb_log_file: "{{ ansible_env.HOME }}/bigchaindb.log"
+
+# Docker configuration
+backend_db_image: "mongo:3.4.1"
+backend_db_name: "mongodb"
+bigchaindb_image_name: "bigchaindb/bigchaindb"
+bigchaindb_docker_name: "bigchaindb"
+bigchaindb_docker_published_ports:
+  - 59984:9984
+bigchaindb_docker_volumes:
+  - "{{ ansible_env.HOME }}/bigchaindb_docker:/data"

--- a/pkg/ansible/roles/bigchaindb/defaults/main.yml
+++ b/pkg/ansible/roles/bigchaindb/defaults/main.yml
@@ -10,10 +10,10 @@ dependencies_deb:
 dependencies_yum:
   - gcc-c++
   - "@Development Tools"
-  - python34-devel
+  - python35u-devel
   - libffi-devel
   - openssl-devel
-  - python34-setuptools
+  - python35u-setuptools
 
 dependencies_dnf:
   - gcc-c++
@@ -22,6 +22,7 @@ dependencies_dnf:
   - python3-devel
   - libffi-devel
   - openssl-devel
+  - python3-pip
 
 python_pip_upgrade: true
 python_setuptools_upgrade: true

--- a/pkg/ansible/roles/bigchaindb/tasks/centos.yml
+++ b/pkg/ansible/roles/bigchaindb/tasks/centos.yml
@@ -14,3 +14,7 @@
     update_cache: yes
   with_items: "{{ dependencies_yum }}"
   tags: [bigchaindb]
+
+- name: Install pip
+  shell: "easy_install-3.5 pip"
+  tags: [bigchaindb-driver]

--- a/pkg/ansible/roles/bigchaindb/tasks/centos.yml
+++ b/pkg/ansible/roles/bigchaindb/tasks/centos.yml
@@ -1,0 +1,16 @@
+---
+- name: Creating directories | CentOS
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: 0700
+  with_items: "{{ directories }}"
+  tags: [bigchaindb]
+
+- name: Install dependencies | CentOS
+  yum:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+  with_items: "{{ dependencies_yum }}"
+  tags: [bigchaindb]

--- a/pkg/ansible/roles/bigchaindb/tasks/common.yml
+++ b/pkg/ansible/roles/bigchaindb/tasks/common.yml
@@ -1,0 +1,36 @@
+---
+- name: Upgrade pip
+  shell: "pip3 install --upgrade pip"
+  when: python_pip_upgrade
+  tags: [bigchaindb]
+
+- name: Upgade setuptools
+  shell: "pip3 install --upgrade setuptools"
+  when: python_setuptools_upgrade
+  tags: [bigchaindb]
+
+- name: Install BigchainDB
+  shell: "pip3 install bigchaindb"
+  tags: [bigchaindb]
+
+- name: Configure BigchainDB
+  shell: "bigchaindb -y configure {{ backend_db }}"
+  environment:
+    BIGCHAINDB_SERVER_BIND:  "{{ bigchaindb_server_bind }}"
+  tags: [bigchaindb]
+
+- name: MongoDB Process Check
+  shell: pgrep mongod | wc -l
+  register: mdb_pchk
+  tags: [bigchaindb]
+
+- name: BigchainDB Process Check
+  shell: pgrep bigchaindb | wc -l
+  register: bdb_pchk
+  tags: [bigchaindb]
+
+- name: Start BigchainDB
+  become: yes
+  shell: "bigchaindb start > {{ bigchaindb_log_file }} 2>&1 &"
+  when: mdb_pchk.stdout| int >= 1 and bdb_pchk.stdout| int == 0
+  tags: [bigchaindb]

--- a/pkg/ansible/roles/bigchaindb/tasks/debian.yml
+++ b/pkg/ansible/roles/bigchaindb/tasks/debian.yml
@@ -1,0 +1,8 @@
+---
+- name: Install dependencies
+  apt:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+  with_items: "{{ dependencies_deb }}"
+  tags: [bigchaindb]

--- a/pkg/ansible/roles/bigchaindb/tasks/fedora.yml
+++ b/pkg/ansible/roles/bigchaindb/tasks/fedora.yml
@@ -1,0 +1,7 @@
+---
+- name: Install dependencies
+  dnf:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ dependencies_dnf }}"
+  tags: [bigchaindb]

--- a/pkg/ansible/roles/bigchaindb/tasks/main.yml
+++ b/pkg/ansible/roles/bigchaindb/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- include: with_docker.yml
+  when: with_docker|bool
+  tags: [bigchaindb]
+
+- include: debian.yml
+  when: not with_docker|bool and (distribution_name == "debian" or distribution_name == "ubuntu")
+
+- include: centos.yml
+  when: not with_docker|bool and (distribution_name == "centos" or distribution_name == "red hat enterprise linux")
+
+- include: fedora.yml
+  when: not with_docker|bool and (distribution_name == "fedora")
+
+- include: common.yml
+  when: not with_docker|bool

--- a/pkg/ansible/roles/bigchaindb/tasks/with_docker.yml
+++ b/pkg/ansible/roles/bigchaindb/tasks/with_docker.yml
@@ -1,0 +1,25 @@
+---
+- name: Configuring BigchainDB Docker
+  docker_container:
+    name: "{{ bigchaindb_docker_name }}"
+    image: "{{ bigchaindb_image_name }}"
+    volumes: "{{ bigchaindb_docker_volumes }}"
+    pull: false
+    env:
+      BIGCHAINDB_SERVER_BIND: "{{ bigchaindb_server_bind }}"
+      BIGCHAINDB_DATABASE_HOST: "{{ bigchaindb_database_host }}"
+    entrypoint: "bigchaindb -y configure mongodb"
+  register: result
+  tags: [bigchaindb]
+
+- name: Start BigchainDB Docker
+  docker_container:
+    name: "{{ bigchaindb_docker_name }}"
+    image: "{{ bigchaindb_image_name }}"
+    published_ports: "{{ bigchaindb_docker_published_ports }}"
+    restart_policy: always
+    volumes: "{{ bigchaindb_docker_volumes }}"
+    state: started
+    pull: false
+  when: result|succeeded
+  tags: [bigchaindb]

--- a/pkg/ansible/roles/docker-compose/defaults/main.yml
+++ b/pkg/ansible/roles/docker-compose/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# TODO: (muawiakh) Install docker-compose using pip
+# docker_compose_pip_install: false #[true, false]
+docker_compose_install: true #[true, false]
+docker_compose_version: "1.15.0"
+docker_compose_binary: /usr/local/bin/docker-compose
+docker_compose_base_url: "https://github.com/docker/compose/releases/download/"

--- a/pkg/ansible/roles/docker-compose/tasks/main.yml
+++ b/pkg/ansible/roles/docker-compose/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Get docker-compose
+  become: yes
+  get_url:
+    url: "{{ docker_compose_base_url }}{{ docker_compose_version }}/docker-compose-{{ ansible_system }}-{{ ansible_machine}}"
+    dest: "{{docker_compose_binary}}"
+    mode: 0755
+  when: docker_compose_install
+  tags: [docker-compose]

--- a/pkg/ansible/roles/docker/defaults/main.yml
+++ b/pkg/ansible/roles/docker/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+uninstall_old_version: false #[true, false]
+docker_edition: 'ce' #[ce, ee] Currently, onlt CE is supported
+docker_pkg: "docker-{{ docker_edition }}" #[docker-ce, docker-ee]
+docker_update_channel: "stable" #[stable, edge]
+
+# Host configuration
+distribution_name: "{{ ansible_distribution|lower }}"
+distribution_codename: "{{ ansible_distribution_release|lower }}"
+distribution_major: "{{ ansible_distribution_major_version }}"
+server_arch: "amd64" #[amd64, armhf, s390x]
+
+# Docker Repositories
+docker_apt_repo: "deb [arch={{ server_arch }}] https://download.docker.com/linux/{{ distribution_name }} {{ distribution_codename }} {{ docker_update_channel }}"
+apt_key_fingerprint: "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
+apt_key_url: "https://download.docker.com/linux/{{ distribution_name }}/gpg"
+docker_yum_repo: "https://download.docker.com/linux/{{ distribution_name }}/{{ distribution_major }}/$basearch/{{ docker_update_channel }}"
+docker_dnf_repo: "https://download.docker.com/linux/{{ distribution_name }}/{{ docker_pkg }}.repo"

--- a/pkg/ansible/roles/docker/tasks/centos.yml
+++ b/pkg/ansible/roles/docker/tasks/centos.yml
@@ -1,0 +1,42 @@
+---
+- name: Uninstall older versions of Docker | CentOS
+  yum:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - docker
+    - docker-common
+    - docker-engine
+    - docker-selinux
+  when: uninstall_old_version
+  tags: [docker]
+
+- name: Setup Pre-reqs | CentOS
+  yum:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+  with_items:
+    - yum-utils
+    - device-mapper-persistent-data
+    - lvm2
+    - python-pip
+  tags: [docker]
+
+- name: Add Docker Repo | CentOS
+  yum_repository:
+    name: "{{ docker_pkg }}"
+    gpgcheck: yes
+    gpgkey: https://download.docker.com/linux/centos/gpg
+    baseurl: "{{ docker_yum_repo }}"
+    file: "{{ docker_pkg }}"
+    description: "Docker Repo"
+    enabled: yes
+  tags: [docker]
+
+- name: Install Docker | CentOS
+  yum:
+    name: "{{ docker_pkg }}"
+    state: present
+    update_cache: yes
+  tags: [docker]

--- a/pkg/ansible/roles/docker/tasks/debian.yml
+++ b/pkg/ansible/roles/docker/tasks/debian.yml
@@ -1,0 +1,52 @@
+--- 
+- name: Uninstall older versions of Docker | Debian
+  apt:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - docker
+    - docker-engine
+    - docker.io
+  when: uninstall_old_version
+  tags: [docker]
+
+- name: Install dependencies | Debian
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - apt-transport-https
+    - ca-certificates
+    - curl
+    - software-properties-common
+    - python-pip
+  tags: [docker]
+
+- name: Add APT Key | Debian
+  apt_key:
+    url: "{{ apt_key_url }}"
+    id: "{{ apt_key_fingerprint }}"
+    state: present
+  register: add_repository_key
+  ignore_errors: true
+  tags: [docker]
+
+- name: Use curl if apt_key fails | Debian
+  shell: "curl -sSl {{ apt_key_url }} | sudo apt-key add -"
+  args:
+    warn: no
+  when: add_repository_key|failed
+  tags: [docker]
+
+- name: Add Docker repo and update cache | Debian
+  apt_repository:
+    repo: "{{ docker_apt_repo }}"
+    update_cache: yes
+    state: present
+  tags: [docker]
+
+- name: Install Docker | Debian
+  apt:
+    name: "{{ docker_pkg }}"
+    state: present
+  tags: [docker]

--- a/pkg/ansible/roles/docker/tasks/fedora.yml
+++ b/pkg/ansible/roles/docker/tasks/fedora.yml
@@ -1,0 +1,34 @@
+---
+- name: Uninstall older versions of Docker | Fedora
+  dnf:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - docker-engine-selinux
+    - docker-common
+    - docker-engine
+    - docker-selinux
+  when: uninstall_old_version
+  tags: [docker]
+
+- name: Setup Pre-reqs | Fedora
+  dnf:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - dnf-plugins-core
+  tags: [docker]
+
+- name: Add Docker repo | Fedora
+  shell: "dnf config-manager --add-repo {{ docker_dnf_repo }}"
+  tags: [docker]
+
+- name: Update Cache | Fedora
+  shell: "dnf makecache fast"
+  tags: [docker]
+
+- name: Install Docker | Fedora
+  dnf:
+    name: "{{ docker_pkg }}"
+    state: present
+  tags: [docker]

--- a/pkg/ansible/roles/docker/tasks/main.yml
+++ b/pkg/ansible/roles/docker/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+- include: debian.yml
+  when: distribution_name == "debian" or distribution_name == "ubuntu"
+
+- include: centos.yml
+  when: distribution_name == "centos" or distribution_name == "red hat enterprise linux"
+
+- include: fedora.yml
+  when: distribution_name == "fedora"
+
+- name: Create Docker group
+  group:
+    name: docker
+    state: present
+  register: group_result
+  tags: [docker]
+
+- name: Add USER to docker group
+  user:
+    append: yes
+    name: "{{ item }}"
+    state: present
+    group: docker
+  with_items:
+    - vagrant
+    - "{{ distribution_name }}"
+  tags: [docker]
+
+- name: Start docker service
+  systemd:
+    name: docker
+    enabled: yes
+    state: started
+  tags: [docker]
+
+- name: Install docker-py
+  pip:
+    name: docker-py
+    state: present
+  tags: [docker]

--- a/pkg/ansible/roles/mongodb/defaults/main.yml
+++ b/pkg/ansible/roles/mongodb/defaults/main.yml
@@ -1,0 +1,34 @@
+---
+mongodb_version: "3.4"
+mongodb_package: "mongodb-org"
+apt_key_fingerprint: "0C49F3730359A14518585931BC711F9BA15703C6"
+apt_keyserver: "keyserver.ubuntu.com"
+distribution_name: "{{ansible_distribution|lower }}"
+distribution_codename: "{{ ansible_distribution_release|lower }}"
+distribution_major: "{{ ansible_distribution_major_version }}"
+server_arch: "amd64,arm64"
+
+# MongoDB Repos
+mongodb_apt_repo: "deb [arch={{ server_arch }}] http://repo.mongodb.org/apt/{{ distribution_name }} {{ distribution_codename }}/{{ mongodb_package }}/{{ mongodb_version }} {{'main' if ansible_distribution == 'debian' else 'multiverse'}}"
+mongodb_yum_base_url: "https://repo.mongodb.org/yum/{{ ansible_os_family|lower }}/$releasever/{{ mongodb_package }}/{{ mongodb_version }}/{{ ansible_architecture }}"
+mongodb_dnf_base_url: "https://repo.mongodb.org/yum/{{ ansible_os_family|lower }}/7/{{ mongodb_package }}/{{ mongodb_version }}/{{ ansible_architecture }}"
+
+# MongoDB running config
+mongodb_storage_path: /data/db
+mongodb_log_path: /var/log/mongodb
+mongodb_config_path: /data/configdb
+se_linux: "TODO: (muawiakh)"
+directories:
+  - "{{ mongodb_storage_path }}"
+  - "{{ mongodb_log_path }}"
+  - "{{ mongodb_config_path }}"
+
+# Docker configuration
+mongodb_default_port: 27017
+mongodb_docker_image: "mongo:3.4.1"
+mongodb_docker_name: "mongodb"
+mongodb_docker_published_ports:
+  - 172.17.0.1:27017:27017
+mongodb_docker_volumes:
+  - "/tmp/mongodb_docker/db:{{ mongodb_storage_path }}"
+  - "/tmp/mongodb_docker/configdb:{{ mongodb_config_path }}"

--- a/pkg/ansible/roles/mongodb/defaults/main.yml
+++ b/pkg/ansible/roles/mongodb/defaults/main.yml
@@ -14,7 +14,7 @@ mongodb_yum_base_url: "https://repo.mongodb.org/yum/{{ ansible_os_family|lower }
 mongodb_dnf_base_url: "https://repo.mongodb.org/yum/{{ ansible_os_family|lower }}/7/{{ mongodb_package }}/{{ mongodb_version }}/{{ ansible_architecture }}"
 
 # MongoDB running config
-mongodb_storage_path: /data/db
+mongodb_storage_path: /data/db/main
 mongodb_log_path: /var/log/mongodb
 mongodb_config_path: /data/configdb
 se_linux: "TODO: (muawiakh)"
@@ -25,10 +25,12 @@ directories:
 
 # Docker configuration
 mongodb_default_port: 27017
-mongodb_docker_image: "mongo:3.4.1"
+mongodb_docker_image: "mongo:3.4.4"
 mongodb_docker_name: "mongodb"
 mongodb_docker_published_ports:
   - 172.17.0.1:27017:27017
+mongodb_host_mount_dir_db: /tmp/mongodb_docker/db
+mongodb_host_mount_dir_config: /tmp/mongodb_docker/configdb
 mongodb_docker_volumes:
-  - "/tmp/mongodb_docker/db:{{ mongodb_storage_path }}"
-  - "/tmp/mongodb_docker/configdb:{{ mongodb_config_path }}"
+  - "{{ mongodb_host_mount_dir_db }}:{{ mongodb_storage_path }}"
+  - "{{ mongodb_host_mount_dir_config }}:{{ mongodb_config_path }}"

--- a/pkg/ansible/roles/mongodb/tasks/centos.yml
+++ b/pkg/ansible/roles/mongodb/tasks/centos.yml
@@ -1,0 +1,18 @@
+---
+- name: Add MongoDB Repo | CentOS
+  yum_repository:
+    name: "{{ mongodb_package }}"
+    gpgcheck: yes
+    gpgkey: https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc
+    baseurl: "{{ mongodb_yum_base_url }}"
+    file: "{{ mongodb_package }}"
+    description: "MongoDB Repo"
+    enabled: yes
+  tags: [mongodb]
+
+- name: Install MongoDB | CentOS
+  yum:
+    name: "{{ mongodb_package }}"
+    state: present
+    update_cache: yes
+  tags: [mongodb]

--- a/pkg/ansible/roles/mongodb/tasks/common.yml
+++ b/pkg/ansible/roles/mongodb/tasks/common.yml
@@ -1,0 +1,10 @@
+---
+- name: MongoDB Process Check
+  shell: pgrep mongod | wc -l
+  register: command_result
+  tags: [mongodb]
+
+- name: Run MongoDB
+  shell: "mongod --replSet=bigchain-rs --logpath {{ mongodb_log_path }}/mongod.log &"
+  when: command_result.stdout| int != 1
+  tags: [mongodb]

--- a/pkg/ansible/roles/mongodb/tasks/debian.yml
+++ b/pkg/ansible/roles/mongodb/tasks/debian.yml
@@ -1,0 +1,21 @@
+---
+- name: Add APT Key | Debian
+  apt_key:
+    keyserver: "{{ apt_keyserver }}"
+    id: "{{ apt_key_fingerprint }}"
+    state: present
+  ignore_errors: true
+  tags: [mongodb]
+
+- name: Add MongoDB repo and update cache | Debian
+  apt_repository:
+    repo: "{{ mongodb_apt_repo }}"
+    update_cache: yes
+    state: present
+  tags: [mongodb]
+
+- name: Install MongoDB | Debian
+  apt:
+    name: "{{ mongodb_package }}"
+    state: present
+  tags: [mongodb]

--- a/pkg/ansible/roles/mongodb/tasks/fedora.yml
+++ b/pkg/ansible/roles/mongodb/tasks/fedora.yml
@@ -1,0 +1,17 @@
+---
+- name: Add MongoDB Repo | Fedora
+  yum_repository:
+    name: "{{ mongodb_package }}"
+    gpgcheck: yes
+    gpgkey: https://www.mongodb.org/static/pgp/server-{{ mongodb_version }}.asc
+    baseurl: "{{ mongodb_dnf_base_url }}"
+    file: "{{ mongodb_package }}"
+    description: "MongoDB Repo"
+    enabled: yes
+  tags: [mongodb]
+
+- name: Install MongoDB | Fedora
+  dnf:
+    name: "{{ mongodb_package }}"
+    state: present
+  tags: [mongodb]

--- a/pkg/ansible/roles/mongodb/tasks/main.yml
+++ b/pkg/ansible/roles/mongodb/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+- name: Creating directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: 0700
+  with_items: "{{ directories }}"
+  tags: [mongodb]
+
+- include: with_docker.yml
+  when: with_docker|bool
+
+- name: Verify logfiles exist | Debian
+  file:
+    path: "{{ mongodb_log_path }}/mongod.log"
+    state: touch
+    mode: 0755
+  when: not with_docker|bool
+  tags: [mongodb]
+
+- include: debian.yml
+  when: not with_docker|bool and (distribution_name == "debian" or distribution_name == "ubuntu")
+
+- include: centos.yml
+  when: not with_docker|bool and (distribution_name == "centos" or distribution_name == "red hat enterprise linux")
+
+- include: fedora.yml
+  when: not with_docker|bool and (distribution_name == "fedora")
+
+- include: common.yml
+  when: not with_docker|bool

--- a/pkg/ansible/roles/mongodb/tasks/with_docker.yml
+++ b/pkg/ansible/roles/mongodb/tasks/with_docker.yml
@@ -1,0 +1,20 @@
+---
+- name: Check Docker Service
+  systemd:
+    name: docker
+    enabled: yes
+    state: started
+  tags: [docker]
+
+- name: Running MongoDB Docker
+  docker_container:
+    name: "{{ mongodb_docker_name }}"
+    image: "{{ mongodb_docker_image }}"
+    detach: True
+    published_ports: "{{ mongodb_docker_published_ports }}"
+    restart_policy: always
+    volumes: "{{ mongodb_docker_volumes }}"
+    state: started
+    pull: false
+    entrypoint: /entrypoint.sh --replSet=bigchain-rs
+  tags: [mongodb]

--- a/pkg/config/bdb-config.yaml
+++ b/pkg/config/bdb-config.yaml
@@ -1,0 +1,12 @@
+---
+- name: "bdb-node-01" # Instance name
+  box:
+    name: "ubuntu/xenial64" # Box name
+  ram: "2048"
+  vcpus: "2"
+  setup_type: "quickstart" # Currently, only quickstart is supported.
+  deploy_docker: true # [true, false]
+  network:
+    ip: "10.20.30.50"
+    type: "private_network" # Currently, only private network is supported.
+  upstart: "/bigchaindb/scripts/bootstrap.sh" # Path to upstart script

--- a/pkg/config/bdb-config.yaml
+++ b/pkg/config/bdb-config.yaml
@@ -8,5 +8,7 @@
   deploy_docker: true # [true, false]
   network:
     ip: "10.20.30.50"
-    type: "private_network" # Currently, only private network is supported.
+    type: "private_network"
+    # Active network interface on host, Only required for public network e.g  "en0: Wi-Fi (AirPort)"
+    bridge: "<network-interface-host>"
   upstart: "/bigchaindb/scripts/bootstrap.sh" # Path to upstart script

--- a/pkg/scripts/bootstrap.sh
+++ b/pkg/scripts/bootstrap.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -e
+
+. ./bootstrap_constants.sh
+. ./bootstrap_helper.sh
+
+# OS ID(ubuntu, centos, fedora)
+OS=""
+# OS Version(16.04, 7, 24)
+VER=""
+
+# Parsing arguments
+while [[ $# -gt 1 ]]; do
+    arg="$1"
+    case $arg in
+        --os)
+            OS="$2"
+            shift
+        ;;
+        --os-version)
+            VER="$2"
+            shift
+        ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+        ;;
+    esac
+    shift
+done
+
+validate_os_configuration(){
+    valid_os=1
+    if [ -f $1 ]; then
+        . $1
+        OS=$ID
+        VER=$VERSION_ID
+    elif type lsb_release >/dev/null 2>&1; then
+        OS=$(lsb_release -si)
+        VER=$(lsb_release -sr)
+    else
+        echo "Cannot find $OS_CONF. Pass arguments to your OS configurations: NAME, VERSION_ID.
+        Supported OS(s) are: [ ${SUPPORTED_OS[*]} ]."
+        exit 1
+    fi
+    for os in "${SUPPORTED_OS[@]}"; do
+        if [[ $os = $2 ]]; then
+            valid_os=true
+            break
+        fi
+    done
+}
+
+validate_os_configuration $OS_CONF $OS $VER
+echo "Operation Sytem: $OS"
+echo "Version: $VER"
+install_deps=$(validate_os_version_and_deps true $OS $VER)
+if [[ $install_deps -eq 1 ]]; then
+    install_dependencies $OS
+else
+    echo "Dependencies already installed:[ ${OS_DEPENDENCIES[*]} ]"
+fi

--- a/pkg/scripts/bootstrap_constants.sh
+++ b/pkg/scripts/bootstrap_constants.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+OS_CONF=/etc/os-release
+declare -a SUPPORTED_OS=('ubuntu' 'centos' 'fedora')
+declare -a OS_DEPENDENCIES=('ansible')
+MINIMUM_UBUNTU_VERSION=16.04
+MINIUMUM_CENTOS_VERSION=7
+MINIMIUM_FEDORA_VERSION=24

--- a/pkg/scripts/bootstrap_helper.sh
+++ b/pkg/scripts/bootstrap_helper.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+. ./bootstrap_constants.sh
+
+validate_os_version_and_deps(){
+    if $1; then
+        case $2 in
+            ubuntu)
+                apt-get install bc -y > /dev/null 2>&1
+                if [[ ($(echo $3 | bc) > $MINIMUM_UBUNTU_VERSION)
+                    || ($(echo $3 | bc) == $MINIMUM_UBUNTU_VERSION)]]; then
+                    dpkg -s "${OS_DEPENDENCIES[@]}" > /dev/null 2>&1
+                    echo $?
+                else
+                    echo "Supported $2 Versions: >= $MINIMUM_UBUNTU_VERSION"
+                    exit 1
+                fi
+            ;;
+            centos)
+                yum install bc -y > /dev/null 2>&1
+                if [[ ($(echo $3 | bc) > $MINIMUM_CENTOS_VERSION)
+                    || ($(echo $3 | bc) == $MINIMUM_CENTOS_VERSION) ]]; then
+                    rpm -q "${OS_DEPENDENCIES[@]}" > /dev/null 2>&1
+                    echo $?
+                else
+                    echo "Supported $2 Versions: >= $MINIMUM_CENTOS_VERSION"
+                    exit 1
+                fi
+            ;;
+            fedora)
+                dnf install bc -y > /dev/null 2>&1
+                if [[ ($(echo $3 | bc) > $MINIMUM_FEDORA_VERSION)
+                    || ($(echo $3 | bc) == $MINIMUM_FEDORA_VERSION) ]]; then
+                    rpm -q "${OS_DEPENDENCIES[@]}" > /dev/null 2>&1
+                    echo $?
+                else
+                    echo "Supported $2 Versions: >= $MINIMUM_FEDORA_VERSION"
+                    exit 1
+                fi
+            ;;
+            *)
+                echo "Supported OS(s) are: [ ${SUPPORTED_OS[*]} ]."
+                exit 1
+            ;;
+        esac
+    else
+        echo "Supported OS(s) are: [ ${SUPPORTED_OS[*]} ]."
+        exit 1
+    fi
+}
+
+install_dependencies() {
+    case $1 in
+        ubuntu)
+            install_deps_deb
+        ;;
+        centos)
+            install_deps_centos
+        ;;
+        fedora)
+            install_deps_fedora
+        ;;
+        *)
+            echo "Supported OS(s) are: [ ${SUPPORTED_OS[*]} ]."
+            exit 1
+        ;;
+    esac
+}
+
+#TODO: muawiakh(Currently only ansible is required. Make it generic for
+# multiple dependencies)
+install_deps_deb() {
+    echo "Installing Dependencies..."
+    apt-get install -y software-properties-common
+    apt-add-repository ppa:ansible/ansible
+    apt-get update
+    apt-get install -y --force-yes ansible
+}
+install_deps_centos() {
+    echo "Installing Dependencies..."
+    yum install epel-release -y
+    yum install ansible -y
+}
+install_deps_fedora() {
+    echo "Installing Dependencies..."
+    export LC_ALL=C
+    dnf makecache
+    dnf -y install ansible python2-dnf
+}

--- a/pkg/scripts/bootstrap_helper.sh
+++ b/pkg/scripts/bootstrap_helper.sh
@@ -79,6 +79,7 @@ install_deps_deb() {
 install_deps_centos() {
     echo "Installing Dependencies..."
     yum install epel-release -y
+    yum install -y https://centos7.iuscommunity.org/ius-release.rpm
     yum install ansible -y
 }
 install_deps_fedora() {


### PR DESCRIPTION
- Change consists of two deployment models:
  - Using Vagrant(single node, with/without docker)
  - Using Ansible(single node, with/without docker)
- Updated quickstart documentation.
- Some WIP comments, which will be addressed later. Depending on the
  requirements.