### PR TITLE
Some edits to common/schema/README.md

### DIFF
--- a/bigchaindb/common/schema/README.md
+++ b/bigchaindb/common/schema/README.md
@@ -4,21 +4,23 @@ This directory contains the schemas for the different JSON documents BigchainDB 
 
 The aim is to provide:
 
-- a strict definition of the data structures used in BigchainDB
-- a language independent tool to validate the structure of incoming/outcoming
-  data (there are several ready to use
+- a strict definition of the data structures used in BigchainDB,
+- a language-independent tool to validate the structure of incoming/outcoming
+  data. (There are several ready to use
   [implementations](http://json-schema.org/implementations.html) written in
-  different languages)
+  different languages.)
 
 ## Sources
 
-The file defining the JSON Schema for votes (`vote.yaml`) is BigchainDB-specific.
-
 The files defining the JSON Schema for transactions (`transaction_*.yaml`)
-are copied from the [IPDB Protocol](https://github.com/ipdb/ipdb-protocol).
-If you want to add a new version, you must add it to the IPDB Protocol first.
-(You can't change existing versions. Those were used to validate old transactions
+are based on the [IPDB Transaction Spec](https://github.com/ipdb/ipdb-tx-spec).
+If you want to add a new transaction version,
+you must add it to the IPDB Transaction Spec first.
+(You can't change the JSON Schema files for old versions.
+Those were used to validate old transactions
 and are needed to re-check those transactions.)
+
+The file defining the JSON Schema for votes (`vote.yaml`) is BigchainDB-specific.
 
 ## Learn about JSON Schema
 


### PR DESCRIPTION
- For now, we're just storing the JSON Schema files in the bigchaindb/bigchaindb repository, _not_ in the repository for the IPDB Transaction Spec.
- Fixed some grammar and punctuation.

Note: We can't easily delete the `vote.yaml` file right now. Doing so breaks lots of things so I left it alone.