### PR TITLE
Fix getstarted undefined referrer issue with IPDB

### DIFF
--- a/k8s/nginx-https-web-proxy/container/docker_build_and_push.bash
+++ b/k8s/nginx-https-web-proxy/container/docker_build_and_push.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-docker build -t bigchaindb/nginx-https-web-proxy:0.10 .
+docker build -t bigchaindb/nginx-https-web-proxy:0.12 .
 
-docker push bigchaindb/nginx-https-web-proxy:0.10
+docker push bigchaindb/nginx-https-web-proxy:0.12

--- a/k8s/nginx-https-web-proxy/container/nginx.conf.template
+++ b/k8s/nginx-https-web-proxy/container/nginx.conf.template
@@ -90,12 +90,6 @@ http {
         end
       }
 
-      # check if the request originated from the required web page
-      # use referer header.
-      if ($http_referer !~ "PROXY_EXPECTED_REFERER_HEADER" ) {
-        return 403 'Unknown referer';
-      }
-
       # check if the request has the expected origin header
       if ($http_origin !~ "PROXY_EXPECTED_ORIGIN_HEADER" ) {
         return 403 'Unknown origin';
@@ -108,7 +102,14 @@ http {
         add_header 'Access-Control-Max-Age' 43200;
         add_header 'Content-Type' 'text/plain charset=UTF-8';
         add_header 'Content-Length' 0;
+        add_header 'Referrer-Policy' "PROXY_REFERRER_POLICY";
         return 204;
+      }
+
+      # check if the request originated from the required web page
+      # use referer header.
+      if ($http_referer !~ "PROXY_EXPECTED_REFERER_HEADER" ) {
+        return 403 'Unknown referer';
       }
 
       # No auth for GETs, forward directly to BDB.

--- a/k8s/nginx-https-web-proxy/nginx-https-web-proxy-conf.yaml
+++ b/k8s/nginx-https-web-proxy/nginx-https-web-proxy-conf.yaml
@@ -49,6 +49,11 @@ data:
   # are available to external clients.
   proxy-frontend-port: "4443"
 
+  # proxy-referrer-policy defines the expected behaviour from
+  # browser while setting the referer header in  the HTTP requests to the
+  # proxy service.
+  proxy-referrer-policy: "origin-when-cross-origin"
+
   # expected-http-referer is the expected regex expression of the Referer
   # header in the HTTP requests to the proxy.
   # The default below accepts the referrer value to be *.bigchaindb.com

--- a/k8s/nginx-https-web-proxy/nginx-https-web-proxy-dep.yaml
+++ b/k8s/nginx-https-web-proxy/nginx-https-web-proxy-dep.yaml
@@ -25,6 +25,11 @@ spec:
             configMapKeyRef:
               name: proxy-vars
               key: proxy-frontend-port
+        - name: PROXY_REFERRER_POLICY
+          valueFrom:
+            configMapKeyRef:
+              name: proxy-vars
+              key: proxy-referrer-policy
         - name: PROXY_EXPECTED_REFERER_HEADER
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
Fixes #1815 

## Description
Newer browsers stopped setting `Referer` with the introduction of [this](https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-header) Spec. This essentially breaks the https://www.bigchaindb.com/getstarted/ page since we expect the `Referer` header to be set to bigchaindb.com

## Solution
Skip `Referer` check on preflight request (OPTIONS) and set `Referrer-Policy` to `origin-when-cross-origin` in response to OPTIONS request. Once `Referrer-Policy` is set on the subsequent POST request referrer is set by the browser to expected value. 

## Deployment Notes
Updated the nginx-proxy deployment templates and nginx config template updated nginx-proxy docker image to version 0.12

## How to QA
Create a new PR and the template should be visible

## Impacted Areas in Application
- Security impact: None