### PR TITLE
Problem: Inconsistent treatment of storageAccount across two storageClasses

### DIFF
--- a/k8s/tendermint/tendermint-sc.yaml
+++ b/k8s/tendermint/tendermint-sc.yaml
@@ -10,7 +10,7 @@ parameters:
   skuName: Premium_LRS #[Premium_LRS, Standard_LRS]
   location: westeurope
   # If you have created a different storage account e.g. for Premium Storage
-  #storageAccount: <Storage account name>
+  storageAccount: <Storage account name>
   # Use Managed Disk(s) with VMs using Managed Disks(Only used for Tectonic deployment)
   #kind: Managed
 ---
@@ -26,6 +26,6 @@ parameters:
   skuName: Premium_LRS #[Premium_LRS, Standard_LRS]
   location: westeurope
   # If you have created a different storage account e.g. for Premium Storage
-  #storageAccount: <Storage account name>
+  storageAccount: <Storage account name>
   # Use Managed Disk(s) with VMs using Managed Disks(Only used for Tectonic deployment)
   #kind: Managed


### PR DESCRIPTION
In pull request #2107, the `storageAccount` was uncommented in `mongo-sc.yaml`

This pull request uncomments `storageAccount` in `tendermint-sc.yaml`
