### PR TITLE
New production-ready page for tendermint branch

### DIFF
--- a/docs/root/source/index.rst
+++ b/docs/root/source/index.rst
@@ -78,6 +78,7 @@ More About BigchainDB
    :maxdepth: 1
 
    BigchainDB Docs Home <self>
+   production-ready
    terminology
    decentralized
    diversity

--- a/docs/root/source/production-ready.md
+++ b/docs/root/source/production-ready.md
@@ -1,0 +1,3 @@
+# Production-Ready?
+
+Depending on your use case, BigchainDB may or may not be production-ready. You should ask your service provider.


### PR DESCRIPTION
Based on user feedback, I brought back the **Production-Ready?** page in the root docs, but with different content.

This change will only be made to the `tendermint` branch for now. I will make that branch visible in ReadTheDocs, so once this PR is merged, the new text should show up there if the reader selects the `tendermint` branch.