### PR TITLE
Adjust resources for MongoDB Stateful Set

### DIFF
--- a/docs/server/source/production-deployment-template/client-tls-certificate.rst
+++ b/docs/server/source/production-deployment-template/client-tls-certificate.rst
@@ -92,7 +92,7 @@ consolidated file containing both the public and private keys.
 
 .. code:: bash
 
-   cat /path/to/mdb-instance-0.crt /path/to/mdb-instance-0.key > mdb-instance-0.pem
+   cat /path/to/bdb-instance-0.crt /path/to/bdb-instance-0.key > bdb-instance-0.pem
 
     OR
 

--- a/docs/server/source/production-deployment-template/node-on-kubernetes.rst
+++ b/docs/server/source/production-deployment-template/node-on-kubernetes.rst
@@ -542,6 +542,19 @@ Step 12: Start a Kubernetes StatefulSet for MongoDB
     - ``mdb-certs``
     - ``ca-auth``
 
+  * **Optional**: You can also change the value for ``STORAGE_ENGINE_CACHE_SIZE``, for more information
+    regarding this configuration, please consult the `MongoDB Official
+    Documentation <https://docs.mongodb.com/manual/reference/configuration-options/#storage.wiredTiger.engineConfig.cacheSizeGB>`_.
+
+  * **Optional**: If you are not using the **Standard_D2_v2** virtual machines for Kubernetes agents as per the guide,
+    please update the ``resources`` for ``mongo-ss``. We suggest allocating ``memory`` using the following scheme
+    for a MongoDB StatefulSet:
+
+    .. code:: bash
+
+      memory = (Total_Memory_Agent_VM_GB - 2GB)
+      STORAGE_ENGINE_CACHE_SIZE = memory / 2
+
   * Create the MongoDB StatefulSet using:
 
     .. code:: bash

--- a/docs/server/source/production-deployment-template/node-on-kubernetes.rst
+++ b/docs/server/source/production-deployment-template/node-on-kubernetes.rst
@@ -542,7 +542,7 @@ Step 12: Start a Kubernetes StatefulSet for MongoDB
     - ``mdb-certs``
     - ``ca-auth``
 
-  * **Optional**: You can also change the value for ``STORAGE_ENGINE_CACHE_SIZE``, for more information
+  * **Optional**: You can change the value for ``STORAGE_ENGINE_CACHE_SIZE`` in the ConfigMap ``storage-engine-cache-size``, for more information
     regarding this configuration, please consult the `MongoDB Official
     Documentation <https://docs.mongodb.com/manual/reference/configuration-options/#storage.wiredTiger.engineConfig.cacheSizeGB>`_.
 

--- a/k8s/configuration/config-map.yaml
+++ b/k8s/configuration/config-map.yaml
@@ -99,6 +99,11 @@ data:
   # WebSocket API in BigchainDB; can be 'ws' or 'wss' (default).
   bigchaindb-wsserver-advertised-scheme: "wss"
 
+  # Optional: Optimize storage engine(wired tiger)
+  # cache size. e.g. (2048MB, 2GB, 1TB), otherwise
+  # it will use the default cache size; i.e. max((50% RAM - 1GB), 256MB)
+  storage-engine-cache-size: ""
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/k8s/mongodb/container/docker_build_and_push.bash
+++ b/k8s/mongodb/container/docker_build_and_push.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-docker build -t bigchaindb/mongodb:3.1 .
+docker build -t bigchaindb/mongodb:3.2 .
 
-docker push bigchaindb/mongodb:3.1
+docker push bigchaindb/mongodb:3.2

--- a/k8s/mongodb/container/mongod.conf.template
+++ b/k8s/mongodb/container/mongod.conf.template
@@ -86,6 +86,7 @@ storage:
   wiredTiger:
     engineConfig:
       journalCompressor: snappy
+      configString: cache_size=STORAGE_ENGINE_CACHE_SIZE
     collectionConfig:
       blockCompressor: snappy
     indexConfig:
@@ -98,4 +99,3 @@ operationProfiling:
 replication:
   replSetName: REPLICA_SET_NAME
   enableMajorityReadConcern: true
-

