### PR TITLE
Adding secret access token header checks for authorization

### DIFF
--- a/k8s/configuration/config-map.yaml
+++ b/k8s/configuration/config-map.yaml
@@ -92,6 +92,9 @@ data:
   # it will use the default cache size; i.e. max((50% RAM - 1GB), 256MB)
   storage-engine-cache-size: ""
 
+  # POST API authorization mode [threescale | secrete-token]
+  authorization-mode: "threescale"
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/k8s/configuration/secret.yaml
+++ b/k8s/configuration/secret.yaml
@@ -55,6 +55,16 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
+  name: nginx-secret-header
+  namespace: default
+type: Opaque
+data:
+  # Base64-encoded secret token to authorize POST requests
+  secret-token: "<b64 encoded secret token for authorization>"
+---
+apiVersion: v1
+kind: Secret
+metadata:
   name: https-certs
   namespace: default
 type: Opaque
@@ -65,7 +75,7 @@ data:
   # starting with your primary SSL cert (e.g. your_domain.crt)
   # followed by all intermediate certs.
   # If cert if from DigiCert, download "Best format for nginx".
-  cert.pem: "<b64 encoded HTTPS certificate chain"
+  cert.pem: "<b64 encoded HTTPS certificate chain>"
 ---
 apiVersion: v1
 kind: Secret

--- a/k8s/nginx-https/container/Dockerfile
+++ b/k8s/nginx-https/container/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update \
     && apt-get -y upgrade \
     && apt-get autoremove \
     && apt-get clean
+COPY nginx.conf.threescale.template /etc/nginx/nginx-threescale.conf
 COPY nginx.conf.template /etc/nginx/nginx.conf
 COPY nginx_entrypoint.bash /
 EXPOSE 80 443 27017 9986 46656

--- a/k8s/nginx-https/container/nginx.conf.template
+++ b/k8s/nginx-https/container/nginx.conf.template
@@ -1,6 +1,7 @@
 # Frontend API server that:
 # 1. Acts as the HTTPS termination point.
-# 2. Forwards BDB HTTP requests to OpenResty backend.
+# 2. Authorizes HTTP requests with secret token header
+#    and forwards to BDB backend.
 # 3. Forwards BDB WS requests to BDB backend.
 # 4. Does health check with LB.
 

--- a/k8s/nginx-https/container/nginx.conf.template
+++ b/k8s/nginx-https/container/nginx.conf.template
@@ -57,9 +57,6 @@ http {
   map $remote_addr $bdb_backend {
     default BIGCHAINDB_BACKEND_HOST;
   }
-  map $remote_addr $openresty_backend {
-    default OPENRESTY_BACKEND_HOST;
-  }
 
   # Frontend server for the external clients; acts as HTTPS termination point.
   server {
@@ -116,7 +113,7 @@ http {
         return 403;
       }
 
-      # POST requests get forwarded to OpenResty instance. Enable CORS too.
+      # POST requests get forwarded to BDB.
       if ($request_method = POST ) {}
         proxy_pass http://$bdb_backend:BIGCHAINDB_API_PORT;
       }

--- a/k8s/nginx-https/container/nginx.conf.threescale.template
+++ b/k8s/nginx-https/container/nginx.conf.threescale.template
@@ -100,25 +100,25 @@ http {
         proxy_pass http://$bdb_backend:BIGCHAINDB_API_PORT;
       }
 
+      # POST requests get forwarded to OpenResty instance. Enable CORS too.
+      if ($request_method = POST ) {
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+        add_header 'Access-Control-Expose-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+
+        proxy_pass http://$openresty_backend:OPENRESTY_BACKEND_PORT;
+      }
+
       # OPTIONS requests handling for CORS.
       if ($request_method = 'OPTIONS') {
         add_header 'Access-Control-Allow-Origin' '*';
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-        add_header 'Access-Control-Allow-Headers' 'DNT,X-Secret-Access-Token,User-Agent';
+        add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,app_key,app_id';
         add_header 'Access-Control-Max-Age' 43200;
         add_header 'Content-Type' 'text/plain charset=UTF-8';
         add_header 'Content-Length' 0;
         return 204;
-      }
-
-      # Check for security header to authorize POST requests
-      if ( $http_x_secret_access_token != "SECRET_ACCESS_TOKEN" ) {
-        return 403;
-      }
-
-      # POST requests get forwarded to OpenResty instance. Enable CORS too.
-      if ($request_method = POST ) {}
-        proxy_pass http://$bdb_backend:BIGCHAINDB_API_PORT;
       }
 
       # Only return this reponse if request_method is neither POST|GET|OPTIONS

