### PR TITLE
pre-commit proposal 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+-   repo: git://github.com/pre-commit/pre-commit-hooks
+    sha: v1.1.1
+    hooks:
+    -   id: trailing-whitespace
+        args: ['--no-markdown-linebreak-ext']
+    -   id: check-merge-conflict
+    -   id: debug-statements
+    -   id: check-added-large-files
+    -   id: flake8
+
+-   repo: git://github.com/chewse/pre-commit-mirrors-pydocstyle
+    sha: v2.1.1
+    hooks:
+    -   id: pydocstyle
+        args: ['--select=D204,D201,D209,D210,D212,D300,D403']
+
+exclude: '^(?!bigchaindb/)(?!tests/)'

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ dev_require = [
     'ipython',
     'watchdog',
     'logging_tree',
+    'pre-commit'
 ]
 
 docs_require = [


### PR DESCRIPTION
We already style our code with flake8 but it's not locally enforced.
That's why I want to propose [pre-commit](http://pre-commit.com/)
If people have pre-commit installed it runs with every `git commit` through the given checks.

With pre-commit specific guidelines and style guides can easily be maintained.
An overview of possible hooks you can use [here](http://pre-commit.com/hooks.html)
Note that there are hooks for many different languages!
if that's not enough it's also easy to write new hooks yourself (I did it once)

Every hook I used is a proposal itself and there are many more we can use.

The [pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks) offer multiple hooks to set, for example, a flake8, json and yml check, trim whitespaces, etc.
I added the following for now:
- trailing whitespaces
- check-merge-conflict (checks for merge conflicts in files)
- debug-statements (checks for debug statements in files)

The [pre-commit-python-sorter](https://github.com/FalconSocial/pre-commit-python-sorter) is a nice hook to sort your imports
I currently set it to `--silent-overwrite` which is convenient since the user does not need to change everything manually

 The [pre-commit-hooks-safety](https://github.com/Lucas-C/pre-commit-hooks-safety/tree/v1.1.0) checks python dependencies. Currently, it only looks for requirement files.

The [pre-commit-mirrors-pydocstyle](https://github.com/chewse/pre-commit-mirrors-pydocstyle). I think with a proper configuration and selection of [error codes](http://www.pydocstyle.org/en/2.1.1/error_codes.html) this can be a good feature. In my settings, I check only for the error code 'D300' which checks if triple double quotes are used. 

The [mirrors-yapf](https://github.com/pre-commit/mirrors-yapf) is a hook for [YAPF](https://github.com/google/yapf), a python formatter with a lot of settings. 
The above pre-commit-hooks offer flake8 but you need to take care of all the errors. Yapf instead just changes the code according to the settings. Some details might not be as nicely formatted as you would do it but at least no one has to take care of it.

If you want to test it and see the changes made or errors thrown by the hooks just get the code, install pre-commit via pip and run `pre-commit run -a` (this might take some time).

[info: the pre-commit accidentally ran on setup.py I'll fix this later]





