### PR TITLE
Change Group ID to Project ID for Mongo DB Cloud Manager configs

### DIFF
--- a/docs/server/source/production-deployment-template/cloud-manager.rst
+++ b/docs/server/source/production-deployment-template/cloud-manager.rst
@@ -16,7 +16,7 @@ Configure MongoDB Cloud Manager for Monitoring
 
   * Select the group from the dropdown box on the page.
 
-  * Go to Settings, Group Settings and add a ``Preferred Hostnames`` entry as
+  * Go to Settings and add a ``Preferred Hostnames`` entry as
     a regexp based on the ``mdb-instance-name`` of the nodes in your cluster.
     It may take up to 5 mins till this setting takes effect.
     You may refresh the browser window and verify whether the changes have

--- a/docs/server/source/production-deployment-template/workflow.rst
+++ b/docs/server/source/production-deployment-template/workflow.rst
@@ -110,13 +110,13 @@ secret token, service ID, version header and API service token.
 
 
 ☐ If the cluster uses MongoDB Cloud Manager for monitoring and backup,
-you must ask the managing organization for the ``Group ID`` and the
+you must ask the managing organization for the ``Project ID`` and the
 ``Agent API Key``.
-(Each Cloud Manager "group" has its own ``Group ID``. A ``Group ID`` can
+(Each Cloud Manager "Project" has its own ``Project ID``. A ``Project ID`` can
 contain a number of ``Agent API Key`` s. It can be found under
-**Settings - Group Settings**. It was recently added to the Cloud Manager to
+**Settings**. It was recently added to the Cloud Manager to
 allow easier periodic rotation of the ``Agent API Key`` with a constant
-``Group ID``)
+``Project ID``)
 
 
 ☐ :doc:`Deploy a Kubernetes cluster on Azure <template-kubernetes-azure>`.

--- a/k8s/configuration/secret.yaml
+++ b/k8s/configuration/secret.yaml
@@ -14,9 +14,9 @@ metadata:
   namespace: default
 type: Opaque
 data:
-  # Base64-encoded Group ID
-  # Group ID used by MongoDB deployment
-  group-id: "<b64 encoded Group ID>"
+  # Base64-encoded Project ID
+  # Project ID used by MongoDB deployment
+  group-id: "<b64 encoded Project ID>"
   # Base64-encoded MongoDB Agent API Key for the group
   agent-api-key: "<b64 encoded Agent API Key>"
 ---


### PR DESCRIPTION
MongoDB cloud manager UI has been updated and they have changed **Group ID** to **Project ID** and merged **Settings -> Group Settings** into one consolidated panel **Settings**

- This PR updates the k8s docs accordingly