### PR TITLE
Cloud9 static pdf was removed from the repo

### DIFF
--- a/docs/server/source/dev-and-test/setup-run-node.md
+++ b/docs/server/source/dev-and-test/setup-run-node.md
@@ -181,9 +181,3 @@ root:
 ```bash
 curl 0.0.0.0:32772
 ```
-
-## Option C: Using a Dev Machine on Cloud9
-
-Ian Worrall of [Encrypted Labs](http://www.encryptedlabs.com/) wrote a document (PDF) explaining how to set up a BigchainDB (Server) dev machine on Cloud9:
-
-[Download that document from GitHub](https://raw.githubusercontent.com/bigchaindb/bigchaindb/master/docs/server/source/_static/cloud9.pdf)


### PR DESCRIPTION
https://github.com/bigchaindb/bigchaindb/tree/master/docs/server/source/_static