### PR TITLE
Changed constructed/allowed transaction 'version' from '1.0' to '2.0'

### DIFF
--- a/bigchaindb/common/schema/__init__.py
+++ b/bigchaindb/common/schema/__init__.py
@@ -22,7 +22,7 @@ def _load_schema(name):
     return path, (schema, fast_schema)
 
 
-TX_SCHEMA_VERSION = 'v1.0'
+TX_SCHEMA_VERSION = 'v2.0'
 
 TX_SCHEMA_PATH, TX_SCHEMA_COMMON = _load_schema('transaction_' +
                                                 TX_SCHEMA_VERSION)

--- a/bigchaindb/common/schema/transaction_create_v2.0.yaml
+++ b/bigchaindb/common/schema/transaction_create_v2.0.yaml
@@ -1,0 +1,30 @@
+---
+"$schema": "http://json-schema.org/draft-04/schema#"
+type: object
+title: Transaction Schema - CREATE/GENESIS specific constraints
+required:
+- asset
+- inputs
+properties:
+  asset:
+    additionalProperties: false
+    properties:
+      data:
+        anyOf:
+        - type: object
+          additionalProperties: true
+        - type: 'null'
+    required:
+    - data
+  inputs:
+    type: array
+    title: "Transaction inputs"
+    maxItems: 1
+    minItems: 1
+    items:
+      type: "object"
+      required:
+      - fulfills
+      properties:
+        fulfills:
+            type: "null"

--- a/bigchaindb/common/schema/transaction_transfer_v2.0.yaml
+++ b/bigchaindb/common/schema/transaction_transfer_v2.0.yaml
@@ -1,0 +1,29 @@
+---
+"$schema": "http://json-schema.org/draft-04/schema#"
+type: object
+title: Transaction Schema - TRANSFER specific properties
+required:
+- asset
+properties:
+  asset:
+    additionalProperties: false
+    properties:
+      id:
+        "$ref": "#/definitions/sha3_hexdigest"
+    required:
+    - id
+  inputs:
+    type: array
+    title: "Transaction inputs"
+    minItems: 1
+    items:
+      type: "object"
+      required:
+      - fulfills
+      properties:
+        fulfills:
+            type: "object"
+definitions:
+  sha3_hexdigest:
+    pattern: "[0-9a-f]{64}"
+    type: string

--- a/bigchaindb/common/schema/transaction_v2.0.yaml
+++ b/bigchaindb/common/schema/transaction_v2.0.yaml
@@ -1,0 +1,163 @@
+---
+"$schema": "http://json-schema.org/draft-04/schema#"
+type: object
+additionalProperties: false
+title: Transaction Schema
+required:
+- id
+- inputs
+- outputs
+- operation
+- metadata
+- asset
+- version
+properties:
+  id:
+    anyOf:
+    - "$ref": "#/definitions/sha3_hexdigest"
+    - type: 'null'
+  operation:
+    "$ref": "#/definitions/operation"
+  asset:
+    "$ref": "#/definitions/asset"
+  inputs:
+    type: array
+    title: "Transaction inputs"
+    items:
+      "$ref": "#/definitions/input"
+  outputs:
+    type: array
+    items:
+      "$ref": "#/definitions/output"
+  metadata:
+    "$ref": "#/definitions/metadata"
+  version:
+    type: string
+    pattern: "^2\\.0$"
+definitions:
+  offset:
+    type: integer
+    minimum: 0
+  base58:
+    pattern: "[1-9a-zA-Z^OIl]{43,44}"
+    type: string
+  public_keys:
+    anyOf:
+    - type: array
+      items:
+        "$ref": "#/definitions/base58"
+    - type: 'null'
+  sha3_hexdigest:
+    pattern: "[0-9a-f]{64}"
+    type: string
+  uuid4:
+    pattern: "[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}"
+    type: string
+  operation:
+    type: string
+    enum:
+    - CREATE
+    - TRANSFER
+    - GENESIS
+  asset:
+    type: object
+    additionalProperties: false
+    properties:
+      id:
+        "$ref": "#/definitions/sha3_hexdigest"
+      data:
+        anyOf:
+        - type: object
+          additionalProperties: true
+        - type: 'null'
+  output:
+    type: object
+    additionalProperties: false
+    required:
+    - amount
+    - condition
+    - public_keys
+    properties:
+      amount:
+        type: string
+        pattern: "^[0-9]{1,20}$"
+      condition:
+        type: object
+        additionalProperties: false
+        required:
+        - details
+        - uri
+        properties:
+          details:
+            "$ref": "#/definitions/condition_details"
+          uri:
+            type: string
+            pattern: "^ni:///sha-256;([a-zA-Z0-9_-]{0,86})[?]\
+              (fpt=(ed25519|threshold)-sha-256(&)?|cost=[0-9]+(&)?|\
+              subtypes=ed25519-sha-256(&)?){2,3}$"
+      public_keys:
+        "$ref": "#/definitions/public_keys"
+  input:
+    type: "object"
+    additionalProperties: false
+    required:
+    - owners_before
+    - fulfillment
+    properties:
+      owners_before:
+        "$ref": "#/definitions/public_keys"
+      fulfillment:
+        anyOf:
+        - type: string
+          pattern: "^[a-zA-Z0-9_-]*$"
+        - "$ref": "#/definitions/condition_details"
+      fulfills:
+        anyOf:
+        - type: 'object'
+          additionalProperties: false
+          required:
+          - output_index
+          - transaction_id
+          properties:
+            output_index:
+              "$ref": "#/definitions/offset"
+            transaction_id:
+              "$ref": "#/definitions/sha3_hexdigest"
+        - type: 'null'
+  metadata:
+    anyOf:
+    - type: object
+      additionalProperties: true
+      minProperties: 1
+    - type: 'null'
+  condition_details:
+    anyOf:
+    - type: object
+      additionalProperties: false
+      required:
+      - type
+      - public_key
+      properties:
+        type:
+          type: string
+          pattern: "^ed25519-sha-256$"
+        public_key:
+          "$ref": "#/definitions/base58"
+    - type: object
+      additionalProperties: false
+      required:
+      - type
+      - threshold
+      - subconditions
+      properties:
+        type:
+          type: "string"
+          pattern: "^threshold-sha-256$"
+        threshold:
+          type: integer
+          minimum: 1
+          maximum: 100
+        subconditions:
+          type: array
+          items:
+            "$ref": "#/definitions/condition_details"

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -475,7 +475,7 @@ class Transaction(object):
     TRANSFER = 'TRANSFER'
     GENESIS = 'GENESIS'
     ALLOWED_OPERATIONS = (CREATE, TRANSFER, GENESIS)
