### PR TITLE
Updated all refs to the IPDB Transaction Spec and its URL

### DIFF
--- a/docs/root/source/assets.rst
+++ b/docs/root/source/assets.rst
@@ -13,4 +13,4 @@ BigchainDB can store data of any kind (within reason), but it's designed to be p
 
 .. note::
 
-   We used the word "owners" somewhat loosely above. A more accurate word might be fulfillers, signers, controllers, or transfer-enablers. See the `note about "owners" in the IPDB Transaction Spec <https://the-ipdb-transaction-spec.readthedocs.io/en/latest/ownership.html>`_.
+   We used the word "owners" somewhat loosely above. A more accurate word might be fulfillers, signers, controllers, or transfer-enablers. See the note about "owners" in the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.

--- a/docs/root/source/permissions.rst
+++ b/docs/root/source/permissions.rst
@@ -15,8 +15,8 @@ To spend/transfer an unspent output, a user (or group of users) must fulfill the
 - "…three of these four people must sign."
 - "…either Bob must sign, or both Tom and Sylvia must sign."
 
-For details, see
-`the documentation about conditions in the IPDB Transaction Spec <https://the-ipdb-transaction-spec.readthedocs.io/en/latest/transaction-components/conditions.html>`_.
+For details, see the section about conditions
+in the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.
 
 Once an output has been spent, it can't be spent again: *nobody* has permission to do that. That is, BigchainDB doesn't permit anyone to "double spend" an output.
 

--- a/docs/root/source/smart-contracts.rst
+++ b/docs/root/source/smart-contracts.rst
@@ -15,4 +15,4 @@ Crypto-conditions can be quite complex. They can't include loops or recursion an
 
 .. note::
 
-   We used the word "owners" somewhat loosely above. A more accurate word might be fulfillers, signers, controllers, or transfer-enablers. See the `note about "owners" in the IPDB Transaction Spec <https://the-ipdb-transaction-spec.readthedocs.io/en/latest/ownership.html>`_.
+   We used the word "owners" somewhat loosely above. A more accurate word might be fulfillers, signers, controllers, or transfer-enablers. See the note about "owners" in the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.

