### PR TITLE
Minor revisions to RELEASE_PROCESS.md following the release of v1.1

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -16,13 +16,13 @@ except release candidates are labelled like
 A minor release is preceeded by a feature freeze and created from the 'master' branch. This is a summary of the steps we go through to release a new minor version of BigchainDB Server.
 
 1. Update the `CHANGELOG.md` file in master
-1. In `k8s/bigchaindb/bigchaindb-dep.yaml`, find the line of the form `image: bigchaindb/bigchaindb:0.8.1` and change the version number to the new version number, e.g. `0.9.0`. (This is the Docker image that Kubernetes should pull from Docker Hub.) Commit that change to master
+1. In `k8s/bigchaindb/bigchaindb-dep.yaml` AND in `k8s/dev-setup/bigchaindb.yaml`, find the line of the form `image: bigchaindb/bigchaindb:0.8.1` and change the version number to the new version number, e.g. `0.9.0`. (This is the Docker image that Kubernetes should pull from Docker Hub.) Commit that change to master
 1. Create and checkout a new branch for the minor release, named after the minor version, without a preceeding 'v', e.g. `git checkout -b 0.9` (*not* 0.9.0, this new branch will be for e.g. 0.9.0, 0.9.1, 0.9.2, etc. each of which will be identified by a tagged commit)
 1. Push the new branch to GitHub, e.g. `git push origin 0.9`
 1. Create and checkout a new branch off of the 0.9 branch. Let's call it branch T for now
 1. In `bigchaindb/version.py`, update `__version__` and `__short_version__`, e.g. to `0.9` and `0.9.0` (with no `.dev` on the end)
 1. Commit those changes, push the new branch T to GitHub, and use the pushed branch T to create a new pull request merging the T branch into the 0.9 branch.
-1. Wait for all the tests to pass!
+1. Wait for all the tests to pass! Then merge T into 0.9.
 1. Follow steps outlined in [Common Steps](#common-steps)
 1. In 'master' branch, Edit `bigchaindb/version.py`, increment the minor version to the next planned release, e.g. `0.10.0.dev`. (Exception: If you just released `X.Y.Zrc1` then increment the minor version to `X.Y.Zrc2`.) This step is so people reading the latest docs will know that they're for the latest (master branch) version of BigchainDB Server, not the docs at the time of the most recent release (which are also available).
 1. Go to [Docker Hub](https://hub.docker.com/), sign in, go to bigchaindb/bigchaindb, go to Settings - Build Settings, and under the build with Docker Tag Name equal to `latest`, change the Name to the number of the new release, e.g. `0.9`
@@ -38,7 +38,7 @@ A patch release is similar to a minor release, but piggybacks on an existing min
 1. Update the `CHANGELOG.md` file
 1. Increment the patch version in `bigchaindb/version.py`, e.g. `0.9.1`
 1. Commit that change
-1. In `k8s/bigchaindb/bigchaindb-dep.yaml`, find the line of the form `image: bigchaindb/bigchaindb:0.9.0` and change the version number to the new version number, e.g. `0.9.1`. (This is the Docker image that Kubernetes should pull from Docker Hub.)
+1. In `k8s/bigchaindb/bigchaindb-dep.yaml` AND in `k8s/dev-setup/bigchaindb.yaml`, find the line of the form `image: bigchaindb/bigchaindb:0.9.0` and change the version number to the new version number, e.g. `0.9.1`. (This is the Docker image that Kubernetes should pull from Docker Hub.)
 1. Commit that change
 1. Push the updated minor release branch to GitHub
 1. Follow steps outlined in [Common Steps](#common-steps)
@@ -59,8 +59,7 @@ These steps are common between minor and patch releases:
 1. Make sure your local Git is in the same state as the release: e.g. `git fetch <remote-name>` and `git checkout v0.9.1`
 1. Make sure you have a `~/.pypirc` file containing credentials for PyPI
 1. Do a `make release` to build and publish the new `bigchaindb` package on PyPI
-1. [Login to readthedocs.org](https://readthedocs.org/accounts/login/)
-   as a maintainer of the BigchainDB Server docs, and:
+1. [Login to readthedocs.org](https://readthedocs.org/accounts/login/) and go to the **BigchainDB Server** project (*not* **BigchainDB**), then:
    - Go to Admin --> Advanced Settings
      and make sure that "Default branch:" (i.e. what "latest" points to)
      is set to the new release's tag, e.g. `v0.9.1`.


### PR DESCRIPTION
* Both `k8s/bigchaindb/bigchaindb-dep.yaml` AND in `k8s/dev-setup/bigchaindb.yaml` must get updated
* Clarified that branch T should be merged into master once the tests pass.
* Clarified that in readthedocs.org, one should be going to the **BigchainDB Server** project, not **BigchaindB**