### PR TITLE
Make votes endpoint return 404 and a helpful message

### DIFF
--- a/bigchaindb/web/views/votes.py
+++ b/bigchaindb/web/views/votes.py
@@ -1,27 +1,42 @@
 """This module provides the blueprint for the votes API endpoints.
 
 For more information please refer to the documentation: http://bigchaindb.com/http-api
-"""
-from flask import current_app
-from flask_restful import Resource, reqparse
 
-from bigchaindb import backend
+We might bring back a votes API endpoint in the future, see:
+https://github.com/bigchaindb/bigchaindb/issues/2037
+"""
+
+from flask import jsonify
+from flask_restful import Resource
+#from flask import current_app
+#from flask_restful import Resource, reqparse
+
+#from bigchaindb import backend
 
 
 class VotesApi(Resource):
     def get(self):
-        """API endpoint to get details about votes on a block.
+        """API endpoint to get details about votes.
 
         Return:
-            A list of votes voting for a block with ID ``block_id``.
+            404 Not Found
         """
-        parser = reqparse.RequestParser()
-        parser.add_argument('block_id', type=str, required=True)
+        #parser = reqparse.RequestParser()
+        #parser.add_argument('block_id', type=str, required=True)
 
-        args = parser.parse_args(strict=True)
+        #args = parser.parse_args(strict=True)
 
-        pool = current_app.config['bigchain_pool']
-        with pool() as bigchain:
-            votes = list(backend.query.get_votes_by_block_id(bigchain.connection, args['block_id']))
+        #pool = current_app.config['bigchain_pool']
+        #with pool() as bigchain:
+        #    votes = list(backend.query.get_votes_by_block_id(bigchain.connection, args['block_id']))
+        
+        #return votes
 
-        return votes
+        # Return an HTTP status code 404 Not Found, which means:
+        # The requested resource could not be found but may be available in the future.
+
+        gone = 'The votes endpoint is gone now, but it might return in the future.'
+        response = jsonify({'message': gone})
+        response.status_code = 404
+        
+        return response

--- a/bigchaindb/web/views/votes.py
+++ b/bigchaindb/web/views/votes.py
@@ -8,10 +8,10 @@ https://github.com/bigchaindb/bigchaindb/issues/2037
 
 from flask import jsonify
 from flask_restful import Resource
-#from flask import current_app
-#from flask_restful import Resource, reqparse
+# from flask import current_app
+# from flask_restful import Resource, reqparse
 
-#from bigchaindb import backend
+# from bigchaindb import backend
 
 
 class VotesApi(Resource):
@@ -21,16 +21,16 @@ class VotesApi(Resource):
         Return:
             404 Not Found
         """
-        #parser = reqparse.RequestParser()
-        #parser.add_argument('block_id', type=str, required=True)
+        # parser = reqparse.RequestParser()
+        # parser.add_argument('block_id', type=str, required=True)
 
-        #args = parser.parse_args(strict=True)
+        # args = parser.parse_args(strict=True)
 
-        #pool = current_app.config['bigchain_pool']
-        #with pool() as bigchain:
-        #    votes = list(backend.query.get_votes_by_block_id(bigchain.connection, args['block_id']))
-        
-        #return votes
+        # pool = current_app.config['bigchain_pool']
+        # with pool() as bigchain:
+        #     votes = list(backend.query.get_votes_by_block_id(bigchain.connection, args['block_id']))
+
+        # return votes
 
         # Return an HTTP status code 404 Not Found, which means:
         # The requested resource could not be found but may be available in the future.
@@ -38,5 +38,5 @@ class VotesApi(Resource):
         gone = 'The votes endpoint is gone now, but it might return in the future.'
         response = jsonify({'message': gone})
         response.status_code = 404
-        
+
         return response

--- a/tests/web/test_votes.py
+++ b/tests/web/test_votes.py
@@ -5,6 +5,29 @@ from bigchaindb.models import Transaction
 VOTES_ENDPOINT = '/api/v1/votes'
 
 
+@pytest.mark.tendermint
+def test_get_votes_endpoint(client):
+    gone = 'The votes endpoint is gone now, but it might return in the future.'
+    response = {'message': gone}
+
+    res = client.get(VOTES_ENDPOINT)
+    assert response == res.json
+    assert res.status_code == 404
+
+    res = client.get(VOTES_ENDPOINT + '?block_id=')
+    assert response == res.json
+    assert res.status_code == 404
+
+    res = client.get(VOTES_ENDPOINT + '?block_id=123')
+    assert response == res.json
+    assert res.status_code == 404
+
+
+"""
+# Old tests are below. We're keeping their code in a long comment block for now,
+# because we might bring back a votes endpoint in the future.
+# https://github.com/bigchaindb/bigchaindb/issues/2037
+
 @pytest.mark.bdb
 @pytest.mark.usefixtures('inputs')
 def test_get_votes_endpoint(b, client):
@@ -73,3 +96,4 @@ def test_get_votes_endpoint_returns_400_bad_query_params(client):
 
     res = client.get(VOTES_ENDPOINT + '?tx_id=123&block_id=123')
     assert res.status_code == 400
+"""

--- a/tests/web/test_votes.py
+++ b/tests/web/test_votes.py
@@ -1,6 +1,6 @@
 import pytest
 
-from bigchaindb.models import Transaction
+# from bigchaindb.models import Transaction
 
 VOTES_ENDPOINT = '/api/v1/votes'
 


### PR DESCRIPTION
The votes endpoint in the HTTP API is going away, but it might come back in the future; see issue #2037 

This PR keeps the votes endpoint (and puts existing code + test code in comments), but changes the response to 'The votes endpoint is gone now, but it might return in the future.' with HTTP status code 404 Not Found, which means "The requested resource could not be found but may be available in the future."
