### PR TITLE
Check if kubectl is installed otherwise exit

### DIFF
--- a/k8s/scripts/configure_mdb.sh
+++ b/k8s/scripts/configure_mdb.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
 
+# Checking if kubectl exists
+command -v kubectl > /dev/null
+if [ $? -eq 0 ]
+then
+  echo "kubectl already installed!"
+else
+  echo "Please install kubectl!! https://kubernetes.io/docs/tasks/tools/install-kubectl/"
+  exit 1
+fi
+
 [ -z $1 ] && echo "Please specify MongoDB instance name!!"
 MONGODB_INSTANCE_NAME=$1
 
 if [[ -n "$MONGODB_INSTANCE_NAME" ]]; then
     /usr/local/bin/kubectl exec -it "${MONGODB_INSTANCE_NAME}"\-ss\-0 -- bash -c "if [[ -f /tmp/configure_mongo && -n \$(cat /tmp/configure_mongo) ]]; then  /usr/bin/mongo --host localhost --port \$(printenv MONGODB_PORT) --ssl --sslCAFile /etc/mongod/ca/ca.pem --sslPEMKeyFile  /etc/mongod/ssl/mdb-instance.pem < /configure_mdb_users.js; fi"
 else
-    echo "Skipping configuration!!!"
+    echo "Skipping configuration, because relevant files don't exist!!!"
 fi


### PR DESCRIPTION
## Description
Currently the `configure_mdb.sh` script to configure users in MongoDB StatelfulSet did not check if the user has `kubectl` installed or not. This change adds a minor check for that.