### PR TITLE
Change "IPDB Testnet" to "BigchainDB Testnet" in docs

### DIFF
--- a/docs/root/source/permissions.rst
+++ b/docs/root/source/permissions.rst
@@ -71,5 +71,5 @@ Role-Based Access Control (RBAC)
 ================================
 
 In September 2017, we published a `blog post about how one can define an RBAC sub-system on top of BigchainDB <https://blog.bigchaindb.com/role-based-access-control-for-bigchaindb-assets-b7cada491997>`_.
-At the time of writing (October 2017), doing so required the use of a plugin, so it's not possible using standard BigchainDB (which is what's available on `IPDB <https://ipdb.io/>`_). That may change in the future.
+At the time of writing (January 2018), doing so required the use of a plugin, so it's not possible using standard BigchainDB (which is what's available on the `BigchainDB Testnet <https://testnet.bigchaindb.com/>`_). That may change in the future.
 If you're interested, `contact BigchainDB <https://www.bigchaindb.com/contact/>`_.

--- a/docs/server/source/drivers-clients/index.rst
+++ b/docs/server/source/drivers-clients/index.rst
@@ -25,4 +25,4 @@ Community-Driven Libraries and Tools
 * `Go driver <https://github.com/zbo14/envoke/blob/master/bigchain/bigchain.go>`_
 * `Java driver <https://github.com/authenteq/java-bigchaindb-driver>`_
 * `Ruby driver <https://github.com/LicenseRocks/bigchaindb_ruby>`_
-* `Ruby library for preparing/signing transactions and submitting them or querying a BigchainDB/IPDB node (MIT licensed) <https://rubygems.org/gems/bigchaindb>`_
+* `Ruby library for preparing/signing transactions and submitting them or querying a BigchainDB node (MIT licensed) <https://rubygems.org/gems/bigchaindb>`_

--- a/docs/server/source/production-deployment-template/architecture.rst
+++ b/docs/server/source/production-deployment-template/architecture.rst
@@ -1,7 +1,8 @@
-Architecture of an IPDB Node
-============================
+Architecture of a Testnet Node
+==============================
 
-An IPDB Production deployment is hosted on a Kubernetes cluster and includes:
+Each node in the `BigchainDB Testnet <https://testnet.bigchaindb.com/>`_ 
+is hosted on a Kubernetes cluster and includes:
 
 * NGINX, OpenResty, BigchainDB and MongoDB
   `Kubernetes Services <https://kubernetes.io/docs/concepts/services-networking/service/>`_.

--- a/docs/server/source/quickstart.md
+++ b/docs/server/source/quickstart.md
@@ -50,10 +50,10 @@ Create a BigchainDB transaction and post it to a BigchainDB network in 20 second
 
 ## Develop an App
 
-To develop an app that talks to a BigchainDB network, you'll want a test network to test it against. IPDB is the Interplanetary Database. The IPDB Test Network is a free-to-use, publicly-available BigchainDB network that you can test against.
+To develop an app that talks to a BigchainDB network, you'll want a test network to test it against. The BigchainDB Testnet is a free-to-use, publicly-available BigchainDB network that you can test against.
 
 <div class="buttondiv">
-    <a class="button" href="https://ipdb.io/#getstarted">Get started with IPDB</a>
+    <a class="button" href="https://testnet.bigchaindb.com/">Get started with the BigchainDB Testnet</a>
 </div>
 
 Regardless of which BigchainDB network you use, you'll probably use one of the [BigchainDB drivers or tools](https://www.bigchaindb.com/getstarted/#drivers).


### PR DESCRIPTION
This PR is for the `tendermint` branch. It changes the "IPDB Testnet" to the "BigchainDB Testnet" in the docs (root and server docs).

The "IPDB Transaction Spec" will continue to be called that for now, so that wasn't changed.

The image in `docs/server/source/_static/arch.jpg` should also be updated but it needs more updates than just the "IPDB Node" label (e.g. it needs to add the Tendermint stuff), so I'll leave that for another PR.