### PR TITLE
Tx gen protocol issue 1891

### DIFF
--- a/bigchaindb/common/schema/transaction_v1.0.yaml
+++ b/bigchaindb/common/schema/transaction_v1.0.yaml
@@ -13,7 +13,9 @@ required:
 - version
 properties:
   id:
-    "$ref": "#/definitions/sha3_hexdigest"
+    anyOf:
+    - "$ref": "#/definitions/sha3_hexdigest"
+    - type: 'null'
   operation:
     "$ref": "#/definitions/operation"
   asset:

--- a/bigchaindb/models.py
+++ b/bigchaindb/models.py
@@ -84,6 +84,7 @@ class Transaction(Transaction):
 
     @classmethod
     def from_dict(cls, tx_body):
+        super().validate_id(tx_body)
         validate_transaction_schema(tx_body)
         validate_txn_obj('asset', tx_body['asset'], 'data', validate_key)
         validate_txn_obj('metadata', tx_body, 'metadata', validate_key)

--- a/tests/assets/test_digital_assets.py
+++ b/tests/assets/test_digital_assets.py
@@ -71,8 +71,10 @@ def test_asset_id_mismatch(b, user_pk):
 
     tx1 = Transaction.create([b.me], [([user_pk], 1)],
                              metadata={'msg': random.random()})
+    tx1.sign([b.me_private])
     tx2 = Transaction.create([b.me], [([user_pk], 1)],
                              metadata={'msg': random.random()})
+    tx2.sign([b.me_private])
 
     with pytest.raises(AssetIdMismatch):
         Transaction.get_asset_id([tx1, tx2])

--- a/tests/common/conftest.py
+++ b/tests/common/conftest.py
@@ -202,3 +202,149 @@ def dummy_transaction():
         }],
         'version': '1.0'
     }
