### PR TITLE
Move implicit database initialization in "bigchaindb start" to command line flag

### DIFF
--- a/bigchaindb/commands/bigchaindb.py
+++ b/bigchaindb/commands/bigchaindb.py
@@ -196,7 +196,9 @@ def run_start(args):
         logger.info('RethinkDB started with PID %s' % proc.pid)
 
     try:
-        _run_init()
+        if args.initialize_database:
+            logger.info('Initializing database')
+            _run_init()
     except DatabaseAlreadyExists:
         pass
     except KeypairNotFoundException:
@@ -299,6 +301,11 @@ def create_parser():
                               dest='start_rethinkdb',
                               action='store_true',
                               help='Run RethinkDB on start')
+
+    start_parser.add_argument('--init',
+                              dest='initialize_database',
+                              action='store_true',
+                              help='Force initialize database')
 
     # parser for configuring the number of shards
     sharding_parser = subparsers.add_parser('set-shards',

--- a/docker-compose.benchmark.yml
+++ b/docker-compose.benchmark.yml
@@ -25,7 +25,7 @@ services:
       BIGCHAINDB_GRAPHITE_HOST: graphite
     ports:
       - "9984"
-    command: bigchaindb start
+    command: bigchaindb start --init
 
   graphite:
     image: hopsoft/graphite-statsd

--- a/docker-compose.rdb.yml
+++ b/docker-compose.rdb.yml
@@ -45,4 +45,4 @@ services:
       BIGCHAINDB_SERVER_BIND: 0.0.0.0:9984
     ports:
       - "9984"
-    command: bigchaindb start
+    command: bigchaindb start --init

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,4 +30,4 @@ services:
       BIGCHAINDB_WSSERVER_HOST: 0.0.0.0
     ports:
       - "9984"
-    command: bigchaindb start
+    command: bigchaindb start --init

--- a/docs/server/source/appendices/azure-quickstart-template.md
+++ b/docs/server/source/appendices/azure-quickstart-template.md
@@ -33,7 +33,7 @@ API Server bind? (default `localhost:9984`): 0.0.0.0:9984
 
 Finally, run BigchainDB Server by doing:
 ```text
-bigchaindb start
+bigchaindb start --init
 ```
 
 BigchainDB Server should now be running on the Azure virtual machine.

--- a/docs/server/source/dev-and-test/setup-bdb-host.md
+++ b/docs/server/source/dev-and-test/setup-bdb-host.md
@@ -27,7 +27,7 @@ waiting for connections on port 27017
 
 To run BigchainDB Server, do:
 ```text
-$ bigchaindb start
+$ bigchaindb start --init
 ```
 
 You can [run all the unit tests](running-all-tests.html) to test your installation.
@@ -55,7 +55,7 @@ You can verify that RethinkDB is running by opening the RethinkDB web interface 
 
 To run BigchainDB Server, do:
 ```text
-$ bigchaindb start
+$ bigchaindb start --init
 ```
 
 You can [run all the unit tests](running-all-tests.html) to test your installation.

--- a/docs/server/source/quickstart.md
+++ b/docs/server/source/quickstart.md
@@ -54,7 +54,7 @@ $ bigchaindb -y configure mongodb
 
 I. Run BigchainDB Server:
 ```text
-$ bigchaindb start
+$ bigchaindb start --init
 ```
 
 J. Verify BigchainDB Server setup by visiting the BigchainDB Root URL in your browser:

--- a/docs/server/source/server-reference/bigchaindb-cli.md
+++ b/docs/server/source/server-reference/bigchaindb-cli.md
@@ -51,8 +51,6 @@ all database tables/collections,
 various backend database indexes,
 and the genesis block.
 
-Note: The `bigchaindb start` command (see below) always starts by trying a `bigchaindb init` first. If it sees that the backend database already exists, then it doesn't re-initialize the database. One doesn't have to do `bigchaindb init` before `bigchaindb start`. `bigchaindb init` is useful if you only want to initialize (but not start).
-
 
 ## bigchaindb drop
 
@@ -63,7 +61,7 @@ If you want to force-drop the database (i.e. skipping the yes/no prompt), then u
 
 ## bigchaindb start
 
-Start BigchainDB. It always begins by trying a `bigchaindb init` first. See the note in the documentation for `bigchaindb init`.
+Start BigchainDB assuming that the database has already been initialized using `bigchaindb init`. If that is not the case then passing the flag `--init` will initialize the database and start BigchainDB.
 You can also use the `--dev-start-rethinkdb` command line option to automatically start rethinkdb with bigchaindb if rethinkdb is not already running,
 e.g. `bigchaindb --dev-start-rethinkdb start`. Note that this will also shutdown rethinkdb when the bigchaindb process stops.
 The option `--dev-allow-temp-keypair` will generate a keypair on the fly if no keypair is found, this is useful when you want to run a temporary instance of BigchainDB in a Docker container, for example.

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -49,6 +49,7 @@ def run_start_args(request):
         config=param.get('config'),
         start_rethinkdb=param.get('start_rethinkdb', False),
         allow_temp_keypair=param.get('allow_temp_keypair', False),
+        initialize_database=param.get('initialize_database', True),
     )
 
 

--- a/tests/commands/rethinkdb/test_commands.py
+++ b/tests/commands/rethinkdb/test_commands.py
@@ -13,7 +13,8 @@ def test_bigchain_run_start_with_rethinkdb(mock_start_rethinkdb,
                                            mocked_setup_logging):
     from bigchaindb import config
     from bigchaindb.commands.bigchaindb import run_start
-    args = Namespace(start_rethinkdb=True, allow_temp_keypair=False, config=None, yes=True)
+    args = Namespace(start_rethinkdb=True, allow_temp_keypair=False, config=None, yes=True,
+                     initialize_database=True)
     run_start(args)
 
     mock_start_rethinkdb.assert_called_with()

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -39,7 +39,8 @@ def test_bigchain_run_start(mock_run_configure,
                             mocked_setup_logging):
     from bigchaindb import config
     from bigchaindb.commands.bigchaindb import run_start
-    args = Namespace(start_rethinkdb=False, allow_temp_keypair=False, config=None, yes=True)
+    args = Namespace(start_rethinkdb=False, allow_temp_keypair=False, config=None, yes=True,
+                     initialize_database=True)
     run_start(args)
     mocked_setup_logging.assert_called_once_with(user_log_config=config['log'])
 
@@ -288,7 +289,8 @@ def test_allow_temp_keypair_generates_one_on_the_fly(
 
     bigchaindb.config['keypair'] = {'private': None, 'public': None}
 
-    args = Namespace(allow_temp_keypair=True, start_rethinkdb=False, config=None, yes=True)
+    args = Namespace(allow_temp_keypair=True, start_rethinkdb=False, config=None, yes=True,
+                     initialize_database=True)
     run_start(args)
 
     mocked_setup_logging.assert_called_once_with(
@@ -314,7 +316,8 @@ def test_allow_temp_keypair_doesnt_override_if_keypair_found(mock_gen_keypair,
     assert isinstance(original_public_key, str)
     assert isinstance(original_private_key, str)
 
-    args = Namespace(allow_temp_keypair=True, start_rethinkdb=False, config=None, yes=True)
+    args = Namespace(allow_temp_keypair=True, start_rethinkdb=False, config=None, yes=True,
+                     initialize_database=True)
     run_start(args)
 
     mocked_setup_logging.assert_called_once_with(


### PR DESCRIPTION
Migrate database setup during `bigchaindb start` to command line flag `--init`
Fixes #1661 