### PR TITLE
Remove the HTTP API docs for the /statuses & /votes endpoints

### DIFF
--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -67,6 +67,14 @@ Content-Type: application/json
 """
 
 
+TPLS['post-tx-response'] = """\
+HTTP/1.1 202 Accepted
+Content-Type: application/json
+
+%(tx)s
+"""
+
+
 TPLS['get-block-request'] = """\
 GET /api/v1/blocks/%(blockid)s HTTP/1.1
 Host: example.com

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -67,68 +67,6 @@ Content-Type: application/json
 """
 
 
-TPLS['post-tx-response'] = """\
-HTTP/1.1 202 Accepted
-Content-Type: application/json
-
-%(tx)s
-"""
-
-
-TPLS['get-statuses-tx-request'] = """\
-GET /statuses?transaction_id=%(txid)s HTTP/1.1
-Host: example.com
-
-"""
-
-
-TPLS['get-statuses-tx-invalid-response'] = """\
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-{
-  "status": "invalid"
-}
-"""
-
-
-TPLS['get-statuses-tx-valid-response'] = """\
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-{
-  "status": "valid"
-}
-"""
-
-
-TPLS['get-statuses-block-request'] = """\
-GET /api/v1/statuses?block_id=%(blockid)s HTTP/1.1
-Host: example.com
-
-"""
-
-
-TPLS['get-statuses-block-invalid-response'] = """\
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-{
-  "status": "invalid"
-}
-"""
-
-
-TPLS['get-statuses-block-valid-response'] = """\
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-{
-  "status": "valid"
-}
-"""
-
-
 TPLS['get-block-request'] = """\
 GET /api/v1/blocks/%(blockid)s HTTP/1.1
 Host: example.com
