### PR TITLE
Automate MongoDB user creation for prod/test deployments

### DIFF
--- a/docs/server/source/production-deployment-template/template-kubernetes-azure.rst
+++ b/docs/server/source/production-deployment-template/template-kubernetes-azure.rst
@@ -102,7 +102,7 @@ Finally, you can deploy an ACS using something like:
    $ az acs create --name <a made-up cluster name> \
    --resource-group <name of resource group created earlier> \
    --master-count 3 \
-   --agent-count 2 \
+   --agent-count 3 \
    --admin-username ubuntu \
    --agent-vm-size Standard_L4s \
    --dns-prefix <make up a name> \

--- a/k8s/configuration/config-map.yaml
+++ b/k8s/configuration/config-map.yaml
@@ -169,3 +169,16 @@ data:
   # tm-pub-key-access is the port number used to host/publish the
   # public key of the tendemrint node in this cluster.
   tm-pub-key-access: "9986"
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mdb-config
+  namespace: default
+data:
+  # User name for MongoDB adminuser
+  mdb-admin-username: "<mongodb admin username>"
+
+  # MongoDB monitoring agent authentication user name
+  mdb-mon-user: "<mongodb monitoring agent username>"

--- a/k8s/configuration/secret.yaml
+++ b/k8s/configuration/secret.yaml
@@ -100,3 +100,14 @@ data:
   # Base64-encoded CA certificate (ca.crt)
   ca.pem: "<b64 encoded CA certificate>"
   crl.pem: "<b64 encoded CRL>"
+---
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mdb-config
+  namespace: default
+type: Opaque
+data:
+  # Password for for MongoDB adminuser
+  mdb-admin-password: "<b64 encoded mdb admin password>"

--- a/k8s/mongodb/container/Dockerfile
+++ b/k8s/mongodb/container/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
     && apt-get autoremove \
     && apt-get clean
 COPY mongod.conf.template /etc/mongod.conf
+COPY configure_mdb_users.template.js /configure_mdb_users.js
 COPY mongod_entrypoint.bash /
 VOLUME /data/db /data/configdb /etc/mongod/ssl /etc/mongod/ca
 EXPOSE 27017

--- a/k8s/mongodb/container/configure_mdb_users.template.js
+++ b/k8s/mongodb/container/configure_mdb_users.template.js
@@ -1,4 +1,4 @@
-use admin;
+db = db.getSiblingDB("admin");
 db.createUser({
     user: "MONGODB_ADMIN_USERNAME",
     pwd: "MONGODB_ADMIN_PASSWORD",
@@ -12,7 +12,7 @@ db.createUser({
         }
     ]
 });
