### PR TITLE
Same as PR #2056 but merging into master branch

### DIFF
--- a/docs/root/source/index.rst
+++ b/docs/root/source/index.rst
@@ -62,9 +62,6 @@ At a high level, one can communicate with a BigchainDB cluster (set of nodes) us
      <a class="button" href="https://docs.bigchaindb.com/projects/js-driver/en/latest/index.html">JavaScript Driver Docs</a>
    </div>
    <div class="buttondiv">
-     <a class="button" href="https://docs.bigchaindb.com/projects/cli/en/latest/">Command Line Transaction Tool</a>
-   </div>
-   <div class="buttondiv">
      <a class="button" href="http://docs.bigchaindb.com/projects/server/en/latest/index.html">Server Docs</a>
    </div>
    <div class="buttondiv">

--- a/docs/server/source/drivers-clients/index.rst
+++ b/docs/server/source/drivers-clients/index.rst
@@ -6,12 +6,6 @@ Libraries and Tools Maintained by the BigchainDB Team
 
 * `Python Driver <https://docs.bigchaindb.com/projects/py-driver/en/latest/index.html>`_
 * `JavaScript / Node.js Driver <https://github.com/bigchaindb/js-bigchaindb-driver>`_
-* `The Transaction CLI <https://docs.bigchaindb.com/projects/cli/en/latest/>`_ is
-  a command-line interface for building BigchainDB transactions.
-  You may be able to call it from inside the language of
-  your choice, and then use :ref:`the HTTP API <The HTTP Client-Server API>`
-  to post transactions.
-
 
 Community-Driven Libraries and Tools
 ------------------------------------


### PR DESCRIPTION
This pull request is the same as PR #2056 but merging into `master` branch rather than the `tendermint` branch.

The "root docs" show whatever is on the latest `master` branch so once this gets merged, the "root docs" will no longer show the big link/button to the CLI Transaction Tool.