### PR TITLE
Provide log server port as config parameter

### DIFF
--- a/bigchaindb/__init__.py
+++ b/bigchaindb/__init__.py
@@ -97,6 +97,7 @@ config = {
         'fmt_console': log_config['formatters']['console']['format'],
         'fmt_logfile': log_config['formatters']['file']['format'],
         'granular_levels': {},
+        'port': log_config['root']['port']
     },
     'graphite': {
         'host': os.environ.get('BIGCHAINDB_GRAPHITE_HOST', 'localhost'),

--- a/bigchaindb/log/configs.py
+++ b/bigchaindb/log/configs.py
@@ -63,6 +63,6 @@ SUBSCRIBER_LOGGING_CONFIG = {
     'root': {
         'level': logging.DEBUG,
         'handlers': ['console', 'file', 'errors'],
-        'port': 9020
+        'port': DEFAULT_SOCKET_LOGGING_PORT
     },
 }

--- a/bigchaindb/log/configs.py
+++ b/bigchaindb/log/configs.py
@@ -62,6 +62,7 @@ SUBSCRIBER_LOGGING_CONFIG = {
     'loggers': {},
     'root': {
         'level': logging.DEBUG,
-        'handlers': ['console', 'file', 'errors']
+        'handlers': ['console', 'file', 'errors'],
+        'port': 9020
     },
 }

--- a/bigchaindb/log/loggers.py
+++ b/bigchaindb/log/loggers.py
@@ -22,11 +22,14 @@ class HttpServerLogger(Logger):
                 object. *Ignored*.
 
         """
+        log_cfg = self.cfg.env_orig.get('custom_log_config', {})
+        self.log_port = log_cfg.get('port', DEFAULT_SOCKET_LOGGING_PORT)
+
         self._set_socklog_handler(self.error_log)
         self._set_socklog_handler(self.access_log)
 
     def _set_socklog_handler(self, log):
         socket_handler = logging.handlers.SocketHandler(
-            DEFAULT_SOCKET_LOGGING_HOST, DEFAULT_SOCKET_LOGGING_PORT)
+            DEFAULT_SOCKET_LOGGING_HOST, self.log_port)
         socket_handler._gunicorn = True
         log.addHandler(socket_handler)

--- a/bigchaindb/log/setup.py
+++ b/bigchaindb/log/setup.py
@@ -26,8 +26,7 @@ def _normalize_log_level(level):
 
 
 def setup_pub_logger(logging_port=None):
-    if logging_port is None:
-        logging_port = DEFAULT_SOCKET_LOGGING_PORT
+    logging_port = logging_port or DEFAULT_SOCKET_LOGGING_PORT
 
     dictConfig(PUBLISHER_LOGGING_CONFIG)
     socket_handler = logging.handlers.SocketHandler(
@@ -39,13 +38,10 @@ def setup_pub_logger(logging_port=None):
 
 def setup_sub_logger(*, user_log_config=None):
     kwargs = {}
-    logging_port = None
+    log_port = user_log_config.get('port') if user_log_config is not None else None
 
-    if user_log_config is not None:
-        logging_port = user_log_config.get('port')
-
-    if logging_port is not None:
-        kwargs['port'] = logging_port
+    if log_port is not None:
+        kwargs['port'] = log_port
 
     server = LogRecordSocketServer(**kwargs)
     with server:

--- a/bigchaindb/processes.py
+++ b/bigchaindb/processes.py
@@ -63,7 +63,8 @@ def start():
     election.start(events_queue=exchange.get_publisher_queue())
 
     # start the web api
-    app_server = server.create_server(bigchaindb.config['server'])
+    app_server = server.create_server(settings=bigchaindb.config['server'],
+                                      log_config=bigchaindb.config['log'])
     p_webapi = mp.Process(name='webapi', target=app_server.run)
     p_webapi.start()
 

--- a/bigchaindb/web/server.py
+++ b/bigchaindb/web/server.py
@@ -37,6 +37,11 @@ class StandaloneApplication(gunicorn.app.base.BaseApplication):
         super().__init__()
 
     def load_config(self):
+        # find a better way to pass this such that
+        # the custom logger class can access it.
+        custom_log_config = self.options.get('custom_log_config')
+        self.cfg.env_orig['custom_log_config'] = custom_log_config
+
         config = dict((key, value) for key, value in self.options.items()
                       if key in self.cfg.settings and value is not None)
 
@@ -74,7 +79,7 @@ def create_app(*, debug=False, threads=1):
     return app
 
 
-def create_server(settings):
+def create_server(settings, log_config=None):
     """Wrap and return an application ready to be run.
 
     Args:
@@ -97,6 +102,7 @@ def create_server(settings):
         settings['threads'] = 1
 
     settings['logger_class'] = 'bigchaindb.log.loggers.HttpServerLogger'
+    settings['custom_log_config'] = log_config
     app = create_app(debug=settings.get('debug', False),
                      threads=settings['threads'])
     standalone = StandaloneApplication(app, options=settings)

--- a/docs/server/source/server-reference/configuration.md
+++ b/docs/server/source/server-reference/configuration.md
@@ -319,7 +319,8 @@ holding the logging configuration.
         "granular_levels": {
             "bichaindb.backend": "info",
             "bichaindb.core": "info"
-        }
+        },
+        "port": 7070
 }
 ```
 
@@ -336,7 +337,8 @@ holding the logging configuration.
         "datefmt_logfile": "%Y-%m-%d %H:%M:%S",
         "fmt_logfile": "[%(asctime)s] [%(levelname)s] (%(name)s) %(message)s (%(processName)-10s - pid: %(process)d)",
         "fmt_console": "[%(asctime)s] [%(levelname)s] (%(name)s) %(message)s (%(processName)-10s - pid: %(process)d)",
-        "granular_levels": {}
+        "granular_levels": {},
+        "port": 9020
 }
 ```
 