--- a/k8s/nginx-https/container/nginx_entrypoint.bash
+++ b/k8s/nginx-https/container/nginx_entrypoint.bash
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+# Authorization Modes
+threescale_auth_mode="threescale"
+secret_token_auth_mode="secret-token"
+
 # Cluster vars
 cluster_fqdn=`printenv CLUSTER_FQDN`
 cluster_frontend_port=`printenv CLUSTER_FRONTEND_PORT`
@@ -49,7 +53,7 @@ if [[ -z "${cluster_frontend_port:?CLUSTER_FRONTEND_PORT not specified. Exiting!
       -z "${tm_pub_key_access_port:?TM_PUB_KEY_ACCESS_PORT not specified. Exiting!}" || \
       -z "${tm_backend_host:?TM_BACKEND_HOST not specified. Exiting!}" || \
       -z "${tm_p2p_port:?TM_P2P_PORT not specified. Exiting!}" || \
-      -z "${authorization_mode:-threescale}" ]]; then
+      -z "${authorization_mode:-threescale_auth_mode}" ]]; then # Set the default authorization mode to threescale
   echo "Missing required environment variables. Exiting!"
   exit 1
 else
@@ -70,13 +74,17 @@ else
   echo TM_P2P_PORT="$tm_p2p_port"
 fi
 
-# Set Default nginx config file
-NGINX_CONF_FILE=/etc/nginx/nginx-threescale.conf
-
-if [[ ${authorization_mode} == "secret-header" ]]; then
+if [[ ${authorization_mode} == ${secret_token_auth_mode} ]]; then
   NGINX_CONF_FILE=/etc/nginx/nginx.conf
   secret_access_token=`printenv SECRET_ACCESS_TOKEN`
   sed -i "s|SECRET_ACCESS_TOKEN|${secret_token_header}|g"
+elif [[ ${authorization_mode} == ${threescale_auth_mode} ]]; then
+  NGINX_CONF_FILE=/etc/nginx/nginx-threescale.conf
+  sed -i "s|OPENRESTY_BACKEND_PORT|${openresty_backend_port}|g" ${NGINX_CONF_FILE}
+  sed -i "s|OPENRESTY_BACKEND_HOST|${openresty_backend_host}|g" ${NGINX_CONF_FILE}
+else
+  echo "Unrecognised authorization mode: ${authorization_mode}. Exiting!"
+  exit 1
 fi
 
 # configure the nginx.conf file with env variables
@@ -85,8 +93,6 @@ sed -i "s|CLUSTER_FRONTEND_PORT|${cluster_frontend_port}|g" ${NGINX_CONF_FILE}
 sed -i "s|MONGODB_FRONTEND_PORT|${mongo_frontend_port}|g" ${NGINX_CONF_FILE}
 sed -i "s|MONGODB_BACKEND_HOST|${mongo_backend_host}|g" ${NGINX_CONF_FILE}
 sed -i "s|MONGODB_BACKEND_PORT|${mongo_backend_port}|g" ${NGINX_CONF_FILE}
-sed -i "s|OPENRESTY_BACKEND_PORT|${openresty_backend_port}|g" ${NGINX_CONF_FILE}
-sed -i "s|OPENRESTY_BACKEND_HOST|${openresty_backend_host}|g" ${NGINX_CONF_FILE}
 sed -i "s|BIGCHAINDB_BACKEND_HOST|${bdb_backend_host}|g" ${NGINX_CONF_FILE}
 sed -i "s|BIGCHAINDB_API_PORT|${bdb_api_port}|g" ${NGINX_CONF_FILE}
 sed -i "s|BIGCHAINDB_WS_PORT|${bdb_ws_port}|g" ${NGINX_CONF_FILE}

--- a/k8s/nginx-https/nginx-https-dep.yaml
+++ b/k8s/nginx-https/nginx-https-dep.yaml
@@ -85,6 +85,11 @@ spec:
             configMapKeyRef:
               name: tendermint-config
               key: tm-p2p-port
+        - name: AUTHORIZATION_MODE
+          valueFrom:
+            configMapKeyRef:
+              name: vars
+              key: authorization-mode
         ports:
         # return a pretty error message on port 80, since we are expecting
         # HTTPS traffic.


### PR DESCRIPTION
## Description
Currently production deployment templates use threescale apicast for authentication and authorization. This PR adds a second option to restrict POST API access to a bigchaindb node based on a secret access token programmed into nginx conf file.

## Issues This PR Fixes
Fixes #2035 


## Todos
- [ ] Added/Updated all related documentation #2081 