### PR TITLE
Update BDB Docker image version for k8s

### DIFF
--- a/k8s/bigchaindb/bigchaindb-dep.yaml
+++ b/k8s/bigchaindb/bigchaindb-dep.yaml
@@ -12,7 +12,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: bigchaindb
-        image: bigchaindb/bigchaindb:1.0.1
+        image: bigchaindb/bigchaindb:1.1.0
         imagePullPolicy: IfNotPresent
         args:
         - start

--- a/k8s/dev-setup/bigchaindb.yaml
+++ b/k8s/dev-setup/bigchaindb.yaml
@@ -34,7 +34,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: bigchaindb
-        image: bigchaindb/bigchaindb:1.0.0
+        image: bigchaindb/bigchaindb:1.1.0
         imagePullPolicy: Always
         args:
         - start


### PR DESCRIPTION
Part of the BigchainDB release process for version 1.1.

@krish7919 Is there anywhere else we should be updating the version number of the bigchaindb/bigchaindb image to 1.1.0? (That's its identity on Docker Hub.)