### PR TITLE
Updated docs/server/requirements.txt

### DIFF
--- a/docs/server/requirements.txt
+++ b/docs/server/requirements.txt
@@ -3,3 +3,5 @@ recommonmark>=0.4.0
 sphinx-rtd-theme>=0.1.9
 sphinxcontrib-napoleon>=0.4.4
 sphinxcontrib-httpdomain>=1.5.0
+pyyaml
+bigchaindb

--- a/docs/server/requirements.txt
+++ b/docs/server/requirements.txt
@@ -3,5 +3,5 @@ recommonmark>=0.4.0
 sphinx-rtd-theme>=0.1.9
 sphinxcontrib-napoleon>=0.4.4
 sphinxcontrib-httpdomain>=1.5.0
-pyyaml
+pyyaml>=3.12
 bigchaindb


### PR DESCRIPTION
The `requirements.txt` file in `docs/server/` didn't have all the Python packages needed to build the BigchainDB Server docs. I fixed that.