### PR TITLE
Problem: Production deployment template was not updated after v1.0 automation

### DIFF
--- a/docs/server/source/production-deployment-template/node-config-map-and-secrets.rst
+++ b/docs/server/source/production-deployment-template/node-config-map-and-secrets.rst
@@ -10,338 +10,84 @@ named ``config-map.yaml`` (a set of ConfigMaps)
 and ``secret.yaml`` (a set of Secrets).
 They are stored in the Kubernetes cluster's key-value store (etcd).
 
-Make sure you did all the things listed in the section titled
-:ref:`things-each-node-operator-must-do`
-(including generation of all the SSL certificates needed
-for MongoDB auth).
+Make sure you did the first four operations listed in the section titled
+:ref:`things-each-node-operator-must-do`.
 
 
-Edit config-map.yaml
---------------------
+Edit vars
+---------
 
-Make a copy of the file ``k8s/configuration/config-map.yaml``
-and edit the data values in the various ConfigMaps.
+This file is located at: ``k8s/scripts/vars`` and edit
+the configuration parameters.
 That file already contains many comments to help you
 understand each data value, but we make some additional
 remarks on some of the values below.
 
-Note: None of the data values in ``config-map.yaml`` need
-to be base64-encoded. (This is unlike ``secret.yaml``,
-where all data values must be base64-encoded.
-This is true of all Kubernetes ConfigMaps and Secrets.)
+
+vars.NODE_FQDN
+~~~~~~~~~~~~~~~
+FQDN for your BigchainDB node. This is the domain name
+used to query and access your BigchainDB node. More information can be
+found in our :ref:`Kubernetes template overview guide <kubernetes-template-overview>`.
 
 
-vars.cluster-fqdn
+vars.SECRET_TOKEN
 ~~~~~~~~~~~~~~~~~
+This parameter is specific to your BigchainDB node and is used for
+authentication and authorization of requests to your BigchainDB node.
+More information can be found in our :ref:`Kubernetes template overview guide <kubernetes-template-overview>`.
 
-The ``cluster-fqdn`` field specifies the domain you would have
-registered before.
 