@@ -531,6 +533,22 @@ logging of the `core.py` module to be more verbose, you would set the
 ```
 
 **Defaults to**: `"{}"`
+
+
+### log.port
+The port number at which the logging server should listen.
+
+**Example**:
+
+```
+{
+    "log": {
+        "port": 7070
+        }
+}
+```
+
+**Defaults to**: `9020`
 
 
 ## graphite.host

--- a/docs/server/source/server-reference/configuration.md
+++ b/docs/server/source/server-reference/configuration.md
@@ -39,6 +39,7 @@ For convenience, here's a list of all the relevant environment variables (docume
 `BIGCHAINDB_LOG_FMT_CONSOLE`<br>
 `BIGCHAINDB_LOG_FMT_LOGFILE`<br>
 `BIGCHAINDB_LOG_GRANULAR_LEVELS`<br>
+`BIGCHAINDB_LOG_PORT`<br>
 `BIGCHAINDB_DATABASE_SSL`<br>
 `BIGCHAINDB_DATABASE_LOGIN`<br>
 `BIGCHAINDB_DATABASE_PASSWORD`<br>
@@ -532,7 +533,7 @@ logging of the `core.py` module to be more verbose, you would set the
 }
 ```
 
-**Defaults to**: `"{}"`
+**Defaults to**: `{}`
 
 
 ### log.port

--- a/tests/log/test_loggers.py
+++ b/tests/log/test_loggers.py
@@ -7,9 +7,9 @@ class TestHttpServerLogger:
         from bigchaindb.log.configs import (
             DEFAULT_SOCKET_LOGGING_ADDR as expected_socket_address)
         from bigchaindb.log.loggers import HttpServerLogger
-        mocked_config = mocker.patch(
-            'gunicorn.config.Config', autospec=True, spec_set=True)
-        logger = HttpServerLogger(mocked_config.return_value)
+        from gunicorn import config
+        logger_config = config.Config()
+        logger = HttpServerLogger(logger_config)
         assert len(logger.access_log.handlers) == 1
         assert len(logger.error_log.handlers) == 1
         assert isinstance(logger.access_log.handlers[0], SocketHandler)

--- a/tests/log/test_setup.py
+++ b/tests/log/test_setup.py
@@ -70,7 +70,7 @@ def log_record_bytes(log_record_dict):
 def test_setup_logging(mocked_setup_pub_logger, mocked_setup_sub_logger):
     from bigchaindb.log.setup import setup_logging
     setup_logging()
-    mocked_setup_pub_logger.assert_called_once_with()
+    mocked_setup_pub_logger.assert_called_once_with(logging_port=None)
     mocked_setup_sub_logger.assert_called_once_with(user_log_config=None)
 
 

--- a/tests/log/test_setup.py
+++ b/tests/log/test_setup.py
@@ -112,11 +112,12 @@ def test_setup_sub_logger_with_config(mocked_socket_server, mocked_process):
         'granular_levels': {
             'bigchaindb.core': 'debug',
         },
+        'port': 9020
     }
     root_logger = getLogger()
     setup_sub_logger(user_log_config=user_log_config)
     assert root_logger.level == logging.NOTSET
-    mocked_socket_server.assert_called_once_with()
+    mocked_socket_server.assert_called_once_with(port=9020)
     mocked_process.assert_called_once_with(
             target=mocked_socket_server.return_value.serve_forever,
             kwargs={'log_config': user_log_config},

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -302,6 +302,7 @@ def test_autoconfigure_read_both_from_file_and_env(monkeypatch, request, certs_d
             'fmt_console': log_config['formatters']['console']['format'],
             'fmt_logfile': log_config['formatters']['file']['format'],
             'granular_levels': {},
+            'port': 9020
         },
         'graphite': {'host': 'localhost'},
     }


### PR DESCRIPTION
Converted log server's binding port as a parameter in `.bigchaindb` config file
Fixes #1660 