### PR TITLE
Do not use xdist for RethinkDB tests

### DIFF
--- a/.ci/travis_script.sh
+++ b/.ci/travis_script.sh
@@ -13,5 +13,5 @@ elif [[ "${BIGCHAINDB_DATABASE_BACKEND}" == mongodb && \
     # Run a sub-set of tests over SSL; those marked as 'pytest.mark.bdb_ssl'.
   pytest -sv --database-backend=mongodb-ssl --cov=bigchaindb -m bdb_ssl
 else
-  pytest -sv -n auto --cov=bigchaindb
+  pytest -sv --cov=bigchaindb
 fi

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -28,13 +28,10 @@ def flush_db(connection, dbname):
 
 @flush_db.register(RethinkDBConnection)
 def flush_rethink_db(connection, dbname):
-    try:
-        connection.run(r.db(dbname).table('bigchain').delete())
-        connection.run(r.db(dbname).table('backlog').delete())
-        connection.run(r.db(dbname).table('votes').delete())
-        connection.run(r.db(dbname).table('assets').delete())
-    except r.ReqlOpFailedError:
-        pass
+    connection.run(r.db(dbname).table('bigchain').delete())
+    connection.run(r.db(dbname).table('backlog').delete())
+    connection.run(r.db(dbname).table('votes').delete())
+    connection.run(r.db(dbname).table('assets').delete())
 
 
 @flush_db.register(MongoDBConnection)


### PR DESCRIPTION
Tests should be independent, running them in parallel using `xdist` should not be a problem. @kansi found that changing the order of few tests under `tests/integration/test_integration.py` changes the outcome of the test suite, so my guess is that disabling `xdist` for now should make the test suite pass.

This is *not* a nice way to fix the issue.