### PR TITLE
Add standard template for creating PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,9 @@
 ## Description
 A few sentences describing the overall goals of the pull request's commits.
 
-## Feature Status
-**READY/IN DEVELOPMENT**
+## Issues This PR Fixes
+Fixes #NNNN
+Fixes #NNNN
 
 ## Related PRs
 List related PRs against other branches e.g. for backporting features/bugfixes
@@ -16,8 +17,7 @@ some_other_PR | [link]()
 ## Todos
 - [ ] Tested and working on development environment
 - [ ] Unit tests (if appropriate)
-- [ ] New API endpoints documented. Add [link]() if different from this PR 
-- [ ] Reviewed and approved by a senior dev
+- [ ] Added/Updated all related documentation. Add [link]() if different from this PR
 - [ ] DevOps Support needed e.g. create Runscope API test if new endpoint added or
       update deployment docs. Create a ticket and add [link]()
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Description
+A few sentences describing the overall goals of the pull request's commits.
+
+## Feature Status
+**READY/IN DEVELOPMENT**
+
+## Related PRs
+List related PRs against other branches e.g. for backporting features/bugfixes
+to previous release branches:
+
+Repo/Branch | PR
+------ | ------
+some_other_PR | [link]()
+
+
+## Todos
+- [ ] Tested and working on development environment
+- [ ] Unit tests (if appropriate)
+- [ ] New API endpoints documented. Add [link]() if different from this PR 
+- [ ] Reviewed and approved by a senior dev
+- [ ] DevOps Support needed e.g. create Runscope API test if new endpoint added or
+      update deployment docs. Create a ticket and add [link]()
+
+## Deployment Notes
+Notes about how to deploy this work. For example, running a migration against the production DB.
+
+## How to QA
+Outline the steps to test or reproduce the PR here.
+
+## Impacted Areas in Application
+List general components of the application that this PR will affect:
+- Scale
+- Performance
+- Security etc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,20 @@ Once you accept and submit the CLA, we'll email you with further instructions. (
 
 Someone will then merge your branch or suggest changes. If we suggest changes, you won't have to open a new pull request, you can just push new code to the same branch (on `origin`) as you did before creating the pull request.
 
+### Pull Request Guidelines
+
+Before you submit a pull request, check that it meets these guidelines:
+
+1. The pull request should include tests.
+2. If the pull request adds functionality, the docs should be updated. Put
+   your new functionality into a function with a docstring, and add the
+   feature to the list in README.rst.
+3. The pull request should work for Python 3.5, and pass the flake8 check.
+   Check https://travis-ci.org/bigchaindb/bigchaindb-driver/pull_requests
+   and make sure that the tests pass for all supported Python versions.
+4. Follow the pull request template while creating new PRs, the template will
+   be visible to you when you create a new pull request.
+
 ### Tip: Upgrading All BigchainDB Dependencies
 
 Over time, your versions of the Python packages used by BigchainDB will get out of date. You can upgrade them using:


### PR DESCRIPTION
## Description
Recently while updating test net k8s cluster a recently added API endpoint
was skipped from testing because DevOps team was not aware of the new
endpoint and an issue with this endpoint on new cluster was only caught after
we moved the test net to new cluster. To avoid this in the future this PR adds a 
standard PR template to delegate dependencies whenever applicable.

## Feature Status
**READY**

## Related PRs

Repo/Branch | PR
------ | ------
bigchaindb/bigchaindb-driver | [link](https://github.com/bigchaindb/bigchaindb-driver/pull/329)

## Todos
- [x] Documented in CONTRIBUTING.rst
- [ ] Reviewed and approved by a senior dev

## Deployment Notes
No impact on deployment

## How to QA
Create a new PR and the template should be visible

## Impacted Areas in Application
- No Scale impact
- No Performance impact
- No Security impact
- Documentation impact: Developer documentation needs to be updated