### PR TITLE
Updated Quickstart page for Tendermint

### DIFF
--- a/docs/server/source/quickstart.md
+++ b/docs/server/source/quickstart.md
@@ -1,69 +1,87 @@
 # Quickstart
 
-This page has instructions to set up a single stand-alone BigchainDB node for learning or experimenting. Instructions for other cases are [elsewhere](introduction.html). We will assume you're using Ubuntu 16.04 or similar. You can also try, [running BigchainDB with Docker](appendices/run-with-docker.html).
+This page has instructions to set up a single stand-alone BigchainDB node for learning or experimenting. Instructions for other cases are [elsewhere](introduction.html). We will assume you're using Ubuntu 16.04 or similar. You may prefer to try [running BigchainDB with Docker](appendices/run-with-docker.html) instead.
 
-A. Install MongoDB as the database backend. (There are other options but you can ignore them for now.)
+Update apt's list of packages, then install some packages:
+```text
+$ sudo apt-get update
+$ sudo apt-get install curl unzip libffi-dev libssl-dev python3-pip
+```
 
-[Install MongoDB Server 3.4+](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/)
+Install Tendermint. Note: The following commands are for Tendermint 0.12.1. To determine the latest version, see [https://tendermint.com/downloads](https://tendermint.com/downloads).
+```text
+$ curl -fOL# https://s3-us-west-2.amazonaws.com/tendermint/binaries/tendermint/v0.12.1/tendermint_0.12.1_linux_amd64.zip
+$ unzip tendermint_0.12.1_linux_amd64.zip
+$ sudo mv tendermint /usr/local/bin
+$ rm tendermint_0.12.1_linux_amd64.zip
+```
 
-B. To run MongoDB with default database path i.e. /data/db, open a Terminal and run the following command:
+Configure Tendermint:
+```text
+$ tendermint init
+```
+
+Install MongoDB:
+
+🖝 [Install MongoDB Server 3.4+](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/).
+
+Create the default database directory for MongoDB, i.e. /data/db:
 ```text
 $ sudo mkdir -p /data/db
 ```
 
-C. Assign rwx(read/write/execute) permissions to the user for default database directory:
+Give the user read/write/execute permissions on /data/db:
 ```text
 $ sudo chmod -R 700 /data/db
 ```
 
-D. Run MongoDB (but do not close this terminal):
+Get the latest version of pip and setuptools:
 ```text
-$ sudo mongod --replSet=bigchain-rs
-```
-
-E. Ubuntu 16.04 already has Python 3.5, so you don't need to install it, but you do need to install some other things within a new terminal:
-```text
-$ sudo apt-get update
-$ sudo apt-get install libffi-dev libssl-dev
-```
-
-F. Get the latest version of pip and setuptools:
-```text
-$ sudo apt-get install python3-pip
 $ sudo pip3 install --upgrade pip setuptools
 ```
 
-G. Install the `bigchaindb` Python package from PyPI:
+Install the `bigchaindb` Python package from PyPI:
 ```text
 $ sudo pip3 install bigchaindb
 ```
 
-In case you are having problems with installation or package/module versioning, please upgrade the relevant packages on your host by running one the following commands:
-```text
-$ sudo pip3 install [packageName]==[packageVersion]
-
-OR
-
-$ sudo pip3 install [packageName] --upgrade
-```
-
-H. Configure BigchainDB Server:
+Configure BigchainDB Server:
 ```text
 $ bigchaindb -y configure mongodb
 ```
 
-I. Run BigchainDB Server:
+Set some environment variables:
+```text
+$ export BIGCHAINDB_START_TENDERMINT=0
+$ export TENDERMINT_HOST=localhost
+$ export TENDERMINT_PORT=46657
+```
+
+Run MongoDB:
+```text
+$ sudo mongod --replSet=bigchain-rs
+```
+
+That will take hold of that terminal, so open a new terminal and continue.
+
+Run BigchainDB Server:
 ```text
 $ bigchaindb start
 ```
 
-J. Verify BigchainDB Server setup by visiting the BigchainDB Root URL in your browser:
+Verify BigchainDB Server setup by visiting the BigchainDB Root URL in your browser:
 
 [http://127.0.0.1:9984/](http://127.0.0.1:9984/)
 
-A correctly installed installation will show you a JSON object with information about the API, docs, version and your public key.
+The response should be a JSON object with information about the API endpoints, docs URL and more.
 
-You now have a running BigchainDB Server and can post transactions to it.
+In yet another terminal, run Tendermint:
+```text
+$ tendermint unsafe_reset_all
+$ tendermint node
+```
+
+You now have a running BigchainDB Node and can post transactions to it.
 One way to do that is to use the BigchainDB Python Driver.
 
 [Install the BigchainDB Python Driver (link)](https://docs.bigchaindb.com/projects/py-driver/en/latest/quickstart.html)


### PR DESCRIPTION
This is one of the pull requests to tackle issue #1895. It updates the **Quickstart** page in the docs for BigchainDB Server. It rearranges the order a bit, consolidates some things, removes the letter labels on the steps.

What's new? The installation, init, and running of Tendermint.

I based it on pull request #1887 by @shahbazn 

I tested all the installation, config and run instructions on a brand new Ubuntu 16.04 Server (on AWS), up to just before `bigchaindb start` (which isn't going to work correctly yet because the current `bigchaindb` package on PyPI is the wrong one). The tested instructions worked fine.

### Questions

* Do we still need to specify the replica set when we start MongoDB? i.e.
```text
sudo mongod --replSet=bigchain-rs
```
* Do we need to set all those environment variables? i.e.
```text
$ export BIGCHAINDB_START_TENDERMINT=0
$ export TENDERMINT_HOST=localhost
$ export TENDERMINT_PORT=46657
```
* Do we need to do `tendermint unsafe_reset_all` before `tendermint node`?
* Is it really correct to start Tendermint last? I guess so, since Tendermint sees itself as a client and BigchainDB Server as a Server.