+
+
+@pytest.fixture
+def unfulfilled_transaction():
+    return {
+        'asset': {
+            'data': {
+                'msg': 'Hello BigchainDB!',
+            }
+        },
+        'id': None,
+        'inputs': [{
+            # XXX This could be None, see #1925
+            # https://github.com/bigchaindb/bigchaindb/issues/1925
+            'fulfillment': {
+                'public_key': 'JEAkEJqLbbgDRAtMm8YAjGp759Aq2qTn9eaEHUj2XePE',
+                'type': 'ed25519-sha-256'
+            },
+            'fulfills': None,
+            'owners_before': ['JEAkEJqLbbgDRAtMm8YAjGp759Aq2qTn9eaEHUj2XePE']
+        }],
+        'metadata': None,
+        'operation': 'CREATE',
+        'outputs': [{
+            'amount': '1',
+            'condition': {
+                'details': {
+                    'public_key': 'JEAkEJqLbbgDRAtMm8YAjGp759Aq2qTn9eaEHUj2XePE',
+                    'type': 'ed25519-sha-256'
+                },
+                'uri': 'ni:///sha-256;49C5UWNODwtcINxLgLc90bMCFqCymFYONGEmV4a0sG4?fpt=ed25519-sha-256&cost=131072'},
+            'public_keys': ['JEAkEJqLbbgDRAtMm8YAjGp759Aq2qTn9eaEHUj2XePE']
+        }],
+        'version': '1.0'
+    }
+
+
+@pytest.fixture
+def fulfilled_transaction():
+    return {
+        'asset': {
+            'data': {
+                'msg': 'Hello BigchainDB!',
+            }
+        },
+        'id': None,
+        'inputs': [{
+            'fulfillment': ('pGSAIP_2P1Juh-94sD3uno1lxMPd9EkIalRo7QB014pT6dD9g'
+                            'UANRNxasDy1Dfg9C2Fk4UgHdYFsJzItVYi5JJ_vWc6rKltn0k'
+                            'jagynI0xfyR6X9NhzccTt5oiNH9mThEb4QmagN'),
+            'fulfills': None,
+            'owners_before': ['JEAkEJqLbbgDRAtMm8YAjGp759Aq2qTn9eaEHUj2XePE']
+        }],
+        'metadata': None,
+        'operation': 'CREATE',
+        'outputs': [{
+            'amount': '1',
+            'condition': {
+                'details': {
+                    'public_key': 'JEAkEJqLbbgDRAtMm8YAjGp759Aq2qTn9eaEHUj2XePE',
+                    'type': 'ed25519-sha-256'
+                },
+                'uri': 'ni:///sha-256;49C5UWNODwtcINxLgLc90bMCFqCymFYONGEmV4a0sG4?fpt=ed25519-sha-256&cost=131072'},
+            'public_keys': ['JEAkEJqLbbgDRAtMm8YAjGp759Aq2qTn9eaEHUj2XePE']
+        }],
+        'version': '1.0'
+    }
+
+
+@pytest.fixture
+def fulfilled_and_hashed_transaction():
+    return {
+        'asset': {
+            'data': {
+                'msg': 'Hello BigchainDB!',
+            }
+        },
+        'id': '7a7c827cf4ef7985f08f4e9d16f5ffc58ca4e82271921dfbed32e70cb462485f',
+        'inputs': [{
+            'fulfillment': ('pGSAIP_2P1Juh-94sD3uno1lxMPd9EkIalRo7QB014pT6dD9g'
+                            'UANRNxasDy1Dfg9C2Fk4UgHdYFsJzItVYi5JJ_vWc6rKltn0k'
+                            'jagynI0xfyR6X9NhzccTt5oiNH9mThEb4QmagN'),
+            'fulfills': None,
+            'owners_before': ['JEAkEJqLbbgDRAtMm8YAjGp759Aq2qTn9eaEHUj2XePE']
+        }],
+        'metadata': None,
+        'operation': 'CREATE',
+        'outputs': [{
+            'amount': '1',
+            'condition': {
+                'details': {
+                    'public_key': 'JEAkEJqLbbgDRAtMm8YAjGp759Aq2qTn9eaEHUj2XePE',
+                    'type': 'ed25519-sha-256'
+                },
+                'uri': 'ni:///sha-256;49C5UWNODwtcINxLgLc90bMCFqCymFYONGEmV4a0sG4?fpt=ed25519-sha-256&cost=131072'},
+            'public_keys': ['JEAkEJqLbbgDRAtMm8YAjGp759Aq2qTn9eaEHUj2XePE']
+        }],
+        'version': '1.0'
+    }
+
+
+# TODO For reviewers: Pick which approach you like best: parametrized or not?
+@pytest.fixture(params=(
+    {'id': None,
+     'fulfillment': {
+         'public_key': 'JEAkEJqLbbgDRAtMm8YAjGp759Aq2qTn9eaEHUj2XePE',
+         'type': 'ed25519-sha-256'}},
+    {'id': None,
+     'fulfillment': ('pGSAIP_2P1Juh-94sD3uno1lxMPd9EkIalRo7QB014pT6dD9g'
+                     'UANRNxasDy1Dfg9C2Fk4UgHdYFsJzItVYi5JJ_vWc6rKltn0k'
+                     'jagynI0xfyR6X9NhzccTt5oiNH9mThEb4QmagN')},
+    {'id': '7a7c827cf4ef7985f08f4e9d16f5ffc58ca4e82271921dfbed32e70cb462485f',
+     'fulfillment': ('pGSAIP_2P1Juh-94sD3uno1lxMPd9EkIalRo7QB014pT6dD9g'
+                     'UANRNxasDy1Dfg9C2Fk4UgHdYFsJzItVYi5JJ_vWc6rKltn0k'
+                     'jagynI0xfyR6X9NhzccTt5oiNH9mThEb4QmagN')},
+))
+def tri_state_transaction(request):
+    tx = {
+        'asset': {
+            'data': {
+                'msg': 'Hello BigchainDB!',
+            }
+        },
+        'id': None,
+        'inputs': [{
+            'fulfillment': None,
+            'fulfills': None,
+            'owners_before': ['JEAkEJqLbbgDRAtMm8YAjGp759Aq2qTn9eaEHUj2XePE']
+        }],
+        'metadata': None,
+        'operation': 'CREATE',
+        'outputs': [{
+            'amount': '1',
+            'condition': {
+                'details': {
+                    'public_key': 'JEAkEJqLbbgDRAtMm8YAjGp759Aq2qTn9eaEHUj2XePE',
+                    'type': 'ed25519-sha-256'
+                },
+                'uri': 'ni:///sha-256;49C5UWNODwtcINxLgLc90bMCFqCymFYONGEmV4a0sG4?fpt=ed25519-sha-256&cost=131072'},
+            'public_keys': ['JEAkEJqLbbgDRAtMm8YAjGp759Aq2qTn9eaEHUj2XePE']
+        }],
+        'version': '1.0'
+    }
+    tx['id'] = request.param['id']
+    tx['inputs'][0]['fulfillment'] = request.param['fulfillment']
+    return tx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -336,6 +336,15 @@ def signed_transfer_tx(signed_create_tx, user_pk, user_sk):
 
 
 @pytest.fixture
