### PR TITLE
Update docker compose files for tendermint

### DIFF
--- a/docker-compose.network.yml
+++ b/docker-compose.network.yml
@@ -30,7 +30,7 @@ services:
       TENDERMINT_HOST: tendermint-one
     ports:
       - "9984"
-    command: bigchaindb -l DEBUG start --init
+    command: bigchaindb -l DEBUG start
   tendermint-one:
     image: tendermint/tendermint
     volumes:
@@ -67,7 +67,7 @@ services:
       TENDERMINT_HOST: tendermint-two
     ports:
       - "9984"
-    command: bigchaindb -l DEBUG start --init
+    command: bigchaindb -l DEBUG start
   tendermint-two:
     image: tendermint/tendermint
     volumes:
@@ -104,7 +104,7 @@ services:
       TENDERMINT_HOST: tendermint-three
     ports:
       - "9984"
-    command: bigchaindb -l DEBUG start --init
+    command: bigchaindb -l DEBUG start
   tendermint-three:
     image: tendermint/tendermint
     volumes:
@@ -141,7 +141,7 @@ services:
       TENDERMINT_HOST: tendermint-four
     ports:
       - "9984"
-    command: bigchaindb -l DEBUG start --init
+    command: bigchaindb -l DEBUG start
   tendermint-four:
     image: tendermint/tendermint
     volumes:

--- a/docker-compose.tendermint.yml
+++ b/docker-compose.tendermint.yml
@@ -29,7 +29,7 @@ services:
       TENDERMINT_PORT: 46657
     ports:
       - "9984"
-    command: bigchaindb -l DEBUG start --init
+    command: bigchaindb -l DEBUG start
   tendermint:
     image: tendermint/tendermint
     volumes:


### PR DESCRIPTION
## Description
After syncing with master, docker-compose with Tendermint integration was broken
- BigchainDB does not use --init flag anymore
- Either we use `bigchaindb init` explicitly or `bigchaindb start --no-init`
  other wise `bigchaindb start` implicitly does an init

## Issues This PR Fixes
Fixes #1923