### PR TITLE
Add JS Driver button on home page of root docs

### DIFF
--- a/docs/root/source/index.rst
+++ b/docs/root/source/index.rst
@@ -59,6 +59,9 @@ At a high level, one can communicate with a BigchainDB cluster (set of nodes) us
      <a class="button" href="http://docs.bigchaindb.com/projects/py-driver/en/latest/index.html">Python Driver Docs</a>
    </div>
    <div class="buttondiv">
+     <a class="button" href="http://docs.bigchaindb.com/projects/js-driver/en/latest/index.html">JavaScript Driver Docs</a>
+   </div>
+   <div class="buttondiv">
      <a class="button" href="https://docs.bigchaindb.com/projects/cli/en/latest/">Command Line Transaction Tool</a>
    </div>
    <div class="buttondiv">


### PR DESCRIPTION
I just noticed that there's no big blue button for the JavaScript Driver on the home page of the root docs.

This PR adds one.