-
-vars.cluster-frontend-port
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``cluster-frontend-port`` field specifies the port on which your cluster
-will be available to all external clients.
-It is set to the HTTPS port ``443`` by default.
-
-
-vars.cluster-health-check-port
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``cluster-healthcheck-port`` is the port number on which health check
-probes are sent to the main NGINX instance.
-It is set to ``8888`` by default.
-
-
-vars.cluster-dns-server-ip
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``cluster-dns-server-ip`` is the IP of the DNS server for a node.
-We use DNS for service discovery. A Kubernetes deployment always has a DNS
-server (``kube-dns``) running at 10.0.0.10, and since we use Kubernetes, this is
-set to ``10.0.0.10`` by default, which is the default ``kube-dns`` IP address.
-
-
-vars.mdb-instance-name and Similar
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Your BigchainDB cluster organization should have a standard way
-of naming instances, so the instances in your BigchainDB node
-should conform to that standard (i.e. you can't just make up some names).
-There are some things worth noting about the ``mdb-instance-name``:
-
-* This field will be the DNS name of your MongoDB instance, and Kubernetes
-  maps this name to its internal DNS.
-* We use ``mdb-instance-0``, ``mdb-instance-1`` and so on in our
-  documentation. Your BigchainDB cluster may use a different naming convention.
-
-
-vars.ngx-mdb-instance-name and Similar
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-NGINX needs the FQDN of the servers inside the cluster to be able to forward
-traffic.
-The ``ngx-openresty-instance-name``, ``ngx-mdb-instance-name`` and
-``ngx-bdb-instance-name`` are the FQDNs of the OpenResty instance, the MongoDB
-instance, and the BigchainDB instance in this Kubernetes cluster respectively.
-In Kubernetes, this is usually the name of the module specified in the
-corresponding ``vars.*-instance-name`` followed by the
-``<namespace name>.svc.cluster.local``. For example, if you run OpenResty in
-the default Kubernetes namespace, this will be
-``<vars.openresty-instance-name>.default.svc.cluster.local``
-
-
-vars.mongodb-frontend-port and vars.mongodb-backend-port
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``mongodb-frontend-port`` is the port number on which external clients can
-access MongoDB. This needs to be restricted to only other MongoDB instances
-by enabling an authentication mechanism on MongoDB cluster.
-It is set to ``27017`` by default.
-
-The ``mongodb-backend-port`` is the port number on which MongoDB is actually
-available/listening for requests in your cluster.
-It is also set to ``27017`` by default.
-
-
-vars.openresty-backend-port
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``openresty-backend-port`` is the port number on which OpenResty is
-listening for requests.
-This is used by the NGINX instance to forward requests
-destined for the OpenResty instance to the right port.
-This is also used by OpenResty instance to bind to the correct port to
-receive requests from NGINX instance.
-It is set to ``80`` by default.
-
-
-vars.bigchaindb-wsserver-advertised-scheme
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``bigchaindb-wsserver-advertised-scheme`` is the protocol used to access
-the WebSocket API in BigchainDB. This can be set to ``wss`` or ``ws``.
-It is set to ``wss`` by default.
-
-
-vars.bigchaindb-api-port, vars.bigchaindb-ws-port and Similar
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``bigchaindb-api-port`` is the port number on which BigchainDB is
-listening for HTTP requests. Currently set to ``9984`` by default.
-
-The ``bigchaindb-ws-port`` is the port number on which BigchainDB is
-listening for Websocket requests. Currently set to ``9985`` by default.
-
-There's another :doc:`page with a complete listing of all the BigchainDB Server
-configuration settings <../server-reference/configuration>`.
-
-
-bdb-config.bdb-user
-~~~~~~~~~~~~~~~~~~~
-
-This is the user name that BigchainDB uses to authenticate itself to the
-backend MongoDB database.
-
-We need to specify the user name *as seen in the certificate* issued to
-the BigchainDB instance in order to authenticate correctly. Use
-the following ``openssl`` command to extract the user name from the
-certificate:
-
-.. code:: bash
-
-   $ openssl x509 -in <path to the bigchaindb certificate> \
-     -inform PEM -subject -nameopt RFC2253
-
-You should see an output line that resembles:
-
-.. code:: bash
-
-   subject= emailAddress=dev@bigchaindb.com,CN=test-bdb-ssl,OU=BigchainDB-Instance,O=BigchainDB GmbH,L=Berlin,ST=Berlin,C=DE
-
-The ``subject`` line states the complete user name we need to use for this
-field (``bdb-config.bdb-user``), i.e.
-
-.. code:: bash
-
-   emailAddress=dev@bigchaindb.com,CN=test-bdb-ssl,OU=BigchainDB-Instance,O=BigchainDB GmbH,L=Berlin,ST=Berlin,C=DE
-
-
-tendermint-config.tm-instance-name
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Your BigchainDB cluster organization should have a standard way
-of naming instances, so the instances in your BigchainDB node
-should conform to that standard. There are some things worth noting
-about the ``tm-instance-name``:
-
-* This field will be the DNS name of your Tendermint instance, and Kubernetes
-  maps this name to its internal DNS, so all the peer to peer communication
-  depends on this, in case of a network/multi-node deployment.
-* This parameter is also used to access the public key of a particular node.
-* We use ``tm-instance-0``, ``tm-instance-1`` and so on in our
-  documentation. Your BigchainDB cluster may use a different naming convention.
-
-
-tendermint-config.ngx-tm-instance-name
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-NGINX needs the FQDN of the servers inside the cluster to be able to forward
-traffic.
-``ngx-tm-instance-name`` is the FQDN of the Tendermint
-instance in this Kubernetes cluster.
-In Kubernetes, this is usually the name of the module specified in the
-corresponding ``tendermint-config.*-instance-name`` followed by the
-``<namespace name>.svc.cluster.local``. For example, if you run Tendermint in
-the default Kubernetes namespace, this will be
-``<tendermint-config.tm-instance-name>.default.svc.cluster.local``
-
-
-tendermint-config.tm-seeds
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``tm-seeds`` is the initial set of peers to connect to. It is a comma separated
-list of all the peers part of the cluster.
-
-If you are deploying a stand-alone BigchainDB node the value should the same as
-``<tm-instance-name>``. If you are deploying a network this parameter will look
-like this:
-
-.. code::
-
-    <tm-instance-1>,<tm-instance-2>,<tm-instance-3>,<tm-instance-4>
-
-
-tendermint-config.tm-validators
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``tm-validators`` is the initial set of validators in the network. It is a comma separated list
-of all the participant validator nodes.
-
-If you are deploying a stand-alone BigchainDB node the value should be the same as
-``<tm-instance-name>``. If you are deploying a network this parameter will look like
-this:
-
-.. code::
-
-    <tm-instance-1>,<tm-instance-2>,<tm-instance-3>,<tm-instance-4>
-
-
-tendermint-config.tm-validator-power
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``tm-validator-power`` represents the voting power of each validator. It is a comma separated
-list of all the participants in the network.
-
-**Note**: The order of the validator power list should be the same as the ``tm-validators`` list.
-
-.. code::
-
-    tm-validators: <tm-instance-1>,<tm-instance-2>,<tm-instance-3>,<tm-instance-4>
-
-For the above list of validators the ``tm-validator-power`` list should look like this:
-
-.. code::
-
-    tm-validator-power: <tm-instance-1-power>,<tm-instance-2-power>,<tm-instance-3-power>,<tm-instance-4-power>
-
-
-tendermint-config.tm-genesis-time
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``tm-genesis-time`` represents the official time of blockchain start. Details regarding, how to generate
-this parameter are covered :ref:`here <generate-the-blockchain-id-and-genesis-time>`.
-
-
-tendermint-config.tm-chain-id
+vars.HTTPS_CERT_KEY_FILE_NAME
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``tm-chain-id`` represents the ID of the blockchain. This must be unique for every blockchain.
-Details regarding, how to generate this parameter are covered
-:ref:`here <generate-the-blockchain-id-and-genesis-time>`.
+Absolute path of the HTTPS certificate chain of your domain.
+More information can be found in our :ref:`Kubernetes template overview guide <kubernetes-template-overview>`.
 
 
-tendermint-config.tm-abci-port
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``tm-abci-port`` has a default value ``46658`` which is used by Tendermint Core for
-ABCI(Application BlockChain Interface) traffic. BigchainDB nodes use this port
-internally to communicate with Tendermint Core.
+vars.HTTPS_CERT_CHAIN_FILE_NAME
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Absolute path of the HTTPS certificate key of your domain.
+More information can be found in our :ref:`Kubernetes template overview guide <kubernetes-template-overview>`.
 
 
-tendermint-config.tm-p2p-port
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``tm-p2p-port`` has a default value ``46656`` which is used by Tendermint Core for
-peer to peer communication.
-
-For a multi-node/zone deployment, this port needs to be available publicly for P2P
-communication between Tendermint nodes.
+vars.MDB_ADMIN_USER and vars.MDB_ADMIN_PASSWORD
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+MongoDB admin user credentials, username and password.
+This user is created on the *admin* database with the authorization to create other users.
 
 
-tendermint-config.tm-rpc-port
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``tm-rpc-port`` has a default value ``46657`` which is used by Tendermint Core for RPC
-traffic. BigchainDB nodes use this port with RPC listen address.
-
-
-tendermint-config.tm-pub-key-access
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``tm-pub-key-access`` has a default value ``9986``, which is used to discover the public
-key of a tendermint node. Each Tendermint StatefulSet(Pod, Tendermint + NGINX) hosts its
-public key.
-
-.. code::
-
-  http://tendermint-instance-1:9986/pub_key.json
+vars.TM_INSTANCE_NAME
+~~~~~~~~~~~~~~~~~~~~~~
+Name of tendermint instance that is part of your BigchainDB node.
+This name should be unique across the cluster, for more information please refer to
+:ref:`generate-the-blockchain-id-and-genesis-time`.
 
 
-Edit secret.yaml
-----------------
-
-Make a copy of the file ``k8s/configuration/secret.yaml``
-and edit the data values in the various Secrets.
-That file includes many comments to explain the required values.
-**In particular, note that all values must be base64-encoded.**
-There are tips at the top of the file
-explaining how to convert values into base64-encoded values.
-
-Your BigchainDB node might not need all the Secrets.
-For example, if you plan to access the BigchainDB API over HTTP, you
-don't need the ``https-certs`` Secret.
-You can delete the Secrets you don't need,
-or set their data values to ``""``.
-
-Note that ``ca.pem`` is just another name for ``ca.crt``
-(the certificate of your BigchainDB cluster's self-signed CA).
+vars.TM_SEEDS, TM_VALIDATORS, TM_VALIDATORS_POWERS, TM_GENESIS_TIME and TM_CHAIN_ID
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These parameters are shared across the cluster. More information about the generation
+of these parameters can be found at :ref:`generate-the-blockchain-id-and-genesis-time`.
 
 
-threescale-credentials.*
-~~~~~~~~~~~~~~~~~~~~~~~~
+.. _generate-config:
 
-If you're not using 3scale,
-you can delete the ``threescale-credentials`` Secret
-or leave all the values blank (``""``).
-
-If you *are* using 3scale, get the values for ``secret-token``,
-``service-id``, ``version-header`` and ``service-token`` by logging in to 3scale
-portal using your admin account, click **APIs** and click on **Integration**
-for the relevant API.
-Scroll to the bottom of the page and click the small link
-in the lower right corner, labelled **Download the NGINX Config files**.
-Unzip it(if it is a ``zip`` file). Open the ``.conf`` and the ``.lua`` file.
-You should be able to find all the values in those files.
-You have to be careful because it will have values for **all** your APIs,
-and some values vary from API to API.
-The ``version-header`` is the timestamp in a line that looks like:
+Generate configuration
+~~~~~~~~~~~~~~~~~~~~~~
+After populating the ``k8s/scripts/vars`` file, we need to generate
+all the configuration required for the BigchainDB node, for that purpose
+we need to execute ``k8s/scripts/generate_configs.sh`` script.
 
 .. code::
 
-    proxy_set_header  X-3scale-Version "2017-06-28T14:57:34Z";
+   $ bash generate_configs.sh
 
+.. Note::
+    During execution the script will prompt the user for some inputs.
+
+After successful execution, this routine will generate ``config-map.yaml`` and
+``secret.yaml`` under ``k8s/scripts``.
+
+.. _deploy-config-map-and-secret:
 
 Deploy Your config-map.yaml and secret.yaml
 -------------------------------------------

--- a/docs/server/source/production-deployment-template/workflow.rst
+++ b/docs/server/source/production-deployment-template/workflow.rst
@@ -1,3 +1,5 @@
+.. _kubernetes-template-overview:
+
 Overview
 ========
 
@@ -74,112 +76,32 @@ We'll say more about that file below.)
 Things Each Node Operator Must Do
 ---------------------------------
 
-☐ Set Up a Self-Signed Certificate Authority
+1. :doc:`Deploy a Kubernetes cluster on Azure <../production-deployment-template/template-kubernetes-azure>`.
 
-We use SSL/TLS and self-signed certificates
-for MongoDB authentication (and message encryption).
-The certificates are signed by the organization managing the :ref:`bigchaindb-node`.
-If your organization already has a process
-for signing certificates
-(i.e. an internal self-signed certificate authority [CA]),
-then you can skip this step.
-Otherwise, your organization must
-:ref:`set up its own self-signed certificate authority <how-to-set-up-a-self-signed-certificate-authority>`.
-
-
-☐ Follow Standard and Unique Naming Convention
-
-  ☐ Name of the MongoDB instance (``mdb-instance-*``)
-
-  ☐ Name of the BigchainDB instance (``bdb-instance-*``)
-
-  ☐ Name of the NGINX instance (``ngx-http-instance-*`` or ``ngx-https-instance-*``)
-
-  ☐ Name of the OpenResty instance (``openresty-instance-*``)
-
-  ☐ Name of the MongoDB monitoring agent instance (``mdb-mon-instance-*``)
-
-  ☐ Name of the Tendermint instance (``tm-instance-*``)
-
-**Example**
-
-
-.. code:: text
-
-  {
-    "MongoDB": [
-      "mdb-instance-1",
-      "mdb-instance-2",
-      "mdb-instance-3",
-      "mdb-instance-4"
-    ],
-    "BigchainDB": [
-      "bdb-instance-1",
-      "bdb-instance-2",
-      "bdb-instance-3",
-      "bdb-instance-4"
-    ],
-    "NGINX": [
-      "ngx-instance-1",
-      "ngx-instance-2",
-      "ngx-instance-3",
-      "ngx-instance-4"
-    ],
-    "OpenResty": [
-      "openresty-instance-1",
-      "openresty-instance-2",
-      "openresty-instance-3",
-      "openresty-instance-4"
-    ],
-    "MongoDB_Monitoring_Agent": [
-      "mdb-mon-instance-1",
-      "mdb-mon-instance-2",
-      "mdb-mon-instance-3",
-      "mdb-mon-instance-4"
-    ],
-    "Tendermint": [
-      "tm-instance-1",
-      "tm-instance-2",
-      "tm-instance-3",
-      "tm-instance-4"
-    ]
-  }
-
-
-☐ Generate three keys and corresponding certificate signing requests (CSRs):
-
-#. Server Certificate for the MongoDB instance
-#. Client Certificate for BigchainDB Server to identify itself to MongoDB
-#. Client Certificate for MongoDB Monitoring Agent to identify itself to MongoDB
-
-Use the self-signed CA to sign those three CSRs. For help, see the pages:
-
-* :doc:`How to Generate a Server Certificate for MongoDB <../production-deployment-template/server-tls-certificate>`
-* :doc:`How to Generate a Client Certificate for MongoDB <../production-deployment-template/client-tls-certificate>`
-
-☐ Make up an FQDN for your BigchainDB node (e.g. ``mynode.mycorp.com``).
+2. Make up an FQDN for your BigchainDB node (e.g. ``mynode.mycorp.com``).
 Make sure you've registered the associated domain name (e.g. ``mycorp.com``),
 and have an SSL certificate for the FQDN.
 (You can get an SSL certificate from any SSL certificate provider.)
 
-☐ Ask the BigchainDB Node operator/owner for the username to use for authenticating to
-MongoDB.
+3. Download the HTTPS certificate chain and HTTPS certificate key of your registered domain.
+Certificate chain includes your primary SSL cert (e.g. your_domain.crt) followed by all intermediate and root
+CA cert(s). e.g. If cert if from DigiCert, download "Best format for nginx".
 
-☐ If the cluster uses 3scale for API authentication, monitoring and billing,
-you must ask the BigchainDB node operator/owner for all relevant 3scale credentials -
-secret token, service ID, version header and API service token.
+4a. If the BigchainDB node uses 3scale for API authentication, monitoring and billing,
+you must ask the BigchainDB node operator/owner for all relevant 3scale credentials and deployment
+workflow.
 
-☐ If the cluster uses MongoDB Cloud Manager for monitoring,
-you must ask the managing organization for the ``Project ID`` and the
-``Agent API Key``.
-(Each Cloud Manager "Project" has its own ``Project ID``. A ``Project ID`` can
-contain a number of ``Agent API Key`` s. It can be found under
-**Settings**. It was recently added to the Cloud Manager to
-allow easier periodic rotation of the ``Agent API Key`` with a constant
-``Project ID``)
+4b. If the BigchainDB does not use 3scale for API authentication, then the organization managing the BigchainDB
+node **must** generate a unique *SECRET_TOKEN* for authentication and authorization of requests to the BigchainDB node. 
 
+.. Note::
+    All the operations required to set up a Self-Signed CA can be automatically generated from
+    our :ref:`"How to configure a BigchainDB node" <how-to-configure-a-bigchaindb-node>` guide.
 
-☐ :doc:`Deploy a Kubernetes cluster on Azure <../production-deployment-template/template-kubernetes-azure>`.
+5. Set Up a Self-Signed Certificate Authority
 
-☐ You can now proceed to set up your :ref:`BigchainDB node
-<kubernetes-template-deploy-a-single-bigchaindb-node>`.
+We use SSL/TLS and self-signed certificates
+for MongoDB authentication (and message encryption).
+The certificates are signed by the organization managing the :ref:`bigchaindb-node`.
+
+You can now proceed to set up your :ref:`BigchainDB node <kubernetes-template-deploy-a-single-bigchaindb-node>`.

--- a/k8s/mongodb/configure_mdb.sh
+++ b/k8s/mongodb/configure_mdb.sh
@@ -10,8 +10,7 @@ else
   exit 1
 fi
 
-[ -z $1 ] && echo "Please specify MongoDB instance name!!"
-MONGODB_INSTANCE_NAME=$1
+MONGODB_INSTANCE_NAME="mdb-instance-0"
 
 if [[ -n "$MONGODB_INSTANCE_NAME" ]]; then
     /usr/local/bin/kubectl exec -it "${MONGODB_INSTANCE_NAME}"\-ss\-0 -- bash -c "/usr/bin/mongo --host localhost --port \$(printenv MONGODB_PORT) --ssl --sslCAFile /etc/mongod/ca/ca.pem --sslPEMKeyFile  /etc/mongod/ssl/mdb-instance.pem < /configure_mdb_users.js"

--- a/k8s/mongodb/mongo-sc.yaml
+++ b/k8s/mongodb/mongo-sc.yaml
@@ -10,7 +10,7 @@ parameters:
   skuName: Premium_LRS #[Premium_LRS, Standard_LRS]
   location: westeurope
   # If you have created a different storage account e.g. for Premium Storage
-  #storageAccount: <Storage account name>
+  storageAccount: <Storage account name>
   # Use Managed Disk(s) with VMs using Managed Disks(Only used for Tectonic deployment)
   #kind: Managed
 ---
@@ -26,6 +26,6 @@ parameters:
   skuName: Premium_LRS #[Premium_LRS, Standard_LRS]
   location: westeurope
   # If you have created a different storage account e.g. for Premium Storage
-  #storageAccount: <Storage account name>
+  storageAccount: <Storage account name>
   # Use Managed Disk(s) with VMs using Managed Disks(Only used for Tectonic deployment)
   #kind: Managed

--- a/k8s/scripts/vars
+++ b/k8s/scripts/vars
@@ -19,7 +19,7 @@ MDB_ADMIN_PASSWORD='superstrongpassword'
 # node. This name should be unique
 TM_INSTANCE_NAME='tm-instance-0'
 
-# Comma sperated list of initial peers in the
+# Comma separated list of initial peers in the
 # network.
 TM_SEEDS='tm-instance-0,tm-instance-1,tm-instance-2'
 


### PR DESCRIPTION
## Description
- Update the production deployment template for v1.0 automation.
- Add docs in workflow if user does not use 3scale
- Note about accessing UI and adding a ‘/’ at the end
- Make mdb-instance-0 default value for configure mdb users script instead of returning error
- Remove --context from docs in kubectl commands
- Make creating a premium account default instruction(premium storage)