### PR TITLE
Remove pytest-catchlog since it is now in the core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ tests_require = [
     'hypothesis-regex',
     'pylint',
     'pytest>=3.0.0',
-    'pytest-catchlog>=1.2.2',
     'pytest-cov>=2.2.1',
     'pytest-mock',
     'pytest-xdist',


### PR DESCRIPTION
>  pytest-catchlog plugin has been merged into the core, please remove it from your requirements.