### PR TITLE
Fixing Vagrant tutorial

### DIFF
--- a/pkg/Vagrantfile
+++ b/pkg/Vagrantfile
@@ -27,13 +27,7 @@ hosts_config = File.open(HOSTS_FILE, 'w+')
 # TODO: (muawiakh) Add support for Docker, AWS, Azure
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   instances_config["bdb_hosts"].each do |instance|
-    # Workaround till canonical fixes https://bugs.launchpad.net/cloud-images/+bug/1569237
-    # using -u ubuntu as remote user, conventionally vagrant boxes use `vagrant` user
-    if instance["box"]["name"] == "ubuntu/xenial64"
-      hosts_config.puts("#{instance["name"]} ansible_user=ubuntu")
-    else
-      hosts_config.puts("#{instance["name"]} ansible_user=vagrant")
-    end
+    hosts_config.puts("#{instance["name"]} ansible_user=vagrant")
     config.vm.define instance['name'] do |bdb|
       # Workaround until vagrant cachier plugin supports dnf
       if !(instance["box"]["name"].include? "fedora")


### PR DESCRIPTION
## Description

The [Vagrant tutorial](https://docs.bigchaindb.com/projects/server/en/latest/appendices/run-with-vagrant.html) was broken. The issue was with `ubuntu/xenial64` basebox, conventionally all the Vagrant boxes have `username/password` set to `vagrant/vagrant` but that got changed by Ubuntu, you can see the discussion here: https://bugs.launchpad.net/cloud-images/+bug/1569237

To cater for this scenario, in our Vagrant file we were handling the `ubuntu` user for the `ubuntu/xenial64` box. We also mentioned this our Vagrant file [L30](https://github.com/bigchaindb/bigchaindb/blob/master/pkg/Vagrantfile#L30), [L31](https://github.com/bigchaindb/bigchaindb/blob/master/pkg/Vagrantfile#L31).

But, this has been fixed in the latest `ubuntu/xenial64  >= v20180112.0.0` boxes i.e. reverted back to `vagrant` user, so the workaround is not needed anymore.

## Issues This PR Fixes
Fixes #2012 

Thanks to @kazuakiishiguro for filing the ticket.