### PR TITLE
Scripts to bootstrap devstack setup for bigchaindb with tendermint

### DIFF
--- a/pkg/scripts/Vagrantfile
+++ b/pkg/scripts/Vagrantfile
@@ -16,7 +16,8 @@ MOUNT_DIRS = {
   :bigchaindb => {:repo => "bigchaindb", :local => "/opt/stack/bigchaindb", :owner => "edxapp"},
 }
 
-boxname = ENV['BOXNAME']
+boxname = ENV['BOXNAME'] || "ubuntu/xenial64"
+tm_version = ENV['TM_VERSION']
 
 $script = <<SCRIPT
 if [ ! -d /opt/stack/bigchaindb/pkg/scripts ]; then
@@ -29,7 +30,7 @@ bash /opt/stack/bigchaindb/pkg/scripts/stack.sh
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box     = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/xenial64"
   config.vm.box_check_update = false
 
   config.vm.network :private_network, ip: "192.168.33.10"
@@ -51,5 +52,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vbguest.auto_reboot = true
   config.vbguest.auto_update = true
 
-  config.vm.provision "shell", inline: $script, privileged: false
+  config.vm.provision "shell", inline: $script,
+    privileged: false,
+    env: {
+      :TM_VERSION => ENV['TM_VERSION'], 
+      :MONGO_VERSION => ENV['MONGO_VERSION']
+    }
 end

--- a/pkg/scripts/Vagrantfile
+++ b/pkg/scripts/Vagrantfile
@@ -36,7 +36,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.ssh.insert_key = true
 
-  config.vm.synced_folder  ".", "/vagrant", disabled: true
+  config.vm.synced_folder  "bigchaindb", "/opt/stack/bigchaindb"
 
 
   config.vm.provider :virtualbox do |vb|

--- a/pkg/scripts/Vagrantfile
+++ b/pkg/scripts/Vagrantfile
@@ -12,8 +12,7 @@ MOUNT_DIRS = {
   :bigchaindb => {:repo => "bigchaindb", :local => "/opt/stack/bigchaindb", :owner => "edxapp"},
 }
 
-openedx_release = ENV['OPENEDX_RELEASE']
-boxname = ENV['OPENEDX_BOXNAME']
+boxname = ENV['BOXNAME']
 
 $script = <<SCRIPT
 if [ ! -d /opt/stack/bigchaindb/pkg/scripts ]; then

--- a/pkg/scripts/Vagrantfile
+++ b/pkg/scripts/Vagrantfile
@@ -16,7 +16,7 @@ openedx_release = ENV['OPENEDX_RELEASE']
 boxname = ENV['OPENEDX_BOXNAME']
 
 $script = <<SCRIPT
-if [ ! -d /opt/stack/bigchaindb/pkg/scrips ]; then
+if [ ! -d /opt/stack/bigchaindb/pkg/scripts ]; then
     echo "Error: Base box is missing provisioning scripts." 1>&2
     exit 1
 fi

--- a/pkg/scripts/Vagrantfile
+++ b/pkg/scripts/Vagrantfile
@@ -20,7 +20,7 @@ if [ ! -d /opt/stack/bigchaindb/pkg/scripts ]; then
     exit 1
 fi
 
-bash /opt/stack/bigchaindb/bigchaindb/pkg/scrips/stack.sh
+bash /opt/stack/bigchaindb/pkg/scripts/stack.sh
 
 SCRIPT
 

--- a/pkg/scripts/Vagrantfile
+++ b/pkg/scripts/Vagrantfile
@@ -51,5 +51,5 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vbguest.auto_reboot = true
   config.vbguest.auto_update = true
 
-  config.vm.provision "shell", inline: $script
+  config.vm.provision "shell", inline: $script, privileged: false
 end

--- a/pkg/scripts/Vagrantfile
+++ b/pkg/scripts/Vagrantfile
@@ -1,0 +1,52 @@
+Vagrant.require_version ">= 1.8.7"
+unless Vagrant.has_plugin?("vagrant-vbguest")
+  raise "Please install the vagrant-vbguest plugin by running `vagrant plugin install vagrant-vbguest`"
+end
+
+VAGRANTFILE_API_VERSION = "2"
+
+MEMORY = 4096
+CPU_COUNT = 2
+
+MOUNT_DIRS = {
+  :bigchaindb => {:repo => "bigchaindb", :local => "/opt/stack/bigchaindb", :owner => "edxapp"},
+}
+
+openedx_release = ENV['OPENEDX_RELEASE']
+boxname = ENV['OPENEDX_BOXNAME']
+
+$script = <<SCRIPT
+if [ ! -d /opt/stack/bigchaindb/bigchaindb/scrips ]; then
+    echo "Error: Base box is missing provisioning scripts." 1>&2
+    exit 1
+fi
+
+bash /opt/stack/bigchaindb/bigchaindb/pkg/scrips/stack.sh
+
+SCRIPT
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box     = "ubuntu/xenial64"
+  config.vm.box_check_update = false
+
+  config.vm.network :private_network, ip: "192.168.33.10"
+
+
+  config.vm.network :forwarded_port, guest: 9984, host: 9984  # BDB
+
+  config.ssh.insert_key = true
+
+  config.vm.synced_folder  ".", "/vagrant", disabled: true
+
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", MEMORY.to_s]
+    vb.customize ["modifyvm", :id, "--cpus", CPU_COUNT.to_s]
+  end
+
+  # Use vagrant-vbguest plugin to make sure Guest Additions are in sync
+  config.vbguest.auto_reboot = true
+  config.vbguest.auto_update = true
+
+  config.vm.provision "shell", inline: $script
+end

--- a/pkg/scripts/Vagrantfile
+++ b/pkg/scripts/Vagrantfile
@@ -3,6 +3,10 @@ unless Vagrant.has_plugin?("vagrant-vbguest")
   raise "Please install the vagrant-vbguest plugin by running `vagrant plugin install vagrant-vbguest`"
 end
 
+unless Vagrant.has_plugin?("vagrant-cachier")
+  raise "Please install the vagrant-cachier plugin by running `vagrant plugin install vagrant-cachier`"
+end
+
 VAGRANTFILE_API_VERSION = "2"
 
 MEMORY = 4096

--- a/pkg/scripts/Vagrantfile
+++ b/pkg/scripts/Vagrantfile
@@ -16,7 +16,7 @@ openedx_release = ENV['OPENEDX_RELEASE']
 boxname = ENV['OPENEDX_BOXNAME']
 
 $script = <<SCRIPT
-if [ ! -d /opt/stack/bigchaindb/bigchaindb/scrips ]; then
+if [ ! -d /opt/stack/bigchaindb/pkg/scrips ]; then
     echo "Error: Base box is missing provisioning scripts." 1>&2
     exit 1
 fi

