### PR TITLE
Fixed failing test and removed pytest-catchlog on tendermint branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ tests_require = [
     'hypothesis-regex',
     'pylint',
     'pytest>=3.0.0',
-    'pytest-catchlog>=1.2.2',
     'pytest-cov>=2.2.1',
     'pytest-mock',
     'pytest-xdist',

--- a/tests/backend/localmongodb/test_queries.py
+++ b/tests/backend/localmongodb/test_queries.py
@@ -89,13 +89,14 @@ def test_get_owned_ids(signed_create_tx, user_pk):
     assert txns[0] == signed_create_tx.to_dict()
 
 
-def test_get_spending_transactions(user_pk):
+def test_get_spending_transactions(user_pk, user_sk):
     from bigchaindb.backend import connect, query
     from bigchaindb.models import Transaction
     conn = connect()
 
     out = [([user_pk], 1)]
     tx1 = Transaction.create([user_pk], out * 3)
+    tx1.sign([user_sk])
     inputs = tx1.to_inputs()
     tx2 = Transaction.transfer([inputs[0]], out, tx1.id)
     tx3 = Transaction.transfer([inputs[1]], out, tx1.id)


### PR DESCRIPTION
The test `test_get_spending_transactions` in `tests/backend/localmongodb/test_queries.py` was failing so I fixed it by just making it more like the same test in `tests/backend/mongodb/test_queries.py`.

I also removed `pytest-catchlog` from the requirements in `setup.py` to make that warning go away. The same was already done on the `master` branch in PR #1936.