### PR TITLE
Fix issue with STORAGE_ENGINE_CACHE_SIZE parameter

### DIFF
--- a/k8s/mongodb/container/mongod_entrypoint.bash
+++ b/k8s/mongodb/container/mongod_entrypoint.bash
@@ -66,7 +66,7 @@ if [[ -z "${REPLICA_SET_NAME:?REPLICA_SET_NAME not specified. Exiting!}" || \
     -z "${MONGODB_KEY_FILE_PATH:?MONGODB_KEY_FILE_PATH not specified. Exiting!}" || \
     -z "${MONGODB_CA_FILE_PATH:?MONGODB_CA_FILE_PATH not specified. Exiting!}" || \
     -z "${MONGODB_CRL_FILE_PATH:?MONGODB_CRL_FILE_PATH not specified. Exiting!}" || \
-    -z "${STORAGE_ENGINE_CACHE_SIZE:=''}" ]] ; then
+    -z ${STORAGE_ENGINE_CACHE_SIZE:=''} ]] ; then
     #-z "${MONGODB_KEY_FILE_PASSWORD:?MongoDB Key File Password not specified. Exiting!}" || \
   exit 1
 else


### PR DESCRIPTION
## Description

In mongodb docker image STORAGE_ENGINE_CACHE_SIZE
will always be set to '' (two quotation marks)
and verification will fail. So it's impossible to
run image without --storage-engine-cache-size set.

This change removes double quotes while assigning
default value to STORAGE_ENGINE_CACHE_SIZE.

## Issues This PR Fixes
Fixes https://github.com/bigchaindb/bigchaindb/issues/1983