### PR TITLE
Hardcode static ports for k8s deployment

### DIFF
--- a/k8s/bigchaindb/bigchaindb-dep.yaml
+++ b/k8s/bigchaindb/bigchaindb-dep.yaml
@@ -120,13 +120,13 @@ spec:
         - |
           bigchaindb -l DEBUG start
         ports:
-        - containerPort: "<bigchaindb-api-port from ConfigMap>"
+        - containerPort: 9984
           protocol: TCP
           name: bdb-port
-        - containerPort: "<bigchaindb-ws-port from ConfigMap>"
+        - containerPort: 9985
           protocol: TCP
           name: bdb-ws-port
-        - containerPort: "<tm-abci-port from ConfigMap>"
+        - containerPort: 46658
           protocol: TCP
           name: tm-abci-port
         volumeMounts:

--- a/k8s/bigchaindb/bigchaindb-svc.yaml
+++ b/k8s/bigchaindb/bigchaindb-svc.yaml
@@ -9,16 +9,16 @@ spec:
   selector:
     app: bdb-instance-0-dep
   ports:
-  - port: "<bigchaindb-api-port from ConfigMap>"
-    targetPort: "<bigchaindb-api-port from ConfigMap>"
+  - port: 9984
+    targetPort: 9984
     name: bdb-api-port
     protocol: TCP
-  - port: "<bigchaindb-ws-port from ConfigMap>"
-    targetPort: "<bigchaindb-ws-port from ConfigMap>"
+  - port: 9985
+    targetPort: 9985
     name: bdb-ws-port
     protocol: TCP
-  - port: "<tm-abci-port from ConfigMap>"
-    targetPort: "<tm-abci-port from ConfigMap>"
+  - port: 46658
+    targetPort: 46658
     name: tm-abci-port
     protocol: TCP
   type: ClusterIP

--- a/k8s/mongodb/mongo-ss.yaml
+++ b/k8s/mongodb/mongo-ss.yaml
@@ -63,7 +63,7 @@ spec:
             add:
             - FOWNER
         ports:
-        - containerPort: "<mongodb-backend-port from ConfigMap>"
+        - containerPort: 27017
           protocol: TCP
           name: mdb-api-port
         volumeMounts:

--- a/k8s/mongodb/mongo-svc.yaml
+++ b/k8s/mongodb/mongo-svc.yaml
@@ -9,8 +9,8 @@ spec:
   selector:
     app: mdb-instance-0-ss
   ports:
-  - port: "<mongodb-backend-port from ConfigMap>"
-    targetPort: "<mongodb-backend-port from ConfigMap>"
+  - port: 27017
+    targetPort: 27017
     name: mdb-port
     protocol: TCP
   type: ClusterIP

--- a/k8s/nginx-https/nginx-https-dep.yaml
+++ b/k8s/nginx-https/nginx-https-dep.yaml
@@ -90,15 +90,15 @@ spec:
         # HTTPS traffic.
         - containerPort: 80
           protocol: TCP
-        - containerPort: "<cluster-frontend-port from ConfigMap>"
+        - containerPort: 443
           protocol: TCP
-        - containerPort: "<cluster-health-check-port from ConfigMap>"
+        - containerPort: 8888
           protocol: TCP
           name: ngx-port
-        - containerPort: "<tm-pub-key-access from ConfigMap>"
+        - containerPort: 9986
           protocol: TCP
           name: tm-pub-key
-        - containerPort: "<tm-p2p-port from ConfigMap>"
+        - containerPort: 46656
           protocol: TCP
           name: tm-p2p-port
         livenessProbe:

--- a/k8s/nginx-https/nginx-https-svc.yaml
+++ b/k8s/nginx-https/nginx-https-svc.yaml
@@ -13,20 +13,20 @@ spec:
   selector:
     app: ngx-instance-0-dep
   ports:
-  - port: "<cluster-frontend-port from ConfigMap>"
-    targetPort: "<cluster-frontend-port from ConfigMap>"
+  - port: 443
+    targetPort: 443
     name: public-secure-cluster-port
     protocol: TCP
-  - port: "<mongodb-frontend-port from ConfigMap>"
-    targetPort: "<mongodb-frontend-port from ConfigMap>"
+  - port: 27017
+    targetPort: 27017
     name: public-mdb-port
     protocol: TCP
-  - port: "<tm-pub-key-access from ConfigMap>"
-    targetPort: "<tm-pub-key-access from ConfigMap>"
+  - port: 9986
+    targetPort: 9986
     name: tm-pub-key-access
     protocol: TCP
-  - port: "<tm-p2p-port from ConfigMap>"
-    targetPort: "<tm-p2p-port from ConfigMap>"
+  - port: 46656
+    targetPort: 46656
     protocol: TCP
     name: tm-p2p-port
   - port: 80

--- a/k8s/tendermint/tendermint-ext-conn-svc.yaml
+++ b/k8s/tendermint/tendermint-ext-conn-svc.yaml
@@ -9,9 +9,9 @@ spec:
   ports:
 spec:
   ports:
-  - port: "<tm-p2p-port from ConfigMap>"
+  - port: 46656
     name: p2p
-  - port: "<tm-rpc-port from ConfigMap>"
+  - port: 46657
     name: pubkey
   # FQDN of remote cluster/NGINX instance
   externalName: "<dns-name-remote-nginx>"

--- a/k8s/tendermint/tendermint-ss.yaml
+++ b/k8s/tendermint/tendermint-ss.yaml
@@ -40,7 +40,7 @@ spec:
               name: tendermint-config
               key: tm-pub-key-access
         ports:
-        - containerPort: "<tm-pub-key-access from ConfigMap>"
+        - containerPort: 9986
           name: tm-pk-access
         volumeMounts:
         - name: tm-config-data
@@ -109,7 +109,7 @@ spec:
         - name: tm-config-data
           mountPath: /tendermint_node_data
         ports:
-        - containerPort: "<tm-p2p-port from ConfigMap>"
+        - containerPort: 46656
           name: p2p
-        - containerPort: "<tm-rpc-port from ConfigMap>"
+        - containerPort: 46657
           name: rpc

--- a/k8s/tendermint/tendermint-svc.yaml
+++ b/k8s/tendermint/tendermint-svc.yaml
@@ -9,16 +9,16 @@ spec:
   selector:
     app: tm-instance-1-ss
   ports:
-    - port: "<tm-p2p-port from ConfigMap>"
-      targetPort: "<tm-p2p-port from ConfigMap>"
+    - port: 46656
+      targetPort: 46656
       name: p2p
       protocol: TCP
-    - port: "<tm-rpc-port from ConfigMap>"
-      targetPort: "<tm-rpc-port from ConfigMap>"
+    - port: 46657
+      targetPort: 46657
       name: rpc
       protocol: TCP
-    - port: "<tm-pub-key-access from ConfigMap>"
-      targetPort: "<tm-pub-key-access from ConfigMap>"
+    - port: 9986
+      targetPort: 9986
       name: pub-key-access
       protocol: TCP
   clusterIP: None


### PR DESCRIPTION
## Description
Currently we manually configure ports in deployment and service files for k8s deployment e.g [here](https://github.com/bigchaindb/bigchaindb/blob/d5f45d4094a3e3671cf55722b9632d083ffccf56/k8s/bigchaindb/bigchaindb-dep.yaml#L123). Instead these ports should be constant since these are always the same for each deployment

## Issues This PR Fixes
Fixes #2077 


## Todos
- [ ] Added/Updated all related documentation #2081 . 