--- a/pkg/scripts/functions-common
+++ b/pkg/scripts/functions-common
@@ -1,0 +1,409 @@
+#!/bin/bash
+
+# Save trace setting
+_XTRACE_FUNCTIONS_COMMON=$(set +o | grep xtrace)
+set +o xtrace
+
+# Distro Functions
+# ================
+
+# Determine OS Vendor, Release and Update
+
+#
+# NOTE : For portability, you almost certainly do not want to use
+# these variables directly!  The "is_*" functions defined below this
+# bundle up compatible platforms under larger umbrellas that we have
+# determinted are compatible enough (e.g. is_ubuntu covers Ubuntu &
+# Debian, is_fedora covers RPM-based distros).  Higher-level functions
+# such as "install_package" further abstract things in better ways.
+#
+# ``os_VENDOR`` - vendor name: ``Ubuntu``, ``Fedora``, etc
+# ``os_RELEASE`` - major release: ``16.04`` (Ubuntu), ``23`` (Fedora)
+# ``os_PACKAGE`` - package type: ``deb`` or ``rpm``
+# ``os_CODENAME`` - vendor's codename for release: ``xenial``
+
+declare -g os_VENDOR os_RELEASE os_PACKAGE os_CODENAME
+
+# Make a *best effort* attempt to install lsb_release packages for the
+# user if not available.  Note can't use generic install_package*
+# because they depend on this!
+function _ensure_lsb_release {
+    if [[ -x $(command -v lsb_release 2>/dev/null) ]]; then
+        return
+    fi
+
+    if [[ -x $(command -v apt-get 2>/dev/null) ]]; then
+        sudo apt-get install -y lsb-release
+    elif [[ -x $(command -v zypper 2>/dev/null) ]]; then
+        sudo zypper -n install lsb-release
+    elif [[ -x $(command -v dnf 2>/dev/null) ]]; then
+        sudo dnf install -y redhat-lsb-core
+    elif [[ -x $(command -v yum 2>/dev/null) ]]; then
+        # all rh patforms (fedora, centos, rhel) have this pkg
+        sudo yum install -y redhat-lsb-core
+    else
+        die $LINENO "Unable to find or auto-install lsb_release"
+    fi
+}
+
+# GetOSVersion
+#  Set the following variables:
+#  - os_RELEASE
+#  - os_CODENAME
+#  - os_VENDOR
+#  - os_PACKAGE
+function GetOSVersion {
+    # We only support distros that provide a sane lsb_release
+    _ensure_lsb_release
+
+    os_RELEASE=$(lsb_release -r -s)
+    os_CODENAME=$(lsb_release -c -s)
+    os_VENDOR=$(lsb_release -i -s)
+
+    if [[ $os_VENDOR =~ (Debian|Ubuntu|LinuxMint) ]]; then
+        os_PACKAGE="deb"
+    else
+        os_PACKAGE="rpm"
+    fi
+
+    typeset -xr os_VENDOR
+    typeset -xr os_RELEASE
+    typeset -xr os_PACKAGE
+    typeset -xr os_CODENAME
+}
+
+# Translate the OS version values into common nomenclature
+# Sets global ``DISTRO`` from the ``os_*`` values
+declare -g DISTRO
+
+function GetDistro {
+    GetOSVersion
+    if [[ "$os_VENDOR" =~ (Ubuntu) || "$os_VENDOR" =~ (Debian) || \
+            "$os_VENDOR" =~ (LinuxMint) ]]; then
+        # 'Everyone' refers to Ubuntu / Debian / Mint releases by
+        # the code name adjective
+        DISTRO=$os_CODENAME
+    elif [[ "$os_VENDOR" =~ (Fedora) ]]; then
+        # For Fedora, just use 'f' and the release
+        DISTRO="f$os_RELEASE"
+    elif [[ "$os_VENDOR" =~ (openSUSE) ]]; then
+        DISTRO="opensuse-$os_RELEASE"
+    elif [[ "$os_VENDOR" =~ (SUSE LINUX) ]]; then
+        # just use major release
+        DISTRO="sle${os_RELEASE%.*}"
+    elif [[ "$os_VENDOR" =~ (Red.*Hat) || \
+        "$os_VENDOR" =~ (CentOS) || \
+        "$os_VENDOR" =~ (Scientific) || \
+        "$os_VENDOR" =~ (OracleServer) || \
+        "$os_VENDOR" =~ (Virtuozzo) ]]; then
+        # Drop the . release as we assume it's compatible
+        # XXX re-evaluate when we get RHEL10
+        DISTRO="rhel${os_RELEASE::1}"
+    elif [[ "$os_VENDOR" =~ (XenServer) ]]; then
+        DISTRO="xs${os_RELEASE%.*}"
+    elif [[ "$os_VENDOR" =~ (kvmibm) ]]; then
+        DISTRO="${os_VENDOR}${os_RELEASE::1}"
+    else
+        # We can't make a good choice here.  Setting a sensible DISTRO
+        # is part of the problem, but not the major issue -- we really
+        # only use DISTRO in the code as a fine-filter.
+        #
+        # The bigger problem is categorising the system into one of
+        # our two big categories as Ubuntu/Debian-ish or
+        # Fedora/CentOS-ish.
+        #
+        # The setting of os_PACKAGE above is only set to "deb" based
+        # on a hard-coded list of vendor names ... thus we will
+        # default to thinking unknown distros are RPM based
+        # (ie. is_ubuntu does not match).  But the platform will then
+        # also not match in is_fedora, because that also has a list of
+        # names.
+        #
+        # So, if you are reading this, getting your distro supported
+        # is really about making sure it matches correctly in these
+        # functions.  Then you can choose a sensible way to construct
+        # DISTRO based on your distros release approach.
+        die $LINENO "Unable to determine DISTRO, can not continue."
+    fi
+    typeset -xr DISTRO
+}
+
+# Utility function for checking machine architecture
+# is_arch arch-type
+function is_arch {
+    [[ "$(uname -m)" == "$1" ]]
+}
+
+# Determine if current distribution is an Oracle distribution
+# is_oraclelinux
+function is_oraclelinux {
+    if [[ -z "$os_VENDOR" ]]; then
+        GetOSVersion
+    fi
+
+    [ "$os_VENDOR" = "OracleServer" ]
+}
+
+
+# Determine if current distribution is a Fedora-based distribution
+# (Fedora, RHEL, CentOS, etc).
+# is_fedora
+function is_fedora {
+    if [[ -z "$os_VENDOR" ]]; then
+        GetOSVersion
+    fi
+
+    [ "$os_VENDOR" = "Fedora" ] || [ "$os_VENDOR" = "Red Hat" ] || \
+        [ "$os_VENDOR" = "RedHatEnterpriseServer" ] || \
+        [ "$os_VENDOR" = "CentOS" ] || [ "$os_VENDOR" = "OracleServer" ] || \
+        [ "$os_VENDOR" = "Virtuozzo" ] || [ "$os_VENDOR" = "kvmibm" ]
+}
+
+
+# Determine if current distribution is a SUSE-based distribution
+# (openSUSE, SLE).
+# is_suse
+function is_suse {
+    if [[ -z "$os_VENDOR" ]]; then
+        GetOSVersion
+    fi
+
+    [[ "$os_VENDOR" =~ (openSUSE) || "$os_VENDOR" == "SUSE LINUX" ]]
+}
+
+
+# Determine if current distribution is an Ubuntu-based distribution
+# It will also detect non-Ubuntu but Debian-based distros
+# is_ubuntu
+function is_ubuntu {
+    if [[ -z "$os_PACKAGE" ]]; then
+        GetOSVersion
+    fi
+    [ "$os_PACKAGE" = "deb" ]
+}
+
+# Package Functions
+# =================
+
+# _get_package_dir
+function _get_package_dir {
+    local base_dir=$1
+    local pkg_dir
+
+    if [[ -z "$base_dir" ]]; then
+        base_dir=$FILES
+    fi
+    if is_ubuntu; then
+        pkg_dir=$base_dir/debs
+    elif is_fedora; then
+        pkg_dir=$base_dir/rpms
+    elif is_suse; then
+        pkg_dir=$base_dir/rpms-suse
+    else
+        exit_distro_not_supported "list of packages"
+    fi
+    echo "$pkg_dir"
+}
+
+# Wrapper for ``apt-get update`` to try multiple times on the update
+# to address bad package mirrors (which happen all the time).
+function apt_get_update {
+    # only do this once per run
+    if [[ "$REPOS_UPDATED" == "True" && "$RETRY_UPDATE" != "True" ]]; then
+        return
+    fi
+
+    # bail if we are offline
+    [[ "$OFFLINE" = "True" ]] && return
+
+    local sudo="sudo"
+    [[ "$(id -u)" = "0" ]] && sudo="env"
+
+    # time all the apt operations
+    time_start "apt-get-update"
+
+    local proxies="http_proxy=${http_proxy:-} https_proxy=${https_proxy:-} no_proxy=${no_proxy:-} "
+    local update_cmd="$sudo $proxies apt-get update"
+    if ! timeout 300 sh -c "while ! $update_cmd; do sleep 30; done"; then
+        die $LINENO "Failed to update apt repos, we're dead now"
+    fi
+
+    REPOS_UPDATED=True
+    # stop the clock
+    time_stop "apt-get-update"
+}
+
+# Wrapper for ``apt-get`` to set cache and proxy environment variables
+# Uses globals ``OFFLINE``, ``*_proxy``
+# apt_get operation package [package ...]
+function apt_get {
+    local xtrace result
+    xtrace=$(set +o | grep xtrace)
+    set +o xtrace
+
+    [[ "$OFFLINE" = "True" || -z "$@" ]] && return
+    local sudo="sudo"
+    [[ "$(id -u)" = "0" ]] && sudo="env"
+
+    # time all the apt operations
+    time_start "apt-get"
+
+    $xtrace
+
+    $sudo DEBIAN_FRONTEND=noninteractive \
+        http_proxy=${http_proxy:-} https_proxy=${https_proxy:-} \
+        no_proxy=${no_proxy:-} \
+        apt-get --option "Dpkg::Options::=--force-confold" --assume-yes "$@" < /dev/null
+    result=$?
+
+    # stop the clock
+    time_stop "apt-get"
+    return $result
+}
+
+
+# Distro-agnostic package installer
+# Uses globals ``NO_UPDATE_REPOS``, ``REPOS_UPDATED``, ``RETRY_UPDATE``
+# install_package package [package ...]
+function update_package_repo {
+    NO_UPDATE_REPOS=${NO_UPDATE_REPOS:-False}
+    REPOS_UPDATED=${REPOS_UPDATED:-False}
+    RETRY_UPDATE=${RETRY_UPDATE:-False}
+
+    if [[ "$NO_UPDATE_REPOS" = "True" ]]; then
+        return 0
+    fi
+
+    if is_ubuntu; then
+        apt_get_update
+    fi
+}
+
+function real_install_package {
+    if is_ubuntu; then
+        apt_get install "$@"
+    elif is_fedora; then
+        yum_install "$@"
+    elif is_suse; then
+        zypper_install "$@"
+    else
+        exit_distro_not_supported "installing packages"
+    fi
+}
+
+# Distro-agnostic package installer
+# install_package package [package ...]
+function install_package {
+    update_package_repo
+    if ! real_install_package "$@"; then
+        RETRY_UPDATE=True update_package_repo && real_install_package "$@"
+    fi
+}
+
+# Distro-agnostic function to tell if a package is installed
+# is_package_installed package [package ...]
+function is_package_installed {
+    if [[ -z "$@" ]]; then
+        return 1
+    fi
+
+    if [[ -z "$os_PACKAGE" ]]; then
+        GetOSVersion
+    fi
+
+    if [[ "$os_PACKAGE" = "deb" ]]; then
+        dpkg -s "$@" > /dev/null 2> /dev/null
+    elif [[ "$os_PACKAGE" = "rpm" ]]; then
+        rpm --quiet -q "$@"
+    else
+        exit_distro_not_supported "finding if a package is installed"
+    fi
+}
+
+# Distro-agnostic package uninstaller
+# uninstall_package package [package ...]
+function uninstall_package {
+    if is_ubuntu; then
+        apt_get purge "$@"
+    elif is_fedora; then
+        sudo ${YUM:-yum} remove -y "$@" ||:
+    elif is_suse; then
+        sudo zypper remove -y "$@" ||:
+    else
+        exit_distro_not_supported "uninstalling packages"
+    fi
+}
+
+# Wrapper for ``yum`` to set proxy environment variables
+# Uses globals ``OFFLINE``, ``*_proxy``, ``YUM``
+# yum_install package [package ...]
+function yum_install {
+    local result parse_yum_result
+
+    [[ "$OFFLINE" = "True" ]] && return
+
+    time_start "yum_install"
+
+    # This is a bit tricky, because yum -y assumes missing or failed
+    # packages are OK (see [1]).  We want devstack to stop if we are
+    # installing missing packages.
+    #
+    # Thus we manually match on the output (stack.sh runs in a fixed
+    # locale, so lang shouldn't change).
+    #
+    # If yum returns !0, we echo the result as "YUM_FAILED" and return
+    # that from the awk (we're subverting -e with this trick).
+    # Otherwise we use awk to look for failure strings and return "2"
+    # to indicate a terminal failure.
+    #
+    # [1] https://bugzilla.redhat.com/show_bug.cgi?id=965567
+    parse_yum_result='              \
+        BEGIN { result=0 }          \
+        /^YUM_FAILED/ { result=$2 } \
+        /^No package/ { result=2 }  \
+        /^Failed:/    { result=2 }  \
+        //{ print }                 \
+        END { exit result }'
+    (sudo_with_proxies "${YUM:-yum}" install -y "$@" 2>&1 || echo YUM_FAILED $?) \
+        | awk "$parse_yum_result" && result=$? || result=$?
+
+    time_stop "yum_install"
+
+    # if we return 1, then the wrapper functions will run an update
+    # and try installing the package again as a defense against bad
+    # mirrors.  This can hide failures, especially when we have
+    # packages that are in the "Failed:" section because their rpm
+    # install scripts failed to run correctly (in this case, the
+    # package looks installed, so when the retry happens we just think
+    # the package is OK, and incorrectly continue on).
+    if [ "$result" == 2 ]; then
+        die "Detected fatal package install failure"
+    fi
+
+    return "$result"
+}
+
+# zypper wrapper to set arguments correctly
+# Uses globals ``OFFLINE``, ``*_proxy``
+# zypper_install package [package ...]
+function zypper_install {
+    [[ "$OFFLINE" = "True" ]] && return
+    local sudo="sudo"
+    [[ "$(id -u)" = "0" ]] && sudo="env"
+    $sudo http_proxy="${http_proxy:-}" https_proxy="${https_proxy:-}" \
+        no_proxy="${no_proxy:-}" \
+        zypper --non-interactive install --auto-agree-with-licenses "$@"
+}
+
+# Find out if a process exists by partial name.
+# is_running name
+function is_running {
+    local name=$1
+    ps auxw | grep -v grep | grep ${name} > /dev/null
+    local exitcode=$?
+    # some times I really hate bash reverse binary logic
+    return $exitcode
+}
+
+# Restore xtrace
+$_XTRACE_FUNCTIONS_COMMON