+def double_spend_tx(signed_create_tx, carol_pubkey, user_sk):
+    from bigchaindb.models import Transaction
+    inputs = signed_create_tx.to_inputs()
+    tx = Transaction.transfer(
+        inputs, [([carol_pubkey], 1)], asset_id=signed_create_tx.id)
+    return tx.sign([user_sk])
+
+
+@pytest.fixture
 def structurally_valid_vote():
     return {
         'node_pubkey': 'c' * 44,

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -635,7 +635,7 @@ class TestTransactionValidation(object):
 
     @pytest.mark.usefixtures('inputs')
     def test_non_create_double_spend(self, b, signed_create_tx,
-                                     signed_transfer_tx):
+                                     signed_transfer_tx, double_spend_tx):
         from bigchaindb.common.exceptions import DoubleSpend
 
         block1 = b.create_block([signed_create_tx])
@@ -655,10 +655,8 @@ class TestTransactionValidation(object):
 
         sleep(1)
 
-        signed_transfer_tx.metadata = {'different': 1}
-        # FIXME: https://github.com/bigchaindb/bigchaindb/issues/592
         with pytest.raises(DoubleSpend):
-            b.validate_transaction(signed_transfer_tx)
+            b.validate_transaction(double_spend_tx)
 
     @pytest.mark.usefixtures('inputs')
     def test_valid_non_create_transaction_after_block_creation(self, b,

--- a/tests/pipelines/test_election.py
+++ b/tests/pipelines/test_election.py
@@ -18,6 +18,7 @@ def test_check_for_quorum_invalid(b, user_pk):
 
     # create blocks with transactions
     tx1 = Transaction.create([b.me], [([user_pk], 1)])
+    tx1.sign([b.me_private])
     test_block = b.create_block([tx1])
 
     # simulate a federation with four voters
@@ -51,6 +52,7 @@ def test_check_for_quorum_invalid_prev_node(b, user_pk):
 
     # create blocks with transactions
     tx1 = Transaction.create([b.me], [([user_pk], 1)])
+    tx1.sign([b.me_private])
     test_block = b.create_block([tx1])
 
     # simulate a federation with four voters
@@ -94,6 +96,7 @@ def test_check_for_quorum_valid(b, user_pk):
 
     # create blocks with transactions
     tx1 = Transaction.create([b.me], [([user_pk], 1)])
+    tx1.sign([b.me_private])
     test_block = b.create_block([tx1])
 
     # add voters to block and write
@@ -129,6 +132,7 @@ def test_check_requeue_transaction(b, user_pk):
 
     # create blocks with transactions
     tx1 = Transaction.create([b.me], [([user_pk], 1)])
+    tx1.sign([b.me_private])
     test_block = b.create_block([tx1])
 
     e.requeue_transactions(test_block)

--- a/tests/pipelines/test_vote.py
+++ b/tests/pipelines/test_vote.py
@@ -378,6 +378,10 @@ def test_valid_block_voting_with_transfer_transactions(monkeypatch,
                                          vote2_doc['signature']) is True
 
 
+@pytest.mark.skip(
+    reason=('Needs important modification following issue #1891:'
+            'https://github.com/bigchaindb/bigchaindb/issues/1891')
+)
 @pytest.mark.bdb
 def test_unsigned_tx_in_block_voting(monkeypatch, b, user_pk, genesis_block):
     from bigchaindb.backend import query

--- a/tests/test_block_model.py
+++ b/tests/test_block_model.py
@@ -57,14 +57,15 @@ class TestBlockModel(object):
         from bigchaindb.common.utils import gen_timestamp, serialize
         from bigchaindb.models import Block, Transaction
 
-        transactions = [Transaction.create([b.me], [([b.me], 1)])]
+        transaction = Transaction.create([b.me], [([b.me], 1)])
+        transaction.sign([b.me_private])
         timestamp = gen_timestamp()
         voters = ['Qaaa', 'Qbbb']
-        expected = Block(transactions, b.me, timestamp, voters)
+        expected = Block([transaction], b.me, timestamp, voters)
 
         block = {
             'timestamp': timestamp,
-            'transactions': [tx.to_dict() for tx in transactions],
+            'transactions': [transaction.to_dict()],
             'node_pubkey': b.me,
             'voters': voters,
         }
@@ -97,12 +98,13 @@ class TestBlockModel(object):
         from bigchaindb.common.utils import gen_timestamp, serialize
         from bigchaindb.models import Block, Transaction
 
-        transactions = [Transaction.create([b.me], [([b.me], 1)])]
+        transaction = Transaction.create([b.me], [([b.me], 1)])
+        transaction.sign([b.me_private])
         timestamp = gen_timestamp()
 
         block = {
             'timestamp': timestamp,
-            'transactions': [tx.to_dict() for tx in transactions],
+            'transactions': [transaction.to_dict()],
             'node_pubkey': b.me,
             'voters': list(b.federation),
         }
@@ -168,12 +170,14 @@ class TestBlockModel(object):
         # create 3 assets
         for asset in assets:
             tx = Transaction.create([b.me], [([b.me], 1)], asset=asset)
+            tx.sign([b.me_private])
             txs.append(tx)
 
         # create a `TRANSFER` transaction.
         # the asset in `TRANSFER` transactions is not extracted
         tx = Transaction.transfer(txs[0].to_inputs(), [([b.me], 1)],
                                   asset_id=txs[0].id)
+        tx.sign([b.me_private])
         txs.append(tx)
 
         # create the block
@@ -203,12 +207,14 @@ class TestBlockModel(object):
         # create 3 assets
         for asset in assets:
             tx = Transaction.create([b.me], [([b.me], 1)], asset=asset)
+            tx.sign([b.me_private])
             txs.append(tx)
 
         # create a `TRANSFER` transaction.
         # the asset in `TRANSFER` transactions is not extracted
         tx = Transaction.transfer(txs[0].to_inputs(), [([b.me], 1)],
                                   asset_id=txs[0].id)
+        tx.sign([b.me_private])
         txs.append(tx)
 
         # create the block
@@ -236,12 +242,14 @@ class TestBlockModel(object):
         # create 3 assets
         for asset in assets:
             tx = Transaction.create([b.me], [([b.me], 1)], asset=asset)
+            tx.sign([b.me_private])
             txs.append(tx)
 
         # create a `TRANSFER` transaction.
         # the asset in `TRANSFER` transactions is not extracted
         tx = Transaction.transfer(txs[0].to_inputs(), [([b.me], 1)],
                                   asset_id=txs[0].id)
+        tx.sign([b.me_private])
         txs.append(tx)
 
         # create the block
@@ -268,12 +276,14 @@ class TestBlockModel(object):
         # create 3 assets
         for asset in assets:
             tx = Transaction.create([b.me], [([b.me], 1)], asset=asset)
+            tx.sign([b.me_private])
             txs.append(tx)
 
         # create a `TRANSFER` transaction.
         # the asset in `TRANSFER` transactions is not extracted
         tx = Transaction.transfer(txs[0].to_inputs(), [([b.me], 1)],
                                   asset_id=txs[0].id)
+        tx.sign([b.me_private])
         txs.append(tx)
 
         # create the block

--- a/tests/test_fastquery.py
+++ b/tests/test_fastquery.py
@@ -49,17 +49,20 @@ def test_get_outputs_by_public_key(b, user_pk, user2_pk, blockdata):
     ]
 
 
