### PR TITLE
Validation for "language" key in asset.data object

### DIFF
--- a/bigchaindb/common/schema/transaction.yaml
+++ b/bigchaindb/common/schema/transaction.yaml
@@ -117,6 +117,25 @@ definitions:
         anyOf:
         - type: object
           additionalProperties: true
+          patternProperties:
+            language:
+              type: string
+              enum:
+                - danish
+                - dutch
+                - english
+                - finnish
+                - french
+                - german
+                - hungarian
+                - italian
+                - norwegian
+                - portuguese
+                - romanian
+                - russian
+                - spanish
+                - swedish
+                - turkish
         - type: 'null'
   output:
     type: object

--- a/tests/web/test_transactions.py
+++ b/tests/web/test_transactions.py
@@ -47,6 +47,42 @@ def test_post_create_transaction_endpoint(b, client):
     assert res.json['outputs'][0]['public_keys'][0] == user_pub
 
 
+@pytest.mark.parametrize("language,expected_status_code", [
+    ('danish', 202),
+    ('dutch', 202),
+    ('english', 202),
+    ('finnish', 202),
+    ('french', 202),
+    ('german', 202),
+    ('hungarian', 202),
+    ('italian', 202),
+    ('norwegian', 202),
+    ('portuguese', 202),
+    ('romanian', 202),
+    ('russian', 202),
+    ('spanish', 202),
+    ('swedish', 202),
+    ('turkish', 202),
+    ('any', 400),
+])
+@pytest.mark.bdb
+def test_post_create_transaction_with_language(b, client, language, expected_status_code):
+    from bigchaindb.models import Transaction
+    user_priv, user_pub = crypto.generate_key_pair()
+
+    tx = Transaction.create([user_pub], [([user_pub], 1)],
+                            asset={'language': language})
+    tx = tx.sign([user_priv])
+    res = client.post(TX_ENDPOINT, data=json.dumps(tx.to_dict()))
+    assert res.status_code == expected_status_code
+    if res.status_code == 400:
+        expected_error_message = (
+            "Invalid transaction schema: {{'language': '{}'}} "
+            "is not valid under any of the given schemas"
+        ).format(language)
+        assert res.json['message'] == expected_error_message
+
+
 @patch('bigchaindb.web.views.base.logger')
 def test_post_create_transaction_with_invalid_id(mock_logger, b, client):
     from bigchaindb.common.exceptions import InvalidHash


### PR DESCRIPTION
Fixes #1670 for BigchainDB v2.0 by changing the schema of the transaction model (i.e. by restricting the allowed values of `"language"` in assets).