### PR TITLE
New root docs page about permissions in BigchainDB

### DIFF
--- a/docs/root/source/conf.py
+++ b/docs/root/source/conf.py
@@ -34,7 +34,9 @@ from recommonmark.parser import CommonMarkParser
 # ones.
 import sphinx_rtd_theme
 
-extensions = []
+extensions = [
+    'sphinx.ext.autosectionlabel',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/root/source/index.rst
+++ b/docs/root/source/index.rst
@@ -88,5 +88,6 @@ More About BigchainDB
    assets
    smart-contracts
    transaction-concepts
+   permissions
    timestamps
    Data Models <https://docs.bigchaindb.com/projects/server/en/latest/data-models/index.html>

--- a/docs/root/source/permissions.rst
+++ b/docs/root/source/permissions.rst
@@ -1,0 +1,74 @@
+Permissions in BigchainDB
+-------------------------
+
+BigchainDB lets users control what other users can do, to some extent. That ability resembles "permissions" in the \*nix world, "privileges" in the SQL world, and "access control" in the security world.
+
+
+Permission to Spend/Transfer an Output
+======================================
+
+In BigchainDB, every output has an associated condition (crypto-condition).
+
+To spend/transfer an unspent output, a user (or group of users) must fulfill the condition. Another way to say that is that only certain users have permission to spend the output. The simplest condition is of the form, "Only someone with the private key corresponding to this public key can spend this output." Much more elaborate conditions are possible, e.g. "To spend this output, …"
+
+- "…anyone in the Accounting Group can sign."
+- "…three of these four people must sign."
+- "…either Bob must sign, or both Tom and Sylvia must sign."
+
+For details, see `the documentation about conditions in BigchainDB <https://docs.bigchaindb.com/projects/server/en/latest/data-models/conditions.html>`_.
+
+Once an output has been spent, it can't be spent again: *nobody* has permission to do that. That is, BigchainDB doesn't permit anyone to "double spend" an output.
+
+
+Write Permissions
+=================
+
+When someone builds a TRANSFER transaction, they can put an arbitrary JSON object in the ``metadata`` field (within reason; real BigchainDB networks put a limit on the size of transactions). That is, they can write just about anything they want in a TRANSFER transaction.
+
+Does that mean there are no "write permissions" in BigchainDB? Not at all!
+
+A TRANSFER transaction will only be valid (allowed) if its inputs fulfill some previous outputs. The conditions on those outputs will control who can build valid TRANSFER transactions. In other words, one can interpret the condition on an output as giving "write permissions" to certain users to write something into the history of the associated asset.
+
+As a concrete example, you could use BigchainDB to write a public journal where only you have write permissions. Here's how: First you'd build a CREATE transaction with the ``asset.data`` being something like ``{"title": "The Journal of John Doe"}``, with one output. That output would have an amount 1 and a condition that only you (who has your private key) can spend that output.
+Each time you want to append something to your journal, you'd build a new TRANSFER transaction with your latest entry in the ``metadata`` field, e.g.
+
+.. code-block:: json
+
+   {"timestamp": "1508319582",
+    "entry": "I visited Marmot Lake with Jane."}
+
+The TRANSFER transaction would have one output. That output would have an amount 1 and a condition that only you (who has your private key) can spend that output. And so on. Only you would be able to append to the history of that asset (your journal).
+
+The same technique could be used for scientific notebooks, supply-chain records, government meeting minutes, and so on.
+
+You could do more elaborate things too. As one example, each time someone writes a TRANSFER transaction, they give *someone else* permission to spend it, setting up a sort of writers-relay or chain letter.
+
+.. note::
+
+   Anyone can write any JSON (again, within reason) in the ``asset.data`` field of a CREATE transaction. They don't need permission.
+
+
+Read Permissions
+================
+
+All the data stored in a BigchainDB network can be read by anyone with access to that network. One *can* store encrypted data, but if the decryption key ever leaks out, then the encrypted data can be read, decrypted, and leak out too. (Deleting the encrypted data is :doc:`not an option <immutable>`.)
+
+The permission to read some specific information (e.g. a music file) can be thought of as an *asset*. (In many countries, that permission or "right" is a kind of intellectual property.)
+BigchainDB can be used to register that asset and transfer it from owner to owner.
+Today, BigchainDB does not have a way to restrict read access of data stored in a BigchainDB network, but many third-party services do offer that (e.g. Google Docs, Dropbox). 
+In principle, a third party service could ask a BigchainDB network to determine if a particular user has permission to read some particular data. Indeed they could use BigchainDB to keep track of *all* the rights a user has for some data (not just the right to read it).
+That third party could also use BigchainDB to store audit logs, i.e. records of every read, write or other operation on stored data.
+
+BigchainDB can be used in other ways to help parties exchange private data:
+
+- It can be used to publicly disclose the *availability* of some private data (stored elsewhere). For example, there might be a description of the data and a price.
+- It can be used to record the TLS handshakes which two parties sent to each other to establish an encrypted and authenticated TLS connection, which they could use to exchange private data with each other. (The stored handshake information wouldn't be enough, by itself, to decrypt the data.) It would be a "proof of TLS handshake."
+- See the BigchainDB `Privacy Protocols repository <https://github.com/bigchaindb/privacy-protocols>`_ for more techniques.
+
+
+Role-Based Access Control (RBAC)
+================================
+
+In September 2017, we published a `blog post about how one can define an RBAC sub-system on top of BigchainDB <https://blog.bigchaindb.com/role-based-access-control-for-bigchaindb-assets-b7cada491997>`_.
+At the time of writing (October 2017), doing so required the use of a plugin, so it's not possible using standard BigchainDB (which is what's available on `IPDB <https://ipdb.io/>`_). That may change in the future.
+If you're interested, `contact BigchainDB <https://www.bigchaindb.com/contact/>`_.


### PR DESCRIPTION
This pull request resolves #1752 

Note: As soon as this PR gets merged, the page will go live in the "latest" root docs because for the root docs, "latest" == the master branch.

@vrde I put you as a reviewer since you've probably thought the most about permissions in BigchainDB. This PR isn't super urgent but Matthias needs the page to be live before he can link to it from bigchaindb.com (a link to a page about permissions in BigchainDB). It's just one new page of docs and it's not super-technical. It shouldn't take too long too review.

@kremalicious You can link to https://docs.bigchaindb.com/en/latest/permissions.html once this PR gets merged.