@@ -156,21 +94,6 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 %(block_list)s
-"""
-
-
-TPLS['get-vote-request'] = """\
-GET /api/v1/votes?block_id=%(blockid)s HTTP/1.1
-Host: example.com
-
-"""
-
-
-TPLS['get-vote-response'] = """\
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-[%(vote)s]
 """
 
 
@@ -256,18 +179,6 @@ def main():
     ]
     ctx['block_list'] = pretty_json(block_list)
 
-
-    # block = Block(transactions=[tx], node_pubkey=node_public, voters=[node_public], signature=signature)
-    block_transfer = Block(transactions=[tx_transfer], node_pubkey=node_public,
-                           voters=[node_public], signature=signature)
-    ctx['block_transfer'] = pretty_json(block_transfer.to_dict())
-
-    # vote
-    vblock = Block(transactions=[tx], node_pubkey=node_public, voters=[node_public], signature=signature)
-    DUMMY_SHA3 = '0123456789abcdef' * 4
-    b = Bigchain(public_key=node_public, private_key=node_private)
-    vote = b.vote(vblock.id, DUMMY_SHA3, True)
-    ctx['vote'] = pretty_json(vote)
 
     base_path = os.path.join(os.path.dirname(__file__),
                              'source/http-samples')

--- a/docs/server/source/http-client-server-api.rst
+++ b/docs/server/source/http-client-server-api.rst
@@ -287,71 +287,6 @@ unspent outputs.
    :statuscode 400: The request wasn't understood by the server, e.g. the ``public_key`` querystring was not included in the request.
 
 
-Statuses
---------------------------------
-
-.. http:get:: /api/v1/statuses
-
-   Get the status of an asynchronously written transaction or block by their id.
-
-   :query string transaction_id: transaction ID
-   :query string block_id: block ID
-
-   .. note::
-
-        Exactly one of the ``transaction_id`` or ``block_id`` query parameters must be
-        used together with this endpoint (see below for getting `transaction
-        statuses <#get--statuses?tx_id=tx_id>`_ and `block statuses
-        <#get--statuses?block_id=block_id>`_).
-
-.. _get_status_of_transaction:
-
-.. http:get:: /api/v1/statuses?transaction_id={transaction_id}
-
-    Get the status of a transaction.
-
-    The possible status values are ``undecided``, ``valid`` or ``backlog``.
-    If a transaction in neither of those states is found, a ``404 Not Found``
-    HTTP status code is returned. `We're currently looking into ways to unambigously let the user know about a transaction's status that was included in an invalid block. <https://github.com/bigchaindb/bigchaindb/issues/1039>`_
-
-   **Example request**:
-
-   .. literalinclude:: http-samples/get-statuses-tx-request.http
-      :language: http
-
-   **Example response**:
-
-   .. literalinclude:: http-samples/get-statuses-tx-valid-response.http
-      :language: http
-
-   :resheader Content-Type: ``application/json``
-
-   :statuscode 200: A transaction with that ID was found.
-   :statuscode 404: A transaction with that ID was not found.
-
-
-.. http:get:: /api/v1/statuses?block_id={block_id}
-
-    Get the status of a block.
-
-    The possible status values are ``undecided``, ``valid`` or ``invalid``.
-
-   **Example request**:
-
-   .. literalinclude:: http-samples/get-statuses-block-request.http
-      :language: http
-
-   **Example response**:
-
-   .. literalinclude:: http-samples/get-statuses-block-valid-response.http
-      :language: http
-
-   :resheader Content-Type: ``application/json``
-
-   :statuscode 200: A block with that ID was found.
-   :statuscode 404: A block with that ID was not found.
-
-
 Assets
 --------------------------------
 
@@ -672,37 +607,6 @@ Blocks
 
    :statuscode 200: The request was properly formed and zero or more blocks were found containing the specified ``transaction_id``.
    :statuscode 400: The request wasn't understood by the server, e.g. just requesting ``/blocks``, without defining ``transaction_id``.
-
-
-Votes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. http:get:: /api/v1/votes?block_id={block_id}
-
-   Retrieve a list of votes for a certain block with ID ``block_id``.
-   To check for the validity of a vote, a user of this endpoint needs to
-   perform the `following steps: <https://github.com/bigchaindb/bigchaindb/blob/8ebd93ed3273e983f5770b1617292aadf9f1462b/bigchaindb/util.py#L119>`_
-
-   1. Check if the vote's ``node_pubkey`` is allowed to vote.
-   2. Verify the vote's signature against the vote's body (``vote.vote``) and ``node_pubkey``.
-
-
-   :query string block_id: The block ID to filter the votes.
-
-   **Example request**:
-
-   .. literalinclude:: http-samples/get-vote-request.http
-      :language: http
-
-   **Example response**:
-
-   .. literalinclude:: http-samples/get-vote-response.http
-      :language: http
-
-   :resheader Content-Type: ``application/json``
-
-   :statuscode 200: A list of votes voting for a block with ID ``block_id`` was found and returned.
-   :statuscode 400: The request wasn't understood by the server, e.g. just requesting ``/votes``, without defining ``block_id``.
 
 
 .. _determining-the-api-root-url:

--- a/docs/server/source/http-client-server-api.rst
+++ b/docs/server/source/http-client-server-api.rst
@@ -130,11 +130,7 @@ Transactions
    <http://tendermint.readthedocs.io/projects/tools/en/master/using-tendermint.html#broadcast-api>`_ with three different modes to post transactions.
    By setting the mode, a new transaction can be pushed with a different mode than the default. The default mode is ``async``, which
    will return immediately and not wait to see if the transaction is valid. The ``sync`` mode will return after the transaction is validated, while ``commit``
-   returns after the transaction is committed to a block.
-
-   .. note::
-
-       This option is only available when using BigchainDB with Tendermint. 
+   returns after the transaction is committed to a block. 
 
    .. note::
    
@@ -160,8 +156,8 @@ Transactions
 
    .. note::
        If the server is returning a ``202`` HTTP status code when ``mode=aysnc`` or ``mode=sync``, then the
-       transaction has been accepted for processing. The client can subscribe to
-       :ref:`WebSocket Event Stream API <The WebSocket Event Stream API>` for listen for comitted transactions.
+       transaction has been accepted for processing. The client can subscribe to the
+       :ref:`WebSocket Event Stream API <The WebSocket Event Stream API>` to listen for comitted transactions.
 
    :resheader Content-Type: ``application/json``
 
@@ -171,7 +167,8 @@ Transactions
 
 .. http:post:: /api/v1/transactions
 
-   This endpoint (without any parameters) will push a new transaction. If BigchainDB is used with Tendermint, the default mode ``async`` is used.
+   This endpoint (without any parameters) will push a new transaction.
+   Since no ``mode`` parameter is included, the default mode is assumed: ``async``.
 
 
 Transaction Outputs


### PR DESCRIPTION
This pull request removes the HTTP API docs for the /statuses & /votes endpoints. It also removes some text which spoke of using Tendermint as a special case, and tidies up some grammar.

Resolves #2036 
