### PR TITLE
Updated the Notes for Firewall Setup page in docs

### DIFF
--- a/docs/server/source/appendices/firewall-notes.md
+++ b/docs/server/source/appendices/firewall-notes.md
@@ -1,55 +1,41 @@
 # Notes for Firewall Setup
 
-This is a page of notes on the ports potentially used by BigchainDB nodes and the traffic they should expect, to help with firewall setup (and security group setup on AWS). This page is _not_ a firewall tutorial or step-by-step guide.
-
+This is a page of notes on the ports potentially used by BigchainDB nodes and the traffic they should expect, to help with firewall setup (or security group setup on cloud providers). This page is _not_ a firewall tutorial or step-by-step guide.
 
 ## Expected Unsolicited Inbound Traffic
 
-Assuming you aren't exposing the RethinkDB web interface on port 8080 (or any other port, because [there are more secure ways to access it](https://www.rethinkdb.com/docs/security/#binding-the-web-interface-port)), there are only three ports that should expect unsolicited inbound traffic:
+The following ports should expect unsolicited inbound traffic:
 
 1. **Port 22** can expect inbound SSH (TCP) traffic from the node administrator (i.e. a small set of IP addresses).
 1. **Port 9984** can expect inbound HTTP (TCP) traffic from BigchainDB clients sending transactions to the BigchainDB HTTP API.
 1. **Port 9985** can expect inbount WebSocket traffic from BigchainDB clients.
-1. If you're using RethinkDB, **Port 29015** can expect inbound TCP traffic from other RethinkDB nodes in the RethinkDB cluster (for RethinkDB intracluster communications).
-1. If you're using MongoDB, **Port 27017** can expect inbound TCP traffic from other nodes.
+1. **Port 46656** can expect inbount Tendermint P2P traffic from other Tendermint peers.
 
 All other ports should only get inbound traffic in response to specific requests from inside the node.
-
 
 ## Port 22
 
 Port 22 is the default SSH port (TCP) so you'll at least want to make it possible to SSH in from your remote machine(s).
 
-
 ## Port 53
 
 Port 53 is the default DNS port (UDP). It may be used, for example, by some package managers when look up the IP address associated with certain package sources.
 
-
 ## Port 80
 
-Port 80 is the default HTTP port (TCP). It's used by some package managers to get packages. It's _not_ used by the RethinkDB web interface (see Port 8080 below) or the BigchainDB client-server HTTP API (Port 9984).
-
+Port 80 is the default HTTP port (TCP). It's used by some package managers to get packages. It's _not_ the default port for the BigchainDB client-server HTTP API.
 
 ## Port 123
 
 Port 123 is the default NTP port (UDP). You should be running an NTP daemon on production BigchainDB nodes. NTP daemons must be able to send requests to external NTP servers and accept the respones.
 
-
 ## Port 161
 
 Port 161 is the default SNMP port (usually UDP, sometimes TCP). SNMP is used, for example, by some server monitoring systems.
 
-
 ## Port 443
 
-Port 443 is the default HTTPS port (TCP). You may need to open it up for outbound requests (and inbound responses) temporarily because some RethinkDB installation instructions use wget over HTTPS to get the RethinkDB GPG key. Package managers might also get some packages using HTTPS.
-
-
-## Port 8080
-
-Port 8080 is the default port used by RethinkDB for its adminstrative web (HTTP) interface (TCP). While you _can_, you shouldn't allow traffic arbitrary external sources. You can still use the RethinkDB web interface by binding it to localhost and then accessing it via a SOCKS proxy or reverse proxy; see "Binding the web interface port" on [the RethinkDB page about securing your cluster](https://rethinkdb.com/docs/security/).
-
+Port 443 is the default HTTPS port (TCP). Package managers might also get some packages using HTTPS.
 
 ## Port 9984
 
@@ -59,21 +45,21 @@ If Gunicorn and the reverse proxy are running on the same server, then you'll ha
 
 You may want to have Gunicorn and the reverse proxy running on different servers, so that both can listen on port 9984. That would also help isolate the effects of a denial-of-service attack.
 
-
 ## Port 9985
 
 Port 9985 is the default port for the [BigchainDB WebSocket Event Stream API](../websocket-event-stream-api.html).
 
+## Port 46656
 
-## Port 28015
+Port 46656 is the default port used by Tendermint Core to communicate with other instances of Tendermint Core (peers).
 
-Port 28015 is the default port used by RethinkDB client driver connections (TCP). If your BigchainDB node is just one server, then Port 28015 only needs to listen on localhost, because all the client drivers will be running on localhost. Port 28015 doesn't need to accept inbound traffic from the outside world.
+## Port 46657
 
+Port 46657 is the default port used by Tendermint Core for RPC traffic. BigchainDB nodes use that internally; they don't expect incoming traffic from the outside world on port 46657.
 
-## Port 29015
+## Port 46658
 
-Port 29015 is the default port for RethinkDB intracluster connections (TCP). It should only accept incoming traffic from other RethinkDB servers in the cluster (a list of IP addresses that you should be able to find out).
-
+Port 46658 is the default port used by Tendermint Core for ABCI traffic. BigchainDB nodes use that internally; they don't expect incoming traffic from the outside world on port 46658.
 
 ## Other Ports
 


### PR DESCRIPTION
This is one of the pull requests to tackle issue #1895.

This pull request updates the appendix page titled **Notes for Firewall Setup** in the BigchainDB Server docs (in the `tendermint` branch).

- Removed all references to RethinkDB and MongoDB ports, since no firewall should be seeing RethinkDB or MongoDB traffic entering/leaving a BigchainDB node.
- Added notes about the default Tendermint ports.
