### PR TITLE
Handle WS CLOSE properly

### DIFF
--- a/bigchaindb/web/websocket_server.py
+++ b/bigchaindb/web/websocket_server.py
@@ -171,15 +171,3 @@ def start(sync_event_source, loop=None):
     aiohttp.web.run_app(app,
                         host=config['wsserver']['host'],
                         port=config['wsserver']['port'])
-
-
-if __name__ == '__main__':
-    def meow(queue):
-        while True:
-            yield from asyncio.sleep(1)
-            yield from queue.put('meow')
-    loop = asyncio.get_event_loop()
-    event_source = asyncio.Queue(loop=loop)
-    # loop.create_task(meow(event_source))
-    app = init_app(event_source, loop=loop)
-    aiohttp.web.run_app(app)


### PR DESCRIPTION
TL;DR: [Writing to an already closed websocket connection throws errors and increases endpoint's response time](https://github.com/bigchaindb/bigchaindb/issues/1787).

Fix #1787