### PR TITLE
Remove whitepaper refs/links from the master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # BigchainDB Server
 
-BigchainDB is a scalable blockchain database. [The whitepaper](https://www.bigchaindb.com/whitepaper/) explains what that means.
+BigchainDB is a blockchain database.
 
 ## Get Started with BigchainDB Server
 
@@ -21,7 +21,6 @@ BigchainDB is a scalable blockchain database. [The whitepaper](https://www.bigch
 ## Links for Everyone
 
 * [BigchainDB.com](https://www.bigchaindb.com/) - the main BigchainDB website, including newsletter signup
-* [Whitepaper](https://www.bigchaindb.com/whitepaper/) - outlines the motivations, goals and core algorithms of BigchainDB
 * [Roadmap](https://github.com/bigchaindb/org/blob/master/ROADMAP.md)
 * [Blog](https://medium.com/the-bigchaindb-blog)
 * [Twitter](https://twitter.com/BigchainDB)

--- a/bigchaindb/README.md
+++ b/bigchaindb/README.md
@@ -2,13 +2,13 @@
 
 A high-level description of the files and subdirectories of BigchainDB.
 
-There are three database tables which underpin BigchainDB: `backlog`, where incoming transactions are held temporarily until they can be consumed; `bigchain`, where blocks of transactions are written permanently; and `votes`, where votes are written permanently.  It is the votes in the `votes` table which must be queried to determine block validity and order. For more in-depth explanation, see [the whitepaper](https://www.bigchaindb.com/whitepaper/).
+There are three database tables which underpin BigchainDB: `backlog`, where incoming transactions are held temporarily until they can be consumed; `bigchain`, where blocks of transactions are written permanently; and `votes`, where votes are written permanently.  It is the votes in the `votes` table which must be queried to determine block validity and order.
 
 ## Files
 
 ### [`core.py`](./core.py)
 
-The `Bigchain` class is defined here.  Most operations outlined in the [whitepaper](https://www.bigchaindb.com/whitepaper/) as well as database interactions are found in this file.  This is the place to start if you are interested in implementing a server API, since many of these class methods concern BigchainDB interacting with the outside world.
+The `Bigchain` class is defined here.  Most operations outlined in the original BigchainDB whitepaper, as well as database interactions, are found in this file.  This is the place to start if you are interested in implementing a server API, since many of these class methods concern BigchainDB interacting with the outside world.
 
 ### [`models.py`](./models.py)
 

--- a/docs/root/source/index.rst
+++ b/docs/root/source/index.rst
@@ -1,12 +1,11 @@
 BigchainDB Documentation
 ========================
 
-`BigchainDB <https://www.bigchaindb.com/>`_ is a scalable blockchain database.
+`BigchainDB <https://www.bigchaindb.com/>`_ is a blockchain database.
 That is, it's a "big data" database with some blockchain characteristics added, including `decentralization <decentralized.html>`_, 
 `immutability <immutable.html>`_ 
 and 
 `native support for assets <assets.html>`_.
-You can read about the motivations, goals and high-level architecture in the `BigchainDB whitepaper <https://www.bigchaindb.com/whitepaper/>`_.
 
 At a high level, one can communicate with a BigchainDB cluster (set of nodes) using the BigchainDB Client-Server HTTP API, or a wrapper for that API, such as the BigchainDB Python Driver. Each BigchainDB node runs BigchainDB Server and various other software. The `terminology page <terminology.html>`_ explains some of those terms in more detail.
 


### PR DESCRIPTION
I just grepped for "whitepaper" and made edits as appropriate for the `master` branch.

I will make a similar (but not identical) pull request to the `tendermint` branch.