### PR TITLE
Add metadata endpoint to info view

### DIFF
--- a/bigchaindb/web/views/info.py
+++ b/bigchaindb/web/views/info.py
@@ -50,5 +50,6 @@ def get_api_v1_info(api_prefix):
         'statuses': '{}statuses/'.format(api_prefix),
         'assets': '{}assets/'.format(api_prefix),
         'outputs': '{}outputs/'.format(api_prefix),
-        'streams': websocket_root
+        'streams': websocket_root,
+        'metadata': '{}metadata/'.format(api_prefix),
     }

--- a/docs/server/source/data-models/transaction-model.rst
+++ b/docs/server/source/data-models/transaction-model.rst
@@ -45,7 +45,7 @@ Here's some explanation of the contents:
 - **metadata**: User-provided transaction metadata.
   It can be any valid JSON document, or ``null``.
   **NOTE:** When using MongoDB for storage, certain restriction apply
-  to all (including nested) keys of the ``"data"`` JSON document:
+  to all (including nested) keys of the JSON document:
   1) keys (i.e. key names, not values) must **not** begin with the ``$`` character, and
   2) keys must not contain ``.`` or the null character (Unicode code point 0000).
   3) The key `"language"` (at any level in the hierarchy) is a special key and used for specifying text search language. Its value must be one of the allowed values; see the valid `Text Search Languages <https://docs.mongodb.com/manual/reference/text-search-languages/>`_ in the MongoDB Docs. In BigchainDB, only the languages supported by *MongoDB community edition* are allowed.

--- a/docs/server/source/data-models/transaction-model.rst
+++ b/docs/server/source/data-models/transaction-model.rst
@@ -48,7 +48,7 @@ Here's some explanation of the contents:
   to all (including nested) keys of the ``"data"`` JSON document:
   1) keys (i.e. key names, not values) must **not** begin with the ``$`` character, and
   2) keys must not contain ``.`` or the null character (Unicode code point 0000).
-  3) The key `"language"` (at any level in the hierarchy) is a special key and used for specifying text search language. Its value must be one of the allowed values; see the valid [Text Search Languages](https://docs.mongodb.com/manual/reference/text-search-languages/) in the MongoDB Docs. In BigchainDB, only the languages supported by *MongoDB community edition* are allowed.
+  3) The key `"language"` (at any level in the hierarchy) is a special key and used for specifying text search language. Its value must be one of the allowed values; see the valid `Text Search Languages <https://docs.mongodb.com/manual/reference/text-search-languages/>`_ in the MongoDB Docs. In BigchainDB, only the languages supported by *MongoDB community edition* are allowed.
 
 **How the transaction ID is computed.**
 1) Build a Python dictionary containing ``version``, ``inputs``, ``outputs``, ``operation``, ``asset``, ``metadata`` and their values, 

--- a/docs/server/source/data-models/transaction-model.rst
+++ b/docs/server/source/data-models/transaction-model.rst
@@ -48,6 +48,7 @@ Here's some explanation of the contents:
   to all (including nested) keys of the ``"data"`` JSON document:
   1) keys (i.e. key names, not values) must **not** begin with the ``$`` character, and
   2) keys must not contain ``.`` or the null character (Unicode code point 0000).
+  3) The key `"language"` (at any level in the hierarchy) is a special key and used for specifying text search language. Its value must be one of the allowed values; see the valid [Text Search Languages](https://docs.mongodb.com/manual/reference/text-search-languages/) in the MongoDB Docs. In BigchainDB, only the languages supported by *MongoDB community edition* are allowed.
 
 **How the transaction ID is computed.**
 1) Build a Python dictionary containing ``version``, ``inputs``, ``outputs``, ``operation``, ``asset``, ``metadata`` and their values, 

--- a/tests/web/test_info.py
+++ b/tests/web/test_info.py
@@ -18,6 +18,7 @@ def test_api_root_endpoint(client, wsserver_base_url):
                 'outputs': '/api/v1/outputs/',
                 'streams': '{}/api/v1/streams/valid_transactions'.format(
                     wsserver_base_url),
+                "metadata": "/api/v1/metadata/"
             }
         },
         'docs': 'https://docs.bigchaindb.com/projects/server/en/vtsttst/',
@@ -41,6 +42,7 @@ def test_api_v1_endpoint(client, wsserver_base_url):
         'outputs': '/outputs/',
                 'streams': '{}/api/v1/streams/valid_transactions'.format(
                     wsserver_base_url),
+        "metadata": "/metadata/"
     }
     res = client.get('/api/v1')
     assert res.json == api_v1_info


### PR DESCRIPTION
## Description
- Metadata search was recently added and works seamlessly
- The endpoint was not reflected in the info view i.e.
  when someone queries at root / or api/v1 endpoints.
- Handle unit tests for the change as well.

## Issues This PR Fixes
Fixes #1888 

## Related PRs

#1812

## Todos
None

## Deployment Notes
None

## How to QA
Query any BigchainDB setup i.e. `curl http://bdb_root_url` , `curl http://bdb_root_url/api/v1/` In a browser. You will see the `metadata` as part of the response.

## Impacted Areas in Application
None.