-def test_filter_spent_outputs(b, user_pk):
+def test_filter_spent_outputs(b, user_pk, user_sk):
     out = [([user_pk], 1)]
     tx1 = Transaction.create([user_pk], out * 3)
-
+    tx1.sign([user_sk])
     # There are 3 inputs
     inputs = tx1.to_inputs()
 
     # Each spent individually
     tx2 = Transaction.transfer([inputs[0]], out, tx1.id)
+    tx2.sign([user_sk])
     tx3 = Transaction.transfer([inputs[1]], out, tx1.id)
+    tx3.sign([user_sk])
     tx4 = Transaction.transfer([inputs[2]], out, tx1.id)
+    tx4.sign([user_sk])
 
     # The CREATE and first TRANSFER are valid. tx2 produces a new unspent.
     for tx in [tx1, tx2]:
@@ -86,17 +89,21 @@ def test_filter_spent_outputs(b, user_pk):
     }
 
 
-def test_filter_unspent_outputs(b, user_pk):
+def test_filter_unspent_outputs(b, user_pk, user_sk):
     out = [([user_pk], 1)]
     tx1 = Transaction.create([user_pk], out * 3)
+    tx1.sign([user_sk])
 
     # There are 3 inputs
     inputs = tx1.to_inputs()
 
     # Each spent individually
     tx2 = Transaction.transfer([inputs[0]], out, tx1.id)
