### PR TITLE
Updated Docker image version to 1.2.0 in k8s YAML files

### DIFF
--- a/k8s/bigchaindb/bigchaindb-dep.yaml
+++ b/k8s/bigchaindb/bigchaindb-dep.yaml
@@ -12,7 +12,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: bigchaindb
-        image: bigchaindb/bigchaindb:1.1.0
+        image: bigchaindb/bigchaindb:1.2.0
         imagePullPolicy: IfNotPresent
         args:
         - start

--- a/k8s/dev-setup/bigchaindb.yaml
+++ b/k8s/dev-setup/bigchaindb.yaml
@@ -34,7 +34,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: bigchaindb
-        image: bigchaindb/bigchaindb:1.1.0
+        image: bigchaindb/bigchaindb:1.2.0
         imagePullPolicy: Always
         args:
         - start


### PR DESCRIPTION
This is step 2 in the [release process](https://github.com/bigchaindb/bigchaindb/blob/master/RELEASE_PROCESS.md) for the version 1.2 release of BigchainDB Server.