### PR TITLE
Mount other volumes for docker-compose dev

### DIFF
--- a/docker-compose.tendermint.yml
+++ b/docker-compose.tendermint.yml
@@ -18,6 +18,11 @@ services:
     volumes:
       - ./bigchaindb:/usr/src/app/bigchaindb
       - ./tests:/usr/src/app/tests
+      - ./docs:/usr/src/app/docs
+      - ./setup.py:/usr/src/app/setup.py
+      - ./setup.cfg:/usr/src/app/setup.cfg
+      - ./pytest.ini:/usr/src/app/pytest.ini
+      - ./tox.ini:/usr/src/app/tox.ini
     environment:
       BIGCHAINDB_DATABASE_BACKEND: localmongodb
       BIGCHAINDB_DATABASE_HOST: mdb


### PR DESCRIPTION
This is needed when developing and editing some files and wanting to view the effects in the container.