+    tx2.sign([user_sk])
     tx3 = Transaction.transfer([inputs[1]], out, tx1.id)
+    tx3.sign([user_sk])
     tx4 = Transaction.transfer([inputs[2]], out, tx1.id)
+    tx4.sign([user_sk])
 
     # The CREATE and first TRANSFER are valid. tx2 produces a new unspent.
     for tx in [tx1, tx2]:

--- a/tests/validation/test_transaction_structure.py
+++ b/tests/validation/test_transaction_structure.py
@@ -2,11 +2,13 @@
 structural / schematic issues are caught when reading a transaction
 (ie going from dict -> transaction).
 """
+import json
 
 import pytest
+import sha3
 from unittest.mock import MagicMock
 
-from bigchaindb.common.exceptions import (AmountError, InvalidHash,
+from bigchaindb.common.exceptions import (AmountError,
                                           SchemaValidationError,
                                           ThresholdTooDeep)
 from bigchaindb.models import Transaction
@@ -28,137 +30,175 @@ def validate_raises(tx, exc=SchemaValidationError):
 
 
 # We should test that validation works when we expect it to
-def test_validation_passes(create_tx):
-    validate(create_tx)
+def test_validation_passes(signed_create_tx):
+    Transaction.from_dict(signed_create_tx.to_dict())
 
 
 ################################################################################
 # ID
 
 
-def test_tx_serialization_hash_function(create_tx):
-    import sha3
-    import json
-    tx = create_tx.to_dict()
-    tx['inputs'][0]['fulfillment'] = None
-    del tx['id']
+def test_tx_serialization_hash_function(signed_create_tx):
+    tx = signed_create_tx.to_dict()
+    tx['id'] = None
     payload = json.dumps(tx, skipkeys=False, sort_keys=True,
                          separators=(',', ':'))
-    assert sha3.sha3_256(payload.encode()).hexdigest() == create_tx.id
+    assert sha3.sha3_256(payload.encode()).hexdigest() == signed_create_tx.id
 
 
-def test_tx_serialization_with_incorrect_hash(create_tx):
-    tx = create_tx.to_dict()
+def test_tx_serialization_with_incorrect_hash(signed_create_tx):
+    from bigchaindb.common.transaction import Transaction
+    from bigchaindb.common.exceptions import InvalidHash
+    tx = signed_create_tx.to_dict()
     tx['id'] = 'a' * 64
-    validate_raises(tx, InvalidHash)
+    with pytest.raises(InvalidHash):
+        Transaction.validate_id(tx)
 
 
-def test_tx_serialization_with_no_hash(create_tx):
-    tx = create_tx.to_dict()
+def test_tx_serialization_with_no_hash(signed_create_tx):
+    from bigchaindb.common.exceptions import InvalidHash
+    tx = signed_create_tx.to_dict()
     del tx['id']
-    validate_raises(tx)
+    with pytest.raises(InvalidHash):
+        Transaction.from_dict(tx)
 
 
 ################################################################################
 # Operation
 
-def test_validate_invalid_operation(create_tx):
+def test_validate_invalid_operation(b, create_tx):
     create_tx.operation = 'something invalid'
-    validate_raises(create_tx)
+    signed_tx = create_tx.sign([b.me_private])
+    validate_raises(signed_tx)
 
 
 ################################################################################
 # Metadata
 
-def test_validate_fails_metadata_empty_dict(create_tx):
+def test_validate_fails_metadata_empty_dict(b, create_tx):
     create_tx.metadata = {'a': 1}
-    validate(create_tx)
+    signed_tx = create_tx.sign([b.me_private])
+    validate(signed_tx)
+
+    create_tx._id = None
+    create_tx.fulfillment = None
     create_tx.metadata = None
-    validate(create_tx)
+    signed_tx = create_tx.sign([b.me_private])
+    validate(signed_tx)
+
+    create_tx._id = None
+    create_tx.fulfillment = None
     create_tx.metadata = {}
-    validate_raises(create_tx)
+    signed_tx = create_tx.sign([b.me_private])
+    validate_raises(signed_tx)
 
 
 ################################################################################
 # Asset
 
-def test_transfer_asset_schema(signed_transfer_tx):
+def test_transfer_asset_schema(user_sk, signed_transfer_tx):
+    from bigchaindb.common.transaction import Transaction
     tx = signed_transfer_tx.to_dict()
     validate(tx)
+    tx['id'] = None
     tx['asset']['data'] = {}
+    tx = Transaction.from_dict(tx).sign([user_sk]).to_dict()
     validate_raises(tx)
+    tx['id'] = None
     del tx['asset']['data']
     tx['asset']['id'] = 'b' * 63
+    tx = Transaction.from_dict(tx).sign([user_sk]).to_dict()
     validate_raises(tx)
 
 
-def test_create_tx_no_asset_id(create_tx):
+def test_create_tx_no_asset_id(b, create_tx):
     create_tx.asset['id'] = 'b' * 64
-    validate_raises(create_tx)
+    signed_tx = create_tx.sign([b.me_private])
+    validate_raises(signed_tx)
 
 
-def test_create_tx_asset_type(create_tx):
+def test_create_tx_asset_type(b, create_tx):
     create_tx.asset['data'] = 'a'
-    validate_raises(create_tx)
+    signed_tx = create_tx.sign([b.me_private])
+    validate_raises(signed_tx)
 
 
-def test_create_tx_no_asset_data(create_tx):
+def test_create_tx_no_asset_data(b, create_tx):
     tx_body = create_tx.to_dict()
     del tx_body['asset']['data']
-    tx_body_no_signatures = Transaction._remove_signatures(tx_body)
-    tx_body_serialized = Transaction._to_str(tx_body_no_signatures)
-    tx_body['id'] = Transaction._to_hash(tx_body_serialized)
+    tx_serialized = json.dumps(
+        tx_body, skipkeys=False, sort_keys=True, separators=(',', ':'))
+    tx_body['id'] = sha3.sha3_256(tx_serialized.encode()).hexdigest()
     validate_raises(tx_body)
 
 
 ################################################################################
 # Inputs
 
-def test_no_inputs(create_tx):
+def test_no_inputs(b, create_tx):
     create_tx.inputs = []
-    validate_raises(create_tx)
+    signed_tx = create_tx.sign([b.me_private])
+    validate_raises(signed_tx)
 
 
-def test_create_single_input(create_tx):
+def test_create_single_input(b, create_tx):
+    from bigchaindb.common.transaction import Transaction
     tx = create_tx.to_dict()
     tx['inputs'] += tx['inputs']
+    tx = Transaction.from_dict(tx).sign([b.me_private]).to_dict()
     validate_raises(tx)
+    tx['id'] = None
     tx['inputs'] = []
+    tx = Transaction.from_dict(tx).sign([b.me_private]).to_dict()
     validate_raises(tx)
 
 
-def test_create_tx_no_fulfills(create_tx):
+def test_create_tx_no_fulfills(b, create_tx):
+    from bigchaindb.common.transaction import Transaction
     tx = create_tx.to_dict()
-    tx['inputs'][0]['fulfills'] = {'tx': 'a' * 64, 'output': 0}
+    tx['inputs'][0]['fulfills'] = {'transaction_id': 'a' * 64,
+                                   'output_index': 0}
+    tx = Transaction.from_dict(tx).sign([b.me_private]).to_dict()
     validate_raises(tx)
 
 
-def test_transfer_has_inputs(signed_transfer_tx):
+def test_transfer_has_inputs(user_sk, signed_transfer_tx):
     signed_transfer_tx.inputs = []
+    signed_transfer_tx._id = None
+    signed_transfer_tx.sign([user_sk])
     validate_raises(signed_transfer_tx)
 
 
 ################################################################################
 # Outputs
 
-def test_low_amounts(create_tx, signed_transfer_tx):
-    for tx in [create_tx, signed_transfer_tx]:
+def test_low_amounts(b, user_sk, create_tx, signed_transfer_tx):
+    for sk, tx in [(b.me_private, create_tx), (user_sk, signed_transfer_tx)]:
         tx.outputs[0].amount = 0
+        tx._id = None
+        tx.sign([sk])
         validate_raises(tx, AmountError)
         tx.outputs[0].amount = -1
+        tx._id = None
+        tx.sign([sk])
         validate_raises(tx)
 
 
-def test_high_amounts(create_tx):
+def test_high_amounts(b, create_tx):
     # Should raise a SchemaValidationError - don't want to allow ridiculously
     # large numbers to get converted to int
     create_tx.outputs[0].amount = 10 ** 21
+    create_tx.sign([b.me_private])
     validate_raises(create_tx)
     # Should raise AmountError
     create_tx.outputs[0].amount = 9 * 10 ** 18 + 1
+    create_tx._id = None
+    create_tx.sign([b.me_private])
     validate_raises(create_tx, AmountError)
     # Should pass
     create_tx.outputs[0].amount -= 1
+    create_tx._id = None
+    create_tx.sign([b.me_private])
     validate(create_tx)
 
 
@@ -196,10 +236,17 @@ def test_unsupported_condition_type():
 ################################################################################
 # Version
 
-def test_validate_version(create_tx):
+def test_validate_version(b, create_tx):
     create_tx.version = '1.0'
+    create_tx.sign([b.me_private])
     validate(create_tx)
+
     create_tx.version = '0.10'
+    create_tx._id = None
+    create_tx.sign([b.me_private])
     validate_raises(create_tx)
+
     create_tx.version = '110'
+    create_tx._id = None
+    create_tx.sign([b.me_private])
     validate_raises(create_tx)

--- a/tests/web/test_transactions.py
+++ b/tests/web/test_transactions.py
@@ -1,7 +1,11 @@
 import json
 from unittest.mock import patch
 
+import base58
 import pytest
+from cryptoconditions import Ed25519Sha256
+from sha3 import sha3_256
+
 from bigchaindb.common import crypto
 
 
@@ -165,9 +169,16 @@ def test_post_create_transaction_with_invalid_signature(mock_logger,
     from bigchaindb.models import Transaction
     user_priv, user_pub = crypto.generate_key_pair()
 
-    tx = Transaction.create([user_pub], [([user_pub], 1)])
-    tx = tx.sign([user_priv]).to_dict()
+    tx = Transaction.create([user_pub], [([user_pub], 1)]).to_dict()
     tx['inputs'][0]['fulfillment'] = 64 * '0'
+    tx['id'] = sha3_256(
+        json.dumps(
+            tx,
+            sort_keys=True,
+            separators=(',', ':'),
+            ensure_ascii=False,
+        ).encode(),
+    ).hexdigest()
 
     res = client.post(TX_ENDPOINT, data=json.dumps(tx))
     expected_status_code = 400
@@ -202,9 +213,25 @@ def test_post_create_transaction_with_invalid_structure(client):
 def test_post_create_transaction_with_invalid_schema(mock_logger, client):
     from bigchaindb.models import Transaction
     user_priv, user_pub = crypto.generate_key_pair()
-    tx = Transaction.create(
-        [user_pub], [([user_pub], 1)]).sign([user_priv]).to_dict()
+    tx = Transaction.create([user_pub], [([user_pub], 1)]).to_dict()
     del tx['version']
+    ed25519 = Ed25519Sha256(public_key=base58.b58decode(user_pub))
+    message = json.dumps(
+        tx,
+        sort_keys=True,
+        separators=(',', ':'),
+        ensure_ascii=False,
+    ).encode()
+    ed25519.sign(message, base58.b58decode(user_priv))
+    tx['inputs'][0]['fulfillment'] = ed25519.serialize_uri()
+    tx['id'] = sha3_256(
+        json.dumps(
+            tx,
+            sort_keys=True,
+            separators=(',', ':'),
+            ensure_ascii=False,
+        ).encode(),
+    ).hexdigest()
     res = client.post(TX_ENDPOINT, data=json.dumps(tx))
     expected_status_code = 400
     expected_error_message = (
@@ -308,6 +335,7 @@ def test_post_invalid_transfer_transaction_returns_400(b, client, user_pk):
     transfer_tx = Transaction.transfer(create_tx.to_inputs(),
                                        [([user_pub], 1)],
                                        asset_id=create_tx.id)
+    transfer_tx._hash()
 
     res = client.post(TX_ENDPOINT, data=json.dumps(transfer_tx.to_dict()))
     expected_status_code = 400


### PR DESCRIPTION
Fixes #1891 

### To do
- [x] flake8
- [x] rethinkdb tests
- [x] code coverage
- [x] review hacks
- [x] clean up
- [x] test `_hash`
- [x] test `serialized`

~~- [ ]  hash message before fulfilling~~ deferred to #1926
~~- [ ] allow  the key/value pair `fulfillment: None` in `_fulfillment_to_details`, if possible~~ deferred to #1925
~~- [ ] parametrize some tests~~
~~- [ ] address skipped test~~
~~- [ ] docs~~ deferred to #1912


Will be done in #1907, but noting here: 
- update tx model to v2.0
- add error message for tx model v1.0

### Things that are not ideal, but could be tolerated for now
* (#1911) The name of the method that fulfills transactions is called `sign`. In order to simplify the task of hashing which is now done after a transaction is fulfilled, the `sign` method also hashes by default, and updates the `id` field of the transaction. Consequently a better name would be `sign_and_hash`, or even better `fulfill_and_hash`. I wish to defer this work to a separate issue, because the Python client also depends on the `sign` method and changing the name would break the Python client.
- A few tests (perhaps just one) are skipped and it is highly questionable whether these tests are even needed. This can be addressed later.
- Some tests could benefit from fixtures for transactions that are invalid with respect to the asset, signature, schema, etc. Currently, the steps required to craft these invalid transactions is explicitly coded within each test wherever needed. This could also be addressed later.
* Some tests could benefit from parametrization (especially in `tests/validation/test_transaction_structure.py`), and this could also be addressed later.

### Some notes
Validation logic and object initialization are heavily intertwined in the Transaction model. This is not practical..It would be best to separate validation from construction.  As an example, to_dict and from_dict may perform some validation and it makes it very difficult to use the class.

When constructing a transaction there are two main phases; before fulfilling and after fulfilling. Hence, a Transaction instance or dictionary may be in the first phase, and it may be needed to use to_dict or from_dict. If validation is performed then it can obviously fail since the transaction has not been fulfilled yet, and moreover has no hash yet.

At the very most, if any validation is implicitly performed, it should not assume a fulfilled state. Hence, fulfillments and hash should not be expected.

In any case, `this` is urgently needed:

```:python
>>> import this
The Zen of Python, by Tim Peters

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one-- and preferably only one --obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than *right* now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea -- let's do more of those!
``` 