--- a/k8s/mongodb/container/mongod_entrypoint.bash
+++ b/k8s/mongodb/container/mongod_entrypoint.bash
@@ -65,7 +65,7 @@ if [[ -z "${REPLICA_SET_NAME:?REPLICA_SET_NAME not specified. Exiting!}" || \
     -z "${MONGODB_IP:?MONGODB_IP not specified. Exiting!}" || \
     -z "${MONGODB_KEY_FILE_PATH:?MONGODB_KEY_FILE_PATH not specified. Exiting!}" || \
     -z "${MONGODB_CA_FILE_PATH:?MONGODB_CA_FILE_PATH not specified. Exiting!}" || \
-    -z "${MONGODB_CRL_FILE_PATH:?MONGODB_CRL_FILE_PATH not specified. Exiting!}" ||
+    -z "${MONGODB_CRL_FILE_PATH:?MONGODB_CRL_FILE_PATH not specified. Exiting!}" || \
     -z "${STORAGE_ENGINE_CACHE_SIZE:=''}" ]] ; then
     #-z "${MONGODB_KEY_FILE_PASSWORD:?MongoDB Key File Password not specified. Exiting!}" || \
   exit 1
@@ -91,14 +91,14 @@ sed -i "s|MONGODB_CA_FILE_PATH|${MONGODB_CA_FILE_PATH}|g" ${MONGODB_CONF_FILE_PA
 sed -i "s|MONGODB_CRL_FILE_PATH|${MONGODB_CRL_FILE_PATH}|g" ${MONGODB_CONF_FILE_PATH}
 sed -i "s|REPLICA_SET_NAME|${REPLICA_SET_NAME}|g" ${MONGODB_CONF_FILE_PATH}
 if [ ! -z "$STORAGE_ENGINE_CACHE_SIZE" ]; then
-  if [[ "$STORAGE_ENGINE_CACHE_SIZE" =~ ^[0-9]+\.?(G|M|T)B$ ]]; then
+  if [[ "$STORAGE_ENGINE_CACHE_SIZE" =~ ^[0-9]+(G|M|T)B$ ]]; then
     sed -i.bk "s|STORAGE_ENGINE_CACHE_SIZE|${STORAGE_ENGINE_CACHE_SIZE}|g" ${MONGODB_CONF_FILE_PATH}
   else
     echo "Invalid Value for storage engine cache size $STORAGE_ENGINE_CACHE_SIZE"
     exit 1
   fi
 else
-  sed -i.bk "/cacheSizeGB/d" ${MONGODB_CONF_FILE_PATH}
+  sed -i.bk "/cache_size=/d" ${MONGODB_CONF_FILE_PATH}
 fi
 
 # add the hostname and ip to hosts file

--- a/k8s/mongodb/mongo-ss.yaml
+++ b/k8s/mongodb/mongo-ss.yaml
@@ -43,10 +43,11 @@ spec:
             configMapKeyRef:
              name: vars
              key: mongodb-backend-port
-        # Optional: Optimize storage engine(wired tiger)
-        # cache size. e.g. (2048MB, 2GB, 1TB)
         - name: STORAGE_ENGINE_CACHE_SIZE
-          value: ""
+          valueFrom:
+            configMapKeyRef:
+             name: vars
+             key: storage-engine-cache-size
         args:
         - --mongodb-port
         - $(MONGODB_PORT)

--- a/k8s/mongodb/mongo-ss.yaml
+++ b/k8s/mongodb/mongo-ss.yaml
@@ -43,6 +43,10 @@ spec:
             configMapKeyRef:
              name: vars
              key: mongodb-backend-port
+        # Optional: Optimize storage engine(wired tiger)
+        # cache size. e.g. (2048MB, 2GB, 1TB)
+        - name: STORAGE_ENGINE_CACHE_SIZE
+          value: ""
         args:
         - --mongodb-port
         - $(MONGODB_PORT)
@@ -58,6 +62,8 @@ spec:
         - $(MONGODB_FQDN)
         - --mongodb-ip
         - $(MONGODB_POD_IP)
+        - --storage-engine-cache-size
+        - $(STORAGE_ENGINE_CACHE_SIZE)
         securityContext:
           capabilities:
             add:
@@ -80,7 +86,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 3.5G
+            memory: 5G
         livenessProbe:
           tcpSocket:
             port: mdb-api-port


### PR DESCRIPTION
- Currently, MongoDB container crashed because of resource constaints i.e.
out of memory exception. This change updates the resources and provides
data on how the configure/calculate them(if not following the guide).
- Also, add the ability to specify the storage engine(WiredTiger) cache
size for MongoDB, this configuration also helps with keeping the resources
constrained for MongoDB containers.
- Minor changes in some other documents as well.