### PR TITLE
Pin yarl version to <1.0 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ install_requires = [
     'aiohttp~=2.0',
     'python-rapidjson-schema==0.1.1',
     'statsd==3.2.1',
+    'yarl>=0.11,<1.0',
 ]
 
 setup(


### PR DESCRIPTION
## Description
- We need to pin this dependency because version 1.0.0 of yarl
  does not expose `unquote` and if we do not pin it, the latest
  version >=1.*.* is downloaded and `aiohttp` expects it.
- This can also be fixed on `aiohttp`, but meanwhile :)

## Issues This PR Fixes
Fixes #2001 