-use admin;
+db = db.getSiblingDB("admin");
 db.auth("MONGODB_ADMIN_USERNAME", "MONGODB_ADMIN_PASSWORD");
 db.getSiblingDB("$external").runCommand({
     createUser: 'BDB_USERNAME',

--- a/k8s/mongodb/container/configure_mdb_users.template.js
+++ b/k8s/mongodb/container/configure_mdb_users.template.js
@@ -1,0 +1,43 @@
+use admin;
+db.createUser({
+    user: "MONGODB_ADMIN_USERNAME",
+    pwd: "MONGODB_ADMIN_PASSWORD",
+    roles: [{
+            role: "userAdminAnyDatabase",
+            db: "admin"
+        },
+        {
+            role: "clusterManager",
+            db: "admin"
+        }
+    ]
+});
+use admin;
+db.auth("MONGODB_ADMIN_USERNAME", "MONGODB_ADMIN_PASSWORD");
+db.getSiblingDB("$external").runCommand({
+    createUser: 'BDB_USERNAME',
+    writeConcern: {
+        w: 'majority',
+        wtimeout: 5000
+    },
+    roles: [{
+            role: 'clusterAdmin',
+            db: 'admin'
+        },
+        {
+            role: 'readWriteAnyDatabase',
+            db: 'admin'
+        }
+    ]
+});
+db.getSiblingDB("$external").runCommand({
+    createUser: 'MDB_MON_USERNAME',
+    writeConcern: {
+        w: 'majority',
+        wtimeout: 5000
+    },
+    roles: [{
+        role: 'clusterMonitor',
+        db: 'admin'
+    }]
+});

--- a/k8s/mongodb/container/mongod_entrypoint.bash
+++ b/k8s/mongodb/container/mongod_entrypoint.bash
@@ -13,7 +13,7 @@ configure_mongo=true
 MONGODB_CREDENTIALS_DIR=/tmp/mongodb
 mongodb_admin_password=""
 mongodb_admin_username=`printenv MONGODB_ADMIN_USERNAME || true`
-mongodb_admin_password=`printenv MONGODB_ADMIN_PASSWORD || true`
+mongodb_admin_password=""
 bdb_username=`printenv BDB_USERNAME || true`
 mdb_mon_username=`printenv MDB_MON_USERNAME || true`
 
@@ -102,10 +102,10 @@ if [ -f ${MONGODB_CREDENTIALS_DIR}/mdb-admin-password ]; then
 fi
 
 # Only configure if all variables are set
-if [[ -z "${mongodb_admin_username}" && \
-        -z "${mongodb_admin_password}" && \
-        -z "${bdb_username}" && \
-    -z "${mdb_mon_username}" ]]; then
+if [[ -n "${mongodb_admin_username}" && \
+        -n "${mongodb_admin_password}" && \
+        -n "${bdb_username}" && \
+    -n "${mdb_mon_username}" ]]; then
     sed -i "s|MONGODB_ADMIN_USERNAME|${mongodb_admin_username}|g" ${MONGODB_CONFIGURE_USERS_PATH}
     sed -i "s|MONGODB_ADMIN_PASSWORD|${mongodb_admin_password}|g" ${MONGODB_CONFIGURE_USERS_PATH}
     sed -i "s|BDB_USERNAME|${bdb_username}|g" ${MONGODB_CONFIGURE_USERS_PATH}

--- a/k8s/mongodb/container/mongod_entrypoint.bash
+++ b/k8s/mongodb/container/mongod_entrypoint.bash
@@ -13,7 +13,6 @@ configure_mongo=true
 MONGODB_CREDENTIALS_DIR=/tmp/mongodb
 mongodb_admin_password=""
 mongodb_admin_username=`printenv MONGODB_ADMIN_USERNAME || true`
-mongodb_admin_password=""
 bdb_username=`printenv BDB_USERNAME || true`
 mdb_mon_username=`printenv MDB_MON_USERNAME || true`
 

--- a/k8s/mongodb/mongo-ss.yaml
+++ b/k8s/mongodb/mongo-ss.yaml
@@ -43,6 +43,21 @@ spec:
             configMapKeyRef:
              name: vars
              key: storage-engine-cache-size
+        - name: MONGODB_ADMIN_USERNAME
+          valueFrom:
+            configMapKeyRef:
+             name: mdb-config
+             key: mdb-admin-username
+        - name: BDB_USERNAME
+          valueFrom:
+            configMapKeyRef:
+             name: bdb-config
+             key: bdb-user
+        - name: MDB_MON_USERNAME
+          valueFrom:
+            configMapKeyRef:
+             name: mdb-config
+             key: mdb-mon-user
         args:
         - --mongodb-port
         - $(MONGODB_PORT)
@@ -77,6 +92,9 @@ spec:
         - name: ca-auth
           mountPath: /etc/mongod/ca/
           readOnly: true
+        - name: mdb-config
+          mountPath: /tmp/mongodb
+          readOnly: true
         resources:
           limits:
             cpu: 200m
@@ -104,4 +122,8 @@ spec:
       - name: ca-auth
         secret:
           secretName: ca-auth
+          defaultMode: 0400
+      - name: mdb-config
+        secret:
+          secretName: mdb-config
           defaultMode: 0400

--- a/k8s/scripts/configure_mdb.sh
+++ b/k8s/scripts/configure_mdb.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+[ -z $1 ] && echo "Please specify MongoDB instance name!!"
+MONGODB_INSTANCE_NAME=$1
+
+if [[ -n "$MONGODB_INSTANCE_NAME" ]]; then
+    /usr/local/bin/kubectl exec -it "${MONGODB_INSTANCE_NAME}"\-ss\-0 -- bash -c "if [[ -f /tmp/configure_mongo && -n \$(cat /tmp/configure_mongo) ]]; then  /usr/bin/mongo --host localhost --port \$(printenv MONGODB_PORT) --ssl --sslCAFile /etc/mongod/ca/ca.pem --sslPEMKeyFile  /etc/mongod/ssl/mdb-instance.pem < /configure_mdb_users.js; fi"
+else
+    echo "Skipping configuration!!!"
+fi


### PR DESCRIPTION
## Description
- Currently, we had to manually log into the MongoDB container
   and create users, this change will configure the relevant users
   from a single script `configure_mdb.sh`
- Improvements can be done but keeping it minimal for the workshop
- Usage:
  - `bash configure_mdb.sh <mongodb-instance-name>`
    - **Example** `$ bash configure_mdb.sh mdb-instance-1`