-    VERSION = '1.0'
+    VERSION = '2.0'
 
     def __init__(self, operation, asset, inputs=None, outputs=None,
                  metadata=None, version=None, hash_id=None):

--- a/docs/server/source/data-models/transaction-model.rst
+++ b/docs/server/source/data-models/transaction-model.rst
@@ -2,21 +2,3 @@ The Transaction Model
 =====================
 
 See the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.
-
-
-The Transaction Schema
-----------------------
-
-BigchainDB checks all transactions (JSON documents)
-against a formal schema defined
-in some `JSON Schema <http://json-schema.org/>`_ files.
-Those files are part of the 
-`IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.
-Their official source is the ``tx_schema/`` directory
-in the `ipdb/ipdb-tx-spec repository on GitHub
-<https://github.com/ipdb/ipdb-tx-spec>`_,
-but BigchainDB Server uses copies of those files;
-those copies can be found
-in the ``bigchaindb/common/schema/`` directory
-in the `bigchaindb/bigchaindb repository on GitHub
-<https://github.com/bigchaindb/bigchaindb>`_.

--- a/tests/validation/test_transaction_structure.py
+++ b/tests/validation/test_transaction_structure.py
@@ -237,7 +237,7 @@ def test_unsupported_condition_type():
 # Version
 
 def test_validate_version(b, create_tx):
-    create_tx.version = '1.0'
+    create_tx.version = '2.0'
     create_tx.sign([b.me_private])
     validate(create_tx)
 


### PR DESCRIPTION
Resolves #1907 

- Created three new JSON Schema files for the v2.0 transaction schema, based on the v1.0 files. The only change is the allowed value of `version` (from `"^1\\.0$"` to `"^2\\.0$"`).
- I didn't delete the v1.0 JSON Schema files because we might want those some day (to validate old transactions).
- Updated the `__init__.py` in the directory with the JSON Schema files so that it now uses the version 2.0 JSON Schema files.
- Updated all relevant tests. I only found one, in `tests/validation/test_transaction_structure.py`
- Updated `VERSION` in `common/transaction.py`
- Checked to make sure the example HTTP API docs show "version" with value "2.0". They do.
- Updated the docs page about "The Transaction Model". It just points to the IPDB Transaction Spec.
- If someone submits a transaction with "version" having value "1.0" then the error message comes from the JSON Schema checker.