--- a/pkg/scripts/functions-common
+++ b/pkg/scripts/functions-common
@@ -373,7 +373,7 @@ function zypper_install {
 
 function install_tendermint_bin {
     wget https://s3-us-west-2.amazonaws.com/tendermint/binaries/tendermint/v${TM_VERSION}/tendermint_${TM_VERSION}_linux_amd64.zip
-    unzip tendermint_0.12.0_linux_amd64.zip
+    unzip tendermint_${TM_VERSION}_linux_amd64.zip
     sudo mv tendermint /usr/local/bin
 }
 

--- a/pkg/scripts/functions-common
+++ b/pkg/scripts/functions-common
@@ -185,26 +185,6 @@ function is_ubuntu {
 # Package Functions
 # =================
 
-# _get_package_dir
-function _get_package_dir {
-    local base_dir=$1
-    local pkg_dir
-
-    if [[ -z "$base_dir" ]]; then
-        base_dir=$FILES
-    fi
-    if is_ubuntu; then
-        pkg_dir=$base_dir/debs
-    elif is_fedora; then
-        pkg_dir=$base_dir/rpms
-    elif is_suse; then
-        pkg_dir=$base_dir/rpms-suse
-    else
-        exit_distro_not_supported "list of packages"
-    fi
-    echo "$pkg_dir"
-}
-
 # Wrapper for ``apt-get update`` to try multiple times on the update
 # to address bad package mirrors (which happen all the time).
 function apt_get_update {
@@ -339,9 +319,6 @@ function uninstall_package {
 # yum_install package [package ...]
 function yum_install {
     local result parse_yum_result
-
-    [[ "$OFFLINE" = "True" ]] && return
-
     time_start "yum_install"
 
     # This is a bit tricky, because yum -y assumes missing or failed
@@ -387,12 +364,17 @@ function yum_install {
 # Uses globals ``OFFLINE``, ``*_proxy``
 # zypper_install package [package ...]
 function zypper_install {
-    [[ "$OFFLINE" = "True" ]] && return
     local sudo="sudo"
     [[ "$(id -u)" = "0" ]] && sudo="env"
     $sudo http_proxy="${http_proxy:-}" https_proxy="${https_proxy:-}" \
         no_proxy="${no_proxy:-}" \
         zypper --non-interactive install --auto-agree-with-licenses "$@"
+}
+
+function install_tendermint_bin {
+    wget https://s3-us-west-2.amazonaws.com/tendermint/binaries/tendermint/v${TM_VERSION}/tendermint_${TM_VERSION}_linux_amd64.zip
+    unzip tendermint_0.12.0_linux_amd64.zip
+    sudo mv tendermint /usr/local/bin
 }
 
 # Find out if a process exists by partial name.
@@ -401,7 +383,6 @@ function is_running {
     local name=$1
     ps auxw | grep -v grep | grep ${name} > /dev/null
     local exitcode=$?
-    # some times I really hate bash reverse binary logic
     return $exitcode
 }
 

--- a/pkg/scripts/install_stack.sh
+++ b/pkg/scripts/install_stack.sh
@@ -59,13 +59,6 @@ if [[ ! $git_branch ]]; then
     exit 1
 fi
 
-# If there are positional arguments left, something is wrong.
-if [[ $1 ]]; then
-    echo "Don't understand extra arguments: $*"
-    usage
-    exit 1
-fi
-
 mkdir -p logs
 log_file=logs/install-$(date +%Y%m%d-%H%M%S).log
 exec > >(tee $log_file) 2>&1
@@ -80,12 +73,7 @@ trap finish EXIT
 export GIT_BRANCH=$git_branch
 echo "Using bigchaindb branch '$GIT_BRANCH'"
 
-if [[ -d .vagrant ]]; then
-    echo -e "A .vagrant directory already exists here. If you already tried installing devstack, make sure to vagrant destroy the devstack machine and 'rm -rf .vagrant' before trying to reinstall. If you would like to install a separate devstack, change to a different directory and try running the script again."
-    exit 1
-fi
-
-git clone https://github.com/bigchaindb/bigchaindb.git -b $GIT_BRANCH
+git clone https://github.com/bigchaindb/bigchaindb.git -b $GIT_BRANCH || true
 curl -fOL# https://raw.githubusercontent.com/bigchaindb/bigchaindb/${GIT_BRANCH}/pkg/scripts/Vagrantfile
 vagrant up --provider virtualbox
 

--- a/pkg/scripts/install_stack.sh
+++ b/pkg/scripts/install_stack.sh
@@ -122,14 +122,13 @@ fi
 git clone https://github.com/bigchaindb/bigchaindb.git -b $BRANCH
 
 if [[ $stack == "devstack" ]]; then # Install devstack
-    curl -fOL# https://raw.githubusercontent.com/bigchaindb/bigchaindb/4137ca626d094152889cba43196a0ed2d2a96cd0/pkg/scripts/Vagrantfile
-elif [[ $stack == "fullstack" ]]; then # Install fullstack
+    curl -fOL# https://raw.githubusercontent.com/bigchaindb/bigchaindb/${BRANCH}/pkg/scripts/Vagrantfile
+    vagrant up --provider virtualbox
+elif [[ $stack == "network" ]]; then # Install fullstack
     exit
 else # Throw error
     echo -e "${ERROR}Unrecognized stack name, must be either devstack or network${NC}"
     exit 1
 fi
-
-vagrant up --provider virtualbox
 
 echo -e "${SUCCESS}Finished installing! You may now log in using 'vagrant ssh'"

--- a/pkg/scripts/install_stack.sh
+++ b/pkg/scripts/install_stack.sh
@@ -40,12 +40,6 @@ function usage
 EOM
 }
 
-
-ERROR='\033[0;31m' # Red
-WARN='\033[1;33m' # Yellow
-SUCCESS='\033[0;32m' # Green
-NC='\033[0m' # No Color
-
 # GIT_BRANCH
 git_branch=""
 
@@ -106,7 +100,7 @@ export GIT_BRANCH=$git_branch
 echo "Using bigchaindb branch '$GIT_BRANCH'"
 
 if [[ -d .vagrant ]]; then
-    echo -e "${ERROR}A .vagrant directory already exists here. If you already tried installing $stack, make sure to vagrant destroy the $stack machine and 'rm -rf .vagrant' before trying to reinstall. If you would like to install a separate $stack, change to a different directory and try running the script again.${NC}"
+    echo -e "A .vagrant directory already exists here. If you already tried installing $stack, make sure to vagrant destroy the $stack machine and 'rm -rf .vagrant' before trying to reinstall. If you would like to install a separate $stack, change to a different directory and try running the script again."
     exit 1
 fi
 
@@ -116,11 +110,11 @@ if [[ $stack == "devstack" ]]; then # Install devstack
     curl -fOL# https://raw.githubusercontent.com/bigchaindb/bigchaindb/${GIT_BRANCH}/pkg/scripts/Vagrantfile
     vagrant up --provider virtualbox
 elif [[ $stack == "network" ]]; then # Install network
-    echo -e "${WARN}Network support is not yet available"
+    echo -e "Network support is not yet available"
     exit
 else # Throw error
-    echo -e "${ERROR}Unrecognized stack name, must be either devstack or network${NC}"
+    echo -e "Unrecognized stack name, must be either devstack or network"
     exit 1
 fi
 
-echo -e "${SUCCESS}Finished installing! You may now log in using 'vagrant ssh'"
+echo -e "Finished installing! You may now log in using 'vagrant ssh'"

--- a/pkg/scripts/install_stack.sh
+++ b/pkg/scripts/install_stack.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+
+set -x
+set -o xtrace
+
+# Check for uninitialized variables, a big cause of bugs
+NOUNSET=${NOUNSET:-}
+if [[ -n "$NOUNSET" ]]; then
+    set -o nounset
+fi
+
+# Stop if any command fails.
+set -e
+
+function usage
+{
+    cat << EOM
+
+    Usage: $ bash ${0##*/} [-v] [-h] STACK [BRANCH]
+
+    Installs the BigchainDB devstack or network.
+
+    This script captures a log of all output produced during runtime, and saves
+    it in a .log file within the current directory.
+
+    STACK
+        Either'devstack' or 'network'. Network mimics a production network
+        environment with multiple BDB nodes, whereas devstack is useful if 
+        you plan on modifying the bigchaindb code.
+        You must specify this.
+
+    BRANCH
+        The bigchaindb repo branch to use.
+
+    -v
+        Verbose output from ansible playbooks.
+
+    -h
+        Show this help and exit.
+
+EOM
+}
+
+
+ERROR='\033[0;31m' # Red
+WARN='\033[1;33m' # Yellow
+SUCCESS='\033[0;32m' # Green
+NC='\033[0m' # No Color
+
+# Output verbosity
+verbosity=0
+# BRANCH
+branch=""
+
+while getopts "vh" opt; do
+    case "$opt" in
+        v)
+            verbosity=1
+            ;;
+        h)
+            usage
+            exit
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+shift "$((OPTIND-1))" # Shift off the options we've already parsed
+
+# STACK is a required positional argument.
+if [[ ! $1 ]]; then
+    echo "STACK is required"
+    usage
+    exit 1
+fi
+stack=$1
+shift
+
+# RELEASE is an optional positional argument, defaulting to BRANCH.
+if [[ $1 ]]; then
+    release=$1
+    shift
+else
+    release=$BRANCH
+fi
+
+if [[ ! $release ]]; then
+    echo "You must specify RELEASE, or define OPENEDX_RELEASE before running."
+    exit 1
+fi
+
+# If there are positional arguments left, something is wrong.
+if [[ $1 ]]; then
+    echo "Don't understand extra arguments: $*"
+    usage
+    exit 1
+fi
+
+mkdir -p logs
+log_file=logs/install-$(date +%Y%m%d-%H%M%S).log
+exec > >(tee $log_file) 2>&1
+echo "Capturing output to $log_file"
+echo "Installation started at $(date '+%Y-%m-%d %H:%M:%S')"
+
+function finish {
+    echo "Installation finished at $(date '+%Y-%m-%d %H:%M:%S')"
+}
+trap finish EXIT
+
+export BRANCH=$release
+echo "Using bigchaindb branch '$BRANCH'"
+
+if [[ -d .vagrant ]]; then
+    echo -e "${ERROR}A .vagrant directory already exists here. If you already tried installing $stack, make sure to vagrant destroy the $stack machine and 'rm -rf .vagrant' before trying to reinstall. If you would like to install a separate $stack, change to a different directory and try running the script again.${NC}"
+    exit 1
+fi
+
+git clone https://github.com/bigchaindb/bigchaindb.git -b $BRANCH
+
+if [[ $stack == "devstack" ]]; then # Install devstack
+    vagrant plugin install vagrant-vbguest
+elif [[ $stack == "fullstack" ]]; then # Install fullstack
+    exit
+else # Throw error
+    echo -e "${ERROR}Unrecognized stack name, must be either devstack or network${NC}"
+    exit 1
+fi
+
+vagrant up --provider virtualbox
+
+echo -e "${SUCCESS}Finished installing! You may now log in using 'vagrant ssh'"

--- a/pkg/scripts/install_stack.sh
+++ b/pkg/scripts/install_stack.sh
@@ -89,7 +89,7 @@ else
 fi
 
 if [[ ! $release ]]; then
-    echo "You must specify RELEASE, or define OPENEDX_RELEASE before running."
+    echo "You must specify BRANCH, or set BDB_BRANCH before running."
     exit 1
 fi
 
@@ -122,7 +122,7 @@ fi
 git clone https://github.com/bigchaindb/bigchaindb.git -b $BRANCH
 
 if [[ $stack == "devstack" ]]; then # Install devstack
-    vagrant plugin install vagrant-vbguest
+    curl -fOL# https://raw.githubusercontent.com/bigchaindb/bigchaindb/4137ca626d094152889cba43196a0ed2d2a96cd0/pkg/scripts/Vagrantfile
 elif [[ $stack == "fullstack" ]]; then # Install fullstack
     exit
 else # Throw error

--- a/pkg/scripts/install_stack.sh
+++ b/pkg/scripts/install_stack.sh
@@ -17,7 +17,7 @@ function usage
 {
     cat << EOM
 
-    Usage: $ bash ${0##*/} [-v] [-h] STACK [BRANCH]
+    Usage: $ bash ${0##*/} [-v] [-h] [STACK] [GIT_BRANCH]
 
     Installs the BigchainDB devstack or network.
 
@@ -25,13 +25,14 @@ function usage
     it in a .log file within the current directory.
 
     STACK
-        Either'devstack' or 'network'. Network mimics a production network
+        Either 'devstack' or 'network'. Network mimics a production network
         environment with multiple BDB nodes, whereas devstack is useful if 
         you plan on modifying the bigchaindb code.
-        You must specify this.
+        Defualts to STACK environment variable
 
-    BRANCH
-        The bigchaindb repo branch to use.
+    GIT_BRANCH
+        The bigchaindb repo branch to use. defaults to GIT_BRANCH environment
+        variable
 
     -v
         Verbose output from ansible playbooks.
@@ -72,23 +73,22 @@ done
 shift "$((OPTIND-1))" # Shift off the options we've already parsed
 
 # STACK is a required positional argument.
-if [[ ! $1 ]]; then
-    echo "STACK is required"
-    usage
-    exit 1
+if [[ $1 ]]; then
+    stack=$1
+else
+    stack=$STACK
 fi
-stack=$1
 shift
 
 # RELEASE is an optional positional argument, defaulting to BRANCH.
 if [[ $1 ]]; then
-    release=$1
-    shift
+    git_branch=$1
 else
-    release=$BRANCH
+    git_branch=$GIT_BRANCH
 fi
 
-if [[ ! $release ]]; then
+
+if [[ ! $git_branch ]]; then
     echo "You must specify BRANCH, or set BDB_BRANCH before running."
     exit 1
 fi
@@ -124,7 +124,8 @@ git clone https://github.com/bigchaindb/bigchaindb.git -b $BRANCH
 if [[ $stack == "devstack" ]]; then # Install devstack
     curl -fOL# https://raw.githubusercontent.com/bigchaindb/bigchaindb/${BRANCH}/pkg/scripts/Vagrantfile
     vagrant up --provider virtualbox
-elif [[ $stack == "network" ]]; then # Install fullstack
+elif [[ $stack == "network" ]]; then # Install network
+    echo -e "${WARN}Network support is not yet available"
     exit
 else # Throw error
     echo -e "${ERROR}Unrecognized stack name, must be either devstack or network${NC}"

--- a/pkg/scripts/stack.sh
+++ b/pkg/scripts/stack.sh
@@ -86,7 +86,7 @@ cat << 'EOF' >> ~/.tendermint/genesis.json
 EOF
 
 # Configure tmux
-tmux new-session -s bdb-dev -n bdb
+tmux new-session -s bdb-dev -n bdb -d
 tmux new-window -n mdb
 tmux new-window -n tendermint
 

--- a/pkg/scripts/stack.sh
+++ b/pkg/scripts/stack.sh
@@ -4,19 +4,12 @@
 # installs and configures **BigchainDb Server**, **Tendermint Server**,
 # **MongoDB**
 
-# To keep this script simple we assume you are running on a recent **Ubuntu**
-# (16.04 Xenial or newer)
-
 # Print the commands being run so that we can see the command that triggers
 # an error.  It is also useful for following along as the install occurs.
 set -o xtrace
 
 # Make sure umask is sane
 umask 022
-
-# Initialize variables:
-LAST_SPINNER_PID=""
-STACK_USER="stack"
 
 # Keep track of the stack.sh directory
 TOP_DIR=$(cd $(dirname "$0") && pwd)
@@ -27,20 +20,11 @@ if [[ -n "$NOUNSET" ]]; then
     set -o nounset
 fi
 
-# Set start of devstack timestamp
-DEVSTACK_START_TIME=$(date +%s)
-
 # Configuration
 # =============
 
-
-# Prepare the environment
-# -----------------------
-
+# Source utility functions
 source functions-common
-
-# Initialize variables:
-LAST_SPINNER_PID=""
 
 # Determine what system we are running on.  This provides ``os_VENDOR``,
 # ``os_RELEASE``, ``os_PACKAGE``, ``os_CODENAME``
@@ -61,46 +45,7 @@ is_package_installed python3 || install_package python3
 is_package_installed python3-pip || install_package python3-pip
 is_package_installed libffi-dev || install_package libffi-dev
 is_package_installed libssl-dev || install_package libssl-dev
-
-# Configure Logging
-# -----------------
-
-# Set up logging level
-VERBOSE=$(trueorfalse True VERBOSE)
-
-# Draw a spinner so the user knows something is happening
-function spinner {
-    local delay=0.75
-    local spinstr='/-\|'
-    printf "..." >&3
-    while [ true ]; do
-        local temp=${spinstr#?}
-        printf "[%c]" "$spinstr" >&3
-        local spinstr=$temp${spinstr%"$temp"}
-        sleep $delay
-        printf "\b\b\b" >&3
-    done
-}
-
-function kill_spinner {
-    if [ ! -z "$LAST_SPINNER_PID" ]; then
-        kill >/dev/null 2>&1 $LAST_SPINNER_PID
-        printf "\b\b\bdone\n" >&3
-    fi
-}
-
-# Echo text to the log file, summary log file and stdout
-# echo_summary "something to say"
-function echo_summary {
-    if [[ -t 3 && "$VERBOSE" != "True" ]]; then
-        kill_spinner
-        echo -n -e $@ >&6
-        spinner &
-        LAST_SPINNER_PID=$!
-    else
-        echo -e $@ >&6
-    fi
-}
+is_package_installed tmux || install_package tmux
 
 # Configure Error Traps
 # ---------------------

--- a/pkg/scripts/stack.sh
+++ b/pkg/scripts/stack.sh
@@ -66,37 +66,19 @@ sudo chmod -R 700 /data/db
 
 # Configure tendermint
 tendermint init
-touch ~/.tendermint/genesis.json
-cat << 'EOF' >> ~/.tendermint/genesis.json
-{
-  "genesis_time": "0001-01-01T00:00:00Z",
-  "chain_id": "test-chain-EhS6zg",
-  "validators": [
-    {
-      "pub_key": {
-        "type": "ed25519",
-        "data": "C3E96823EB67401C5B794F4100CEA04B745C29A0707979485EAE4F3C1A7D8583"
-      },
-      "power": 10,
-      "name": ""
-    }
-  ],
-  "app_hash": ""
-}
-EOF
 
 # Configure tmux
 tmux new-session -s bdb-dev -n bdb -d
 tmux new-window -n mdb
 tmux new-window -n tendermint
 
-# 
-
 # Start services
-cd BASE_DIR
 tmux send-keys -t bdb-dev:mdb 'sudo mongod --replSet=bigchain-rs' C-m
-tmux send-keys -t bdb-dev:bdb 'sudo python3 setup.py install && bigchaindb -l DEBUG start --init' C-m
-tmux send-key -t bdb-dev:tendermint 'tendermint unsafe_reset_all && tendermint node' C-m
+tmux send-keys -t bdb-dev:bdb 'export BIGCHAINDB_START_TENDERMINT=0 && export TENDERMINT_HOST=localhost && export TENDERMINT_PORT=46657' C-m
+tmux send-keys -t bdb-dev:bdb 'cd /opt/stack/bigchaindb' C-m
+tmux send-keys -t bdb-dev:bdb 'sudo python3 setup.py install && bigchaindb -y configure mongodb && bigchaindb -l DEBUG start --init' C-m
+
+tmux send-key -t bdb-dev:tendermint 'tendermint init && tendermint unsafe_reset_all && tendermint node' C-m
 
 # Configure Error Traps
 # ---------------------

--- a/pkg/scripts/stack.sh
+++ b/pkg/scripts/stack.sh
@@ -34,18 +34,24 @@ GetDistro
 # Configure Distro Repositories
 # -----------------------------
 
-# For Debian/Ubuntu make apt attempt to retry network ops on it's own
+# For Debian/Ubuntu make apt attempt to retry network ops on it's own and mongodb pub key
+# source repo
 if is_ubuntu; then
     echo 'APT::Acquire::Retries "20";' | sudo tee /etc/apt/apt.conf.d/80retry  >/dev/null
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6
+    echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
 fi
 
 # Ensure required packages are installed
 # --------------------------------------
+
 is_package_installed python3 || install_package python3
 is_package_installed python3-pip || install_package python3-pip
 is_package_installed libffi-dev || install_package libffi-dev
 is_package_installed libssl-dev || install_package libssl-dev
 is_package_installed tmux || install_package tmux
+is_package_installed mongodb-org || install_package mongodb-org
+
 
 # Configure Error Traps
 # ---------------------

--- a/pkg/scripts/stack.sh
+++ b/pkg/scripts/stack.sh
@@ -28,7 +28,7 @@ fi
 
 # Set default tendermint version
 if [[ "$TM_VERSION" = "" ]]; then
-    MONGO_VERSION="0.12.1"
+    TM_VERSION="0.12.1"
 fi
 
 # Configuration

--- a/pkg/scripts/stack.sh
+++ b/pkg/scripts/stack.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+
+# ``stack.sh`` is an opinionated BigchainDB developer installation.  It
+# installs and configures **BigchainDb Server**, **Tendermint Server**,
+# **MongoDB**
+
+# To keep this script simple we assume you are running on a recent **Ubuntu**
+# (16.04 Xenial or newer)
+
+# Print the commands being run so that we can see the command that triggers
+# an error.  It is also useful for following along as the install occurs.
+set -o xtrace
+
+# Make sure umask is sane
+umask 022
+
+# Initialize variables:
+LAST_SPINNER_PID=""
+STACK_USER="stack"
+
+# Keep track of the stack.sh directory
+TOP_DIR=$(cd $(dirname "$0") && pwd)
+
+# Check for uninitialized variables, a big cause of bugs
+NOUNSET=${NOUNSET:-}
+if [[ -n "$NOUNSET" ]]; then
+    set -o nounset
+fi
+
+# Set start of devstack timestamp
+DEVSTACK_START_TIME=$(date +%s)
+
+# Configuration
+# =============
+
+# Sanity Checks
+# -------------
+
+# Clean up last environment var cache
+if [[ -r $TOP_DIR/.stackenv ]]; then
+    rm $TOP_DIR/.stackenv
+fi
+
+# stack.sh is designed to be run as a non-root user;
+# ``stack.sh`` must not be run as **root**.  It aborts and suggests one course of
+# action to create a suitable user account.
+if [[ $EUID -eq 0 ]]; then
+    set +o xtrace
+    echo "stack.sh should be run as a user with sudo permissions, "
+    echo "not root."
+    exit 1
+fi
+
+OS=$(uname -s)
+
+if [[ ! ${OS} =~ "Linux" ]]; then
+    set +o xtrace
+    echo "stack.sh is currently only supported on Linux Systems"
+    exit 1
+fi
+
+# Prepare the environment
+# -----------------------
+
+source functions-common
+
+# Initialize variables:
+LAST_SPINNER_PID=""
+
+# Determine what system we are running on.  This provides ``os_VENDOR``,
+# ``os_RELEASE``, ``os_PACKAGE``, ``os_CODENAME``
+# and ``DISTRO``
+GetDistro
+
+# Tell users who aren't on an explicitly supported distro
+if [[ ! ${DISTRO} =~ (xenial) ]]; then
+    echo "ERROR: this script is not supported on $DISTRO"
+    die $LINENO
+fi
+
+
+# Configure Distro Repositories
+# -----------------------------
+
+# For Debian/Ubuntu make apt attempt to retry network ops on it's own
+if is_ubuntu; then
+    echo 'APT::Acquire::Retries "20";' | sudo tee /etc/apt/apt.conf.d/80retry  >/dev/null
+fi
+
+# Ensure required packages are installed
+# --------------------------------------
+is_package_installed python3 || install_package python3
+is_package_installed python3-pip || install_package python3-pip
+is_package_installed libffi-dev || install_package libffi-dev
+is_package_installed libssl-dev || install_package libssl-dev
+
+exit
+
+
+
+# Configure Logging
+# -----------------
+
+# Set up logging level
+VERBOSE=$(trueorfalse True VERBOSE)
+
+# Draw a spinner so the user knows something is happening
+function spinner {
+    local delay=0.75
+    local spinstr='/-\|'
+    printf "..." >&3
+    while [ true ]; do
+        local temp=${spinstr#?}
+        printf "[%c]" "$spinstr" >&3
+        local spinstr=$temp${spinstr%"$temp"}
+        sleep $delay
+        printf "\b\b\b" >&3
+    done
+}
+
+function kill_spinner {
+    if [ ! -z "$LAST_SPINNER_PID" ]; then
+        kill >/dev/null 2>&1 $LAST_SPINNER_PID
+        printf "\b\b\bdone\n" >&3
+    fi
+}
+
+# Echo text to the log file, summary log file and stdout
+# echo_summary "something to say"
+function echo_summary {
+    if [[ -t 3 && "$VERBOSE" != "True" ]]; then
+        kill_spinner
+        echo -n -e $@ >&6
+        spinner &
+        LAST_SPINNER_PID=$!
+    else
+        echo -e $@ >&6
+    fi
+}
+
+# Echo text only to stdout, no log files
+# echo_nolog "something not for the logs"
+function echo_nolog {
+    echo $@ >&3
+}
+
+# Set up logging for ``stack.sh``
+# Set ``LOGFILE`` to turn on logging
+# Append '.xxxxxxxx' to the given name to maintain history
+# where 'xxxxxxxx' is a representation of the date the file was created
+TIMESTAMP_FORMAT=${TIMESTAMP_FORMAT:-"%F-%H%M%S"}
+LOGDAYS=${LOGDAYS:-7}
+CURRENT_LOG_TIME=$(date "+$TIMESTAMP_FORMAT")
+
+if [[ -n "$LOGFILE" ]]; then
+    # Clean up old log files.  Append '.*' to the user-specified
+    # ``LOGFILE`` to match the date in the search template.
+    LOGFILE_DIR="${LOGFILE%/*}"           # dirname
+    LOGFILE_NAME="${LOGFILE##*/}"         # basename
+    mkdir -p $LOGFILE_DIR
+    find $LOGFILE_DIR -maxdepth 1 -name $LOGFILE_NAME.\* -mtime +$LOGDAYS -exec rm {} \;
+    LOGFILE=$LOGFILE.${CURRENT_LOG_TIME}
+    SUMFILE=$LOGFILE.summary.${CURRENT_LOG_TIME}
+
+    # Redirect output according to config
+
+    # Set fd 3 to a copy of stdout. So we can set fd 1 without losing
+    # stdout later.
+    exec 3>&1
+    if [[ "$VERBOSE" == "True" ]]; then
+        # Set fd 1 and 2 to write the log file
+        exec 1> >( $TOP_DIR/tools/outfilter.py -v -o "${LOGFILE}" ) 2>&1
+        # Set fd 6 to summary log file
+        exec 6> >( $TOP_DIR/tools/outfilter.py -o "${SUMFILE}" )
+    else
+        # Set fd 1 and 2 to primary logfile
+        exec 1> >( $TOP_DIR/tools/outfilter.py -o "${LOGFILE}" ) 2>&1
+        # Set fd 6 to summary logfile and stdout
+        exec 6> >( $TOP_DIR/tools/outfilter.py -v -o "${SUMFILE}" >&3 )
+    fi
+
+    echo_summary "stack.sh log $LOGFILE"
+    # Specified logfile name always links to the most recent log
+    ln -sf $LOGFILE $LOGFILE_DIR/$LOGFILE_NAME
+    ln -sf $SUMFILE $LOGFILE_DIR/$LOGFILE_NAME.summary
+else
+    # Set up output redirection without log files
+    # Set fd 3 to a copy of stdout. So we can set fd 1 without losing
+    # stdout later.
+    exec 3>&1
+    if [[ "$VERBOSE" != "True" ]]; then
+        # Throw away stdout and stderr
+        exec 1>/dev/null 2>&1
+    fi
+    # Always send summary fd to original stdout
+    exec 6> >( $TOP_DIR/tools/outfilter.py -v >&3 )
+fi
+
+# Basic test for ``$DEST`` path permissions (fatal on error unless skipped)
+check_path_perm_sanity ${DEST}
+
+# Configure Error Traps
+# ---------------------
+
+# Kill background processes on exit
+trap exit_trap EXIT
+function exit_trap {
+    local r=$?
+    jobs=$(jobs -p)
+    # Only do the kill when we're logging through a process substitution,
+    # which currently is only to verbose logfile
+    if [[ -n $jobs && -n "$LOGFILE" && "$VERBOSE" == "True" ]]; then
+        echo "exit_trap: cleaning up child processes"
+        kill 2>&1 $jobs
+    fi
+
+    #Remove timing data file
+    if [ -f "$OSCWRAP_TIMER_FILE" ] ; then
+        rm "$OSCWRAP_TIMER_FILE"
+    fi
+
+    # Kill the last spinner process
+    kill_spinner
+
+    if [[ $r -ne 0 ]]; then
+        echo "Error on exit"
+        # If we error before we've installed os-testr, this will fail.
+        if type -p generate-subunit > /dev/null; then
+            generate-subunit $DEVSTACK_START_TIME $SECONDS 'fail' >> ${SUBUNIT_OUTPUT}
+        fi
+        if [[ -z $LOGDIR ]]; then
+            $TOP_DIR/tools/worlddump.py
+        else
+            $TOP_DIR/tools/worlddump.py -d $LOGDIR
+        fi
+    else
+        # If we error before we've installed os-testr, this will fail.
+        if type -p generate-subunit > /dev/null; then
+            generate-subunit $DEVSTACK_START_TIME $SECONDS >> ${SUBUNIT_OUTPUT}
+        fi
+    fi
+
+    exit $r
+}
+
+# Exit on any errors so that errors don't compound
+trap err_trap ERR
+function err_trap {
+    local r=$?
+    set +o xtrace
+    if [[ -n "$LOGFILE" ]]; then
+        echo "${0##*/} failed: full log in $LOGFILE"
+    else
+        echo "${0##*/} failed"
+    fi
+    exit $r
+}
+
+# Begin trapping error exit codes
+set -o errexit
+
+# Print the kernel version
+uname -a
+
+# Save configuration values
+save_stackenv $LINENO
+
+
+# Install Packages
+# ================
+
+git_clone $REQUIREMENTS_REPO $REQUIREMENTS_DIR $REQUIREMENTS_BRANCH
+
+# Install package requirements
+# Source it so the entire environment is available
+echo_summary "Installing package prerequisites"
+source $TOP_DIR/tools/install_prereqs.sh
+
+# Configure an appropriate Python environment
+if [[ "$OFFLINE" != "True" ]]; then
+    PYPI_ALTERNATIVE_URL=${PYPI_ALTERNATIVE_URL:-""} $TOP_DIR/tools/install_pip.sh
+fi
+
+# Install subunit for the subunit output stream
+pip_install -U os-testr
+
+TRACK_DEPENDS=${TRACK_DEPENDS:-False}
+
+# Install Python packages into a virtualenv so that we can track them
+if [[ $TRACK_DEPENDS = True ]]; then
+    echo_summary "Installing Python packages into a virtualenv $DEST/.venv"
+    pip_install -U virtualenv
+
+    rm -rf $DEST/.venv
+    virtualenv --system-site-packages $DEST/.venv
+    source $DEST/.venv/bin/activate
+    $DEST/.venv/bin/pip freeze > $DEST/requires-pre-pip
+fi
+
+if [[ "$USE_SYSTEMD" == "True" ]]; then
+    pip_install_gr systemd-python
+    # the default rate limit of 1000 messages / 30 seconds is not
+    # sufficient given how verbose our logging is.
+    iniset -sudo /etc/systemd/journald.conf "Journal" "RateLimitBurst" "0"
+    sudo systemctl restart systemd-journald
+fi
+
+
+
+# Start Services
+# ==============
+
+# Check the status of running services
+service_check
+
+# Fin
+# ===
+
+set +o xtrace
+
+if [[ -n "$LOGFILE" ]]; then
+    exec 1>&3
+    # Force all output to stdout and logs now
+    exec 1> >( tee -a "${LOGFILE}" ) 2>&1
+else
+    # Force all output to stdout now
+    exec 1>&3
+fi
+
+# Dump out the time totals
+time_totals
+
+# Warn that a deprecated feature was used
+if [[ -n "$DEPRECATED_TEXT" ]]; then
+    echo
+    echo -e "WARNING: $DEPRECATED_TEXT"
+    echo
+fi
+
+# Tell the user about using Systemd.
+
+echo
+echo "Services are running under systemd unit files."
+echo
+
+# Indicate how long this took to run (bash maintained variable ``SECONDS``)
+echo_summary "stack.sh completed in $SECONDS seconds."
+
+
+# Restore/close logging file descriptors
+exec 1>&3
+exec 2>&3
+exec 3>&-
+exec 6>&-

--- a/pkg/scripts/stack.sh
+++ b/pkg/scripts/stack.sh
@@ -21,16 +21,21 @@ if [[ -n "$NOUNSET" ]]; then
     set -o nounset
 fi
 
+# Set default MongoDB version
+if [[ "$MONGO_VERSION" = "" ]]; then
+    MONGO_VERSION="3.4"
+fi
+
+# Set default tendermint version
+if [[ "$TM_VERSION" = "" ]]; then
+    MONGO_VERSION="0.12.1"
+fi
+
 # Configuration
 # =============
 
 # Source utility functions
 source ${TOP_DIR}/functions-common
-
-# Determine what system we are running on.  This provides ``os_VENDOR``,
-# ``os_RELEASE``, ``os_PACKAGE``, ``os_CODENAME``
-# and ``DISTRO``
-GetDistro
 
 # Configure Distro Repositories
 # -----------------------------
@@ -40,7 +45,7 @@ GetDistro
 if is_ubuntu; then
     echo 'APT::Acquire::Retries "20";' | sudo tee /etc/apt/apt.conf.d/80retry  >/dev/null
     sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6
-    echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
+    echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/${MONGO_VERSION} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-${MONGO_VERSION}.list
 fi
 
 # Ensure required packages are installed
@@ -53,31 +58,63 @@ is_package_installed libssl-dev || install_package libssl-dev
 is_package_installed tmux || install_package tmux
 is_package_installed mongodb-org || install_package mongodb-org
 is_package_installed unzip || install_package unzip
+install_tendermint_bin
 
-# Install tendermint
-curl -fOL# https://s3-us-west-2.amazonaws.com/tendermint/binaries/tendermint/v0.12.0/tendermint_0.12.0_linux_amd64.zip
-unzip tendermint_0.12.0_linux_amd64.zip
-sudo mv tendermint /usr/local/bin
+# Clean system if re-running the script
+OIFS=$IFS
+IFS=':'
+session_str=$(tmux ls | grep -w bdb-dev)
+if [[ $session_str = "" ]]; then
+    continue
+else
+    session=($session_str)
+    tmux kill-session -t ${session[0]}
+fi
 
+# Stop bigchaindb service
+if is_running "bigchaindb"; then
+    sudo pkill bigchaindb
+fi
+
+# Stop tendermint service
+if is_running "tendermint"; then
+    sudo pkill tendermint
+fi
+
+# Stop mongodb service
+if is_running "monogod"; then
+    sudo pkill mongod
+fi
+
+sleep 5
 
 # Create data dir for mongod
-sudo mkdir -p /data/db
+if [[ ! -d /data/db ]]; then
+    sudo mkdir -p /data/db
+fi
 sudo chmod -R 700 /data/db
 
 # Configure tendermint
 tendermint init
 
 # Configure tmux
+cd ${BASE_DIR}
 tmux new-session -s bdb-dev -n bdb -d
 tmux new-window -n mdb
 tmux new-window -n tendermint
 
-# Start services
+# Start MongoDB
 tmux send-keys -t bdb-dev:mdb 'sudo mongod --replSet=bigchain-rs' C-m
-tmux send-keys -t bdb-dev:bdb 'export BIGCHAINDB_START_TENDERMINT=0 && export TENDERMINT_HOST=localhost && export TENDERMINT_PORT=46657' C-m
-tmux send-keys -t bdb-dev:bdb 'cd /opt/stack/bigchaindb' C-m
-tmux send-keys -t bdb-dev:bdb 'sudo python3 setup.py install && bigchaindb -y configure mongodb && bigchaindb -l DEBUG start --init' C-m
 
+# Start BigchainDB
+tmux send-keys -t bdb-dev:bdb 'sudo python3 setup.py install && bigchaindb -y configure mongodb && bigchaindb -l DEBUG start' C-m
+
+while ! is_running "bigchaindb"; do
+    echo "Waiting bigchaindb service to start"
+    sleep 5
+done
+
+# Start tendermint service
 tmux send-key -t bdb-dev:tendermint 'tendermint init && tendermint unsafe_reset_all && tendermint node' C-m
 
 # Configure Error Traps
@@ -88,11 +125,11 @@ trap exit_trap EXIT
 function exit_trap {
     exit $?
 }
-
-# Exit on any errors so that errors don't compound
+# Exit on any errors so that errors don't compound and kill if any services already started
 trap err_trap ERR
 function err_trap {
     local r=$?
+    tmux kill-session bdb-dev
     set +o xtrace
     exit $?
 }

--- a/pkg/scripts/stack.sh
+++ b/pkg/scripts/stack.sh
@@ -24,7 +24,7 @@ fi
 # =============
 
 # Source utility functions
-source functions-common
+source ${TOP_DIR}/functions-common
 
 # Determine what system we are running on.  This provides ``os_VENDOR``,
 # ``os_RELEASE``, ``os_PACKAGE``, ``os_CODENAME``
@@ -53,8 +53,6 @@ is_package_installed tmux || install_package tmux
 # Kill background processes on exit
 trap exit_trap EXIT
 function exit_trap {
-    # Kill the last spinner process
-    kill_spinner
     exit $?
 }
 


### PR DESCRIPTION
## Description
Adds a single command workflow to bring up development setup with bigchaindb and tendermint

## Issues This PR Fixes
Fixes #1850 


## Todos
- [x] Tested and working on development environment

## How to QA
System requirements: vagrant and virtualbox (install latest versions and you'll be fine)
Install required vagrant plugins
- vagrant plugin install vagrant-cachier
- vagrant plugin install vagrant-vbguest
Set git branch to use: export GIT_BRANCH=shahbaz-dev
down load script: curl -fOL https://raw.githubusercontent.com/bigchaindb/bigchaindb/${GIT_BRANCH}/pkg/scripts/install_stack.sh
run script: bash install_stack.sh

Optionally you can set MONGO_VERSION (current default 3.4) and TM_VERSION (current default 0.12.1) if you wish to configure versions mongodb or tendermint other than defaults