### PR TITLE
Add tendermint marker to pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests/
 norecursedirs = .* *.egg *.egg-info env* devenv* docs
+addopts = -m tendermint


### PR DESCRIPTION
This is convenient when developing and running the tests as one does not need to pass the `-m tendermint` option to `pytest`.