--- a/docs/root/source/transaction-concepts.md
+++ b/docs/root/source/transaction-concepts.md
@@ -30,14 +30,14 @@ Each output also has an associated condition: the condition that must be met
 BigchainDB supports a variety of conditions,
 a subset of the [Interledger Protocol (ILP)](https://interledger.org/)
 crypto-conditions. For details, see
-[the documentation about conditions in the IPDB Transaction Spec](https://the-ipdb-transaction-spec.readthedocs.io/en/latest/transaction-components/conditions.html).
+the section about conditions in the [IPDB Transaction Spec](https://github.com/ipdb/ipdb-tx-spec).
 
 Each output also has a list of all the public keys associated
 with the conditions on that output.
 Loosely speaking, that list might be interpreted as the list of "owners."
 A more accurate word might be fulfillers, signers, controllers,
 or transfer-enablers.
-See the [note about "owners" in the IPDB Transaction Spec](https://the-ipdb-transaction-spec.readthedocs.io/en/latest/ownership.html).
+See the note about "owners" in the [IPDB Transaction Spec](https://github.com/ipdb/ipdb-tx-spec).
 
 A CREATE transaction must be signed by all the owners.
 (If you're looking for that signature,
@@ -87,7 +87,7 @@ things. We documented those things in a post on *The BigchainDB Blog*:
 ["What is a Valid Transaction in BigchainDB?"](https://blog.bigchaindb.com/what-is-a-valid-transaction-in-bigchaindb-9a1a075a9598)
 (Note: That post was about BigchainDB Server v1.0.0.)
 
-The [IPDB Transaction Spec documents the conditions for a transaction to be valid](https://the-ipdb-transaction-spec.readthedocs.io/en/latest/transaction-validation.html).
+The [IPDB Transaction Spec](https://github.com/ipdb/ipdb-tx-spec) documents the conditions for a transaction to be valid.
 
 ## Example Transactions
 

--- a/docs/server/source/appendices/cryptography.rst
+++ b/docs/server/source/appendices/cryptography.rst
@@ -1,9 +1,8 @@
 Cryptography
 ============
 
-See `the IPDB Transaction Spec
-<https://the-ipdb-transaction-spec.readthedocs.io/en/latest/>`_,
-especially the pages about:
+See the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_,
+especially the sections about:
 
 - Cryptographic Hashes
 - Cryptographic Keys & Signatures

--- a/docs/server/source/appendices/json-serialization.rst
+++ b/docs/server/source/appendices/json-serialization.rst
@@ -1,6 +1,5 @@
 JSON Serialization
 ==================
 
-See the page about JSON Serialization & Deserialization
-in `the IPDB Transaction Spec
-<https://the-ipdb-transaction-spec.readthedocs.io/en/latest/>`_.
+See the section about JSON Serialization & Deserialization
+in the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.

--- a/docs/server/source/data-models/asset-model.rst
+++ b/docs/server/source/data-models/asset-model.rst
@@ -1,5 +1,4 @@
 The Asset Model
 ===============
 
-See `the IPDB Transaction Spec
-<https://the-ipdb-transaction-spec.readthedocs.io/en/latest/>`_.
+See the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.

--- a/docs/server/source/data-models/block-model.rst
+++ b/docs/server/source/data-models/block-model.rst
@@ -32,8 +32,8 @@ To compute it, 1) construct an :term:`associative array` ``d`` containing
 ``block.timestamp``, ``block.transactions``, ``block.node_pubkey``,
 ``block.voters``, and their values. 2) compute ``id = hash_of_aa(d)``.
 There's pseudocode for the ``hash_of_aa()`` function
-in the `IPDB Transaction Spec page about cryptographic hashes
-<https://the-ipdb-transaction-spec.readthedocs.io/en/latest/common-operations/crypto-hashes.html#computing-the-hash-of-an-associative-array>`_.
+in the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_
+section about cryptographic hashes.
 The result (``id``) is a string: the block ID.
 An example is ``"b60adf655932bf47ef58c0bfb2dd276d4795b94346b36cbb477e10d7eb02cea8"``
 
@@ -56,8 +56,8 @@ A list of the :ref:`transactions <The Transaction Model>` included in the block.
 
 The public key of the node that created the block.
 It's a string.
-See the `IPDB Transaction Spec page about cryptographic keys & signatures
-<https://the-ipdb-transaction-spec.readthedocs.io/en/latest/common-operations/crypto-keys-and-sigs.html>`_.
+See the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_
+section about cryptographic keys & signatures.
 
 
 **block.voters**
@@ -82,8 +82,8 @@ To compute that:
    where ``private_key`` is the node's private key
    (i.e. ``node_pubkey`` and ``private_key`` are a key pair). There's pseudocode
    for the ``sig_of_aa()`` function
-   on `the IPDB Transaction Spec page about cryptographic keys and signatures 
-   <https://the-ipdb-transaction-spec.readthedocs.io/en/latest/common-operations/crypto-keys-and-sigs.html#computing-the-signature-of-an-associative-array>`_.
+   on the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_
+   section about cryptographic keys and signatures.
 
 .. note::
 

--- a/docs/server/source/data-models/conditions.rst
+++ b/docs/server/source/data-models/conditions.rst
@@ -1,5 +1,4 @@
 Conditions
 ==========
 
-See `the IPDB Transaction Spec
-<https://the-ipdb-transaction-spec.readthedocs.io/en/latest/>`_.
+See the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.

--- a/docs/server/source/data-models/inputs-outputs.rst
+++ b/docs/server/source/data-models/inputs-outputs.rst
@@ -1,5 +1,4 @@
 Inputs and Outputs
 ==================
 
-See `the IPDB Transaction Spec
-<https://the-ipdb-transaction-spec.readthedocs.io/en/latest/>`_.
+See the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.

--- a/docs/server/source/data-models/transaction-model.rst
+++ b/docs/server/source/data-models/transaction-model.rst
@@ -1,8 +1,7 @@
 The Transaction Model
 =====================
 
-See `the IPDB Transaction Spec
-<https://the-ipdb-transaction-spec.readthedocs.io/en/latest/>`_.
+See the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.
 
 
 The Transaction Schema
@@ -11,7 +10,8 @@ The Transaction Schema
 BigchainDB checks all transactions (JSON documents)
 against a formal schema defined
 in some `JSON Schema <http://json-schema.org/>`_ files.
-Those files are part of the IPDB Transaction Spec.
+Those files are part of the 
+`IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.
 Their official source is the ``tx_schema/`` directory
 in the `ipdb/ipdb-tx-spec repository on GitHub
 <https://github.com/ipdb/ipdb-tx-spec>`_,

--- a/docs/server/source/data-models/vote-model.rst
+++ b/docs/server/source/data-models/vote-model.rst
@@ -35,8 +35,8 @@ The JSON Keys in a Vote
 The public key of the node which cast this vote.
 It's a string.
 For more information about public keys,
-see the `IPDB Transaction Spec page about cryptographic keys and signatures
-<https://the-ipdb-transaction-spec.readthedocs.io/en/latest/common-operations/crypto-keys-and-sigs.html>`_.
+see the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_
+section about cryptographic keys and signatures.
 
 
 **vote.voting_for_block**
@@ -92,9 +92,8 @@ To compute that:
 #. Compute ``signature = sig_of_aa(d, private_key)``, where ``private_key``
    is the node's private key (i.e. ``node_pubkey`` and ``private_key`` are a key pair).
    There's pseudocode for the ``sig_of_aa()`` function
-   on `the IPDB Transaction Spec page about cryptographic keys and signatures
-   <https://the-ipdb-transaction-spec.readthedocs.io/en/latest/common-operations/crypto-keys-and-sigs.html#computing-the-signature-of-an-associative-array>`_.
-
+   on the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_
+   section about cryptographic keys and signatures.
 
 The Vote Schema
 ---------------


### PR DESCRIPTION
The location (URL) IPDB Transaction Spec changed, so I updated all references to it in the root and server docs.

The IPDB Transaction Spec is now just a single page with sections, so I changed all references to "pages" in it to be references to "sections."

I realize that the pages about blocks and votes might go away or change substantially, but that can be done in a separate PR.