### PR TITLE
update VM to premium storage VM

### DIFF
--- a/docs/server/source/production-deployment-template/template-kubernetes-azure.rst
+++ b/docs/server/source/production-deployment-template/template-kubernetes-azure.rst
@@ -99,7 +99,7 @@ Finally, you can deploy an ACS using something like:
    --master-count 3 \
    --agent-count 2 \
    --admin-username ubuntu \
-   --agent-vm-size Standard_D2_v2 \
+   --agent-vm-size Standard_L4s \
    --dns-prefix <make up a name> \
    --ssh-key-value ~/.ssh/<name>.pub \
    --orchestrator-type kubernetes \


### PR DESCRIPTION
## Description
Azure ACS now supports premium storage VMs with kubernetes deployment so production deployment templates need to be updated accordingly

## Issues This PR Fixes
Fixes #1971 

## Todos
- [*] Tested and working on development environment

## How to QA
Follow production deployment template and create k8s cluster on azure using [docs](https://docs.bigchaindb.com/projects/server/en/latest/production-deployment-template/template-kubernetes-azure.html)