### PR TITLE
Problem: to get tx utxoset & inputs is cumbersome

### DIFF
--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -1,7 +1,12 @@
 """Transaction related models to parse and construct transaction
 payloads.
 
+Attributes:
+    UnspentOutput (namedtuple): Object holding the information
+        representing an unspent output.
+
 """
+from collections import namedtuple
 from copy import deepcopy
 from functools import reduce
 
@@ -17,6 +22,17 @@ from bigchaindb.common.exceptions import (KeypairMismatchException,
                                           AmountError, AssetIdMismatch,
                                           ThresholdTooDeep)
 from bigchaindb.common.utils import serialize
+
+
+UnspentOutput = namedtuple(
+    'UnspentOutput', (
+        'transaction_id',
+        'output_index',
+        'amount',
+        'asset_id',
+        'condition_uri',
+    )
+)
 
 
 class Input(object):
@@ -531,6 +547,35 @@ class Transaction(object):
         self.outputs = outputs or []
         self.metadata = metadata
         self._id = hash_id
+
+    @property
+    def unspent_outputs(self):
+        """UnspentOutput: The outputs of this transaction, in a data
+        structure containing relevant information for storing them in
+        a UTXO set, and performing validation.
+        """
+        if self.operation == Transaction.CREATE:
+            self._asset_id = self._id
+        elif self.operation == Transaction.TRANSFER:
+            self._asset_id = self.asset['id']
+        return (UnspentOutput(
+            transaction_id=self._id,
+            output_index=output_index,
+            amount=output.amount,
+            asset_id=self._asset_id,
+            condition_uri=output.fulfillment.condition_uri,
+        ) for output_index, output in enumerate(self.outputs))
+
+    @property
+    def spent_outputs(self):
+        """tuple of :obj:`dict`: Inputs of this transaction. Each input
+        is represented as a dictionary containing a transaction id and
+        output index.
+        """
+        return (
+            input_.fulfills.to_dict()
+            for input_ in self.inputs if input_.fulfills
+        )
 
     @property
     def serialized(self):

--- a/tests/common/test_transaction.py
+++ b/tests/common/test_transaction.py
@@ -5,6 +5,7 @@ import json
 from copy import deepcopy
 
 from base58 import b58encode, b58decode
+from cryptoconditions import Ed25519Sha256
 from pytest import mark, raises
 from sha3 import sha3_256
 
@@ -1007,3 +1008,42 @@ def test_output_from_dict_invalid_amount(user_output):
     out['amount'] = 'a'
     with raises(AmountError):
         Output.from_dict(out)
+
+
+def test_unspent_outputs_property(merlin, alice, bob, carol):
+    from bigchaindb.common.transaction import Transaction
+    tx = Transaction.create(
+        [merlin.public_key],
+        [([alice.public_key], 1),
+         ([bob.public_key], 2),
+         ([carol.public_key], 3)],
+        asset={'hash': '06e47bcf9084f7ecfd2a2a2ad275444a'},
+    ).sign([merlin.private_key])
+    unspent_outputs = list(tx.unspent_outputs)
+    assert len(unspent_outputs) == 3
+    assert all(utxo.transaction_id == tx.id for utxo in unspent_outputs)
+    assert all(utxo.asset_id == tx.id for utxo in unspent_outputs)
+    assert all(
+        utxo.output_index == i for i, utxo in enumerate(unspent_outputs))
+    unspent_output_0 = unspent_outputs[0]
+    assert unspent_output_0.amount == 1
+    assert unspent_output_0.condition_uri == Ed25519Sha256(
+        public_key=b58decode(alice.public_key)).condition_uri
+    unspent_output_1 = unspent_outputs[1]
+    assert unspent_output_1.amount == 2
+    assert unspent_output_1.condition_uri == Ed25519Sha256(
+        public_key=b58decode(bob.public_key)).condition_uri
+    unspent_output_2 = unspent_outputs[2]
+    assert unspent_output_2.amount == 3
+    assert unspent_output_2.condition_uri == Ed25519Sha256(
+        public_key=b58decode(carol.public_key)).condition_uri
+
+
+def test_spent_outputs_property(signed_transfer_tx):
+    spent_outputs = list(signed_transfer_tx.spent_outputs)
+    tx = signed_transfer_tx.to_dict()
+    assert len(spent_outputs) == 1
+    spent_output = spent_outputs[0]
+    assert spent_output['transaction_id'] == tx['inputs'][0]['fulfills']['transaction_id']
+    assert spent_output['output_index'] == tx['inputs'][0]['fulfills']['output_index']
+    # assert spent_output._asdict() == tx['inputs'][0]['fulfills']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -311,6 +311,22 @@ def carol_pubkey(carol):
 
 
 @pytest.fixture
+def merlin():
+    from bigchaindb.common.crypto import generate_key_pair
+    return generate_key_pair()
+
+
+@pytest.fixture
+def merlin_privkey(merlin):
+    return merlin.private_key
+
+
+@pytest.fixture
+def merlin_pubkey(merlin):
+    return merlin.public_key
+
+
+@pytest.fixture
 def b():
     from bigchaindb import Bigchain
     return Bigchain()


### PR DESCRIPTION
Problem: to get tx utxoset & inputs is cumbersome

Solution: add properties to more easily get the utxoset and inputs of a transaction

This is prerequisite work for the utxoset work that deals with `bigchaindb/tendermint/lib.py`. It was extracted out to make the review easier and simpler.