### PR TITLE
Validate asset data keys

### DIFF
--- a/bigchaindb/common/utils.py
+++ b/bigchaindb/common/utils.py
@@ -52,6 +52,22 @@ def deserialize(data):
 
 
 def validate_txn_obj(obj_name, obj, key, validation_fun):
+    """Validates value associated to `key` in `obj` by applying
+       `validation_fun`.
+
+        Args:
+            obj_name (str): name for `obj` being validated.
+            obj (dict): dictonary object.
+            key (str): key to be validated in `obj`.
+            validation_fun (function): function used to validate the value
+            of `key`.
+
+        Returns:
+            None: indicates validation successfull
+
+        Raises:
+            ValidationError: `validation_fun` will raise this error on failure
+    """
     backend = bigchaindb.config['database']['backend']
 
     if backend == 'mongodb':
@@ -60,6 +76,20 @@ def validate_txn_obj(obj_name, obj, key, validation_fun):
 
 
 def validate_all_keys(obj_name, obj, validation_fun):
+    """Validates all (nested) keys in `obj` by using `validation_fun`
+
+        Args:
+            obj_name (str): name for `obj` being validated.
+            obj (dict): dictonary object.
+            validation_fun (function): function used to validate the value
+            of `key`.
+
+        Returns:
+            None: indicates validation successfull
+
+        Raises:
+            ValidationError: `validation_fun` will raise this error on failure
+    """
     for key, value in obj.items():
         validation_fun(obj_name, key)
         if type(value) is dict:
@@ -68,6 +98,19 @@ def validate_all_keys(obj_name, obj, validation_fun):
 
 
 def validate_key(obj_name, key):
+    """Check if `key` contains ".", "$" or null characters
+       https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
+
+        Args:
+            obj_name (str): object name to use when raising exception
+            key (str): key to validated
+
+        Returns:
+            None: indicates validation successfull
+
+        Raises:
+            ValidationError: raise execption incase of regex match.
+    """
     if re.search(r'^[$]|\.|\x00', key):
         error_str = ('Invalid key name "{}" in {} object. The '
                      'key name cannot contain characters '

--- a/bigchaindb/models.py
+++ b/bigchaindb/models.py
@@ -8,7 +8,8 @@ from bigchaindb.common.exceptions import (InvalidHash, InvalidSignature,
                                           SybilError,
                                           DuplicateTransaction)
 from bigchaindb.common.transaction import Transaction
-from bigchaindb.common.utils import gen_timestamp, serialize
+from bigchaindb.common.utils import (gen_timestamp, serialize,
+                                     validate_asset_data_keys)
 from bigchaindb.common.schema import validate_transaction_schema
 
 
@@ -84,6 +85,7 @@ class Transaction(Transaction):
     @classmethod
     def from_dict(cls, tx_body):
         validate_transaction_schema(tx_body)
+        validate_asset_data_keys(tx_body)
         return super().from_dict(tx_body)
 
     @classmethod

--- a/bigchaindb/models.py
+++ b/bigchaindb/models.py
@@ -9,7 +9,7 @@ from bigchaindb.common.exceptions import (InvalidHash, InvalidSignature,
                                           DuplicateTransaction)
 from bigchaindb.common.transaction import Transaction
 from bigchaindb.common.utils import (gen_timestamp, serialize,
-                                     validate_asset_data_keys)
+                                     validate_txn_obj, validate_key)
 from bigchaindb.common.schema import validate_transaction_schema
 
 
@@ -85,7 +85,8 @@ class Transaction(Transaction):
     @classmethod
     def from_dict(cls, tx_body):
         validate_transaction_schema(tx_body)
-        validate_asset_data_keys(tx_body)
+        validate_txn_obj('asset', tx_body['asset'], 'data', validate_key)
+        validate_txn_obj('metadata', tx_body, 'metadata', validate_key)
         return super().from_dict(tx_body)
 
     @classmethod

--- a/tests/web/test_transactions.py
+++ b/tests/web/test_transactions.py
@@ -47,22 +47,29 @@ def test_post_create_transaction_endpoint(b, client):
     assert res.json['outputs'][0]['public_keys'][0] == user_pub
 
 
-@pytest.mark.parametrize("key,expected_status_code", [
-    ('bad.key', 400),
-    ('$bad.key', 400),
-    ('$badkey', 400),
-    ('good_key', 202)
+@pytest.mark.parametrize("field", ['asset', 'metadata'])
+@pytest.mark.parametrize("value,err_key,expected_status_code", [
+    ({'bad.key': 'v'}, 'bad.key', 400),
+    ({'$bad.key': 'v'}, '$bad.key', 400),
+    ({'$badkey': 'v'}, '$badkey', 400),
+    ({'bad\x00key': 'v'}, 'bad\x00key', 400),
+    ({'good_key': {'bad.key': 'v'}}, 'bad.key', 400),
+    ({'good_key': 'v'}, 'good_key', 202)
 ])
-@pytest.mark.assetkey
 @pytest.mark.bdb
-def test_post_create_transaction_with_invalid_asset_key(b, client, key, expected_status_code):
+def test_post_create_transaction_with_invalid_key(b, client, field, value,
+                                                  err_key, expected_status_code):
     from bigchaindb.models import Transaction
     from bigchaindb.backend.mongodb.connection import MongoDBConnection
     user_priv, user_pub = crypto.generate_key_pair()
 
     if isinstance(b.connection, MongoDBConnection):
-        tx = Transaction.create([user_pub], [([user_pub], 1)],
-                                asset={key: 'random_value'})
+        if field == 'asset':
+            tx = Transaction.create([user_pub], [([user_pub], 1)],
+                                    asset=value)
+        elif field == 'metadata':
+            tx = Transaction.create([user_pub], [([user_pub], 1)],
+                                    metadata=value)
         tx = tx.sign([user_priv])
         res = client.post(TX_ENDPOINT, data=json.dumps(tx.to_dict()))
 
@@ -70,8 +77,8 @@ def test_post_create_transaction_with_invalid_asset_key(b, client, key, expected
         if res.status_code == 400:
             expected_error_message = (
                 'Invalid transaction (ValidationError): Invalid key name "{}" '
-                'in asset object. The key name cannot contain characters '
-                '"." and "$"').format(key)
+                'in {} object. The key name cannot contain characters '
+                '".", "$" or null characters').format(err_key, field)
             assert res.json['message'] == expected_error_message
 
 


### PR DESCRIPTION
This fix solve asset data `key` validation issues for the v1.x series.

It doesn't change the schema of the transaction model. It just makes an aspect of the schema explicit which until now has been implicit, i.e. if the backend database is MongoDB, then there are restrictions on key names.

Fixes #1702 