### PR TITLE
Revised intro of Overview page in prod dep template docs

### DIFF
--- a/docs/server/source/production-deployment-template/node-config-map-and-secrets.rst
+++ b/docs/server/source/production-deployment-template/node-config-map-and-secrets.rst
@@ -35,7 +35,7 @@ vars.cluster-fqdn
 ~~~~~~~~~~~~~~~~~
 
 The ``cluster-fqdn`` field specifies the domain you would have
-:ref:`registered before <register-a-domain-and-get-an-ssl-certificate-for-it>`.
+registered before.
 
 
 vars.cluster-frontend-port


### PR DESCRIPTION
As discussed in our workshop today.

Note: I removed the link to `<register-a-domain-and-get-an-ssl-certificate-for-it>` in `docs/server/source/production-deployment-template/node-config-map-and-secrets.rst` because that section is gone now.
