### PR TITLE
Problem: K8s deployment with Access Token Authorization expects Access Token for GET calls and others

### DIFF
--- a/k8s/bigchaindb/bigchaindb-dep.yaml
+++ b/k8s/bigchaindb/bigchaindb-dep.yaml
@@ -48,7 +48,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               name: vars
-              key: cluster-fqdn
+              key: node-fqdn
         - name: BIGCHAINDB_WSSERVER_PORT
           valueFrom:
             configMapKeyRef:
@@ -58,7 +58,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               name: vars
-              key: cluster-frontend-port
+              key: node-frontend-port
         - name: BIGCHAINDB_WSSERVER_ADVERTISED_SCHEME
           valueFrom:
             configMapKeyRef:

--- a/k8s/configuration/config-map.yaml
+++ b/k8s/configuration/config-map.yaml
@@ -7,12 +7,12 @@ metadata:
   name: vars
   namespace: default
 data:
-  # cluster-fqdn is the DNS name registered for your HTTPS certificate.
-  cluster-fqdn: "bdb.example.com"
+  # node-fqdn is the DNS name registered for your HTTPS certificate.
+  node-fqdn: "bdb.example.com"
 
-  # cluster-frontend-port is the port number on which this node's services
+  # node-frontend-port is the port number on which this node's services
   # are available to external clients.
-  cluster-frontend-port: "443"
+  node-frontend-port: "443"
 
   # cluster-health-check-port is the port number on which an external load
   # balancer can check the status/liveness of the external/public server.

--- a/k8s/nginx-http/container/nginx.conf.template
+++ b/k8s/nginx-http/container/nginx.conf.template
@@ -59,7 +59,7 @@ http {
 
   # Frontend server for the external clients
   server {
-    listen CLUSTER_FRONTEND_PORT;
+    listen NODE_FRONTEND_PORT;
     underscores_in_headers on;
 
     # Forward websockets to backend BDB at 9985.

--- a/k8s/nginx-http/container/nginx_entrypoint.bash
+++ b/k8s/nginx-http/container/nginx_entrypoint.bash
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Cluster vars
-cluster_frontend_port=`printenv CLUSTER_FRONTEND_PORT`
+node_frontend_port=`printenv NODE_FRONTEND_PORT`
 
 
 # NGINX vars
@@ -23,7 +23,7 @@ bdb_ws_port=`printenv BIGCHAINDB_WS_PORT`
 
 
 # sanity check
-if [[ -z "${cluster_frontend_port:?CLUSTER_FRONTEND_PORT not specified. Exiting!}" || \
+if [[ -z "${node_frontend_port:?NODE_FRONTEND_PORT not specified. Exiting!}" || \
       -z "${mongo_frontend_port:?MONGODB_FRONTEND_PORT not specified. Exiting!}" || \
       -z "${mongo_backend_host:?MONGODB_BACKEND_HOST not specified. Exiting!}" || \
       -z "${mongo_backend_port:?MONGODB_BACKEND_PORT not specified. Exiting!}" || \
@@ -37,7 +37,7 @@ if [[ -z "${cluster_frontend_port:?CLUSTER_FRONTEND_PORT not specified. Exiting!
       -z "${tm_p2p_port:?TM_P2P_PORT not specified. Exiting!}" ]]; then
   exit 1
 else
-  echo CLUSTER_FRONTEND_PORT="$cluster_frontend_port"
+  echo NODE_FRONTEND_PORT="$node_frontend_port"
   echo DNS_SERVER="$dns_server"
   echo HEALTH_CHECK_PORT="$health_check_port"
   echo MONGODB_FRONTEND_PORT="$mongo_frontend_port"
@@ -54,7 +54,7 @@ fi
 NGINX_CONF_FILE=/etc/nginx/nginx.conf
 
 # configure the nginx.conf file with env variables
-sed -i "s|CLUSTER_FRONTEND_PORT|${cluster_frontend_port}|g" ${NGINX_CONF_FILE}
+sed -i "s|NODE_FRONTEND_PORT|${node_frontend_port}|g" ${NGINX_CONF_FILE}
 sed -i "s|MONGODB_FRONTEND_PORT|${mongo_frontend_port}|g" ${NGINX_CONF_FILE}
 sed -i "s|MONGODB_BACKEND_HOST|${mongo_backend_host}|g" ${NGINX_CONF_FILE}
 sed -i "s|MONGODB_BACKEND_PORT|${mongo_backend_port}|g" ${NGINX_CONF_FILE}

--- a/k8s/nginx-http/nginx-http-dep.yaml
+++ b/k8s/nginx-http/nginx-http-dep.yaml
@@ -15,11 +15,11 @@ spec:
         image: bigchaindb/nginx_http:unstable
         imagePullPolicy: Always
         env:
-        - name: CLUSTER_FRONTEND_PORT
+        - name: NODE_FRONTEND_PORT
           valueFrom:
             configMapKeyRef:
               name: vars
-              key: cluster-frontend-port
+              key: node-frontend-port
         - name: HEALTH_CHECK_PORT
           valueFrom:
             configMapKeyRef:
@@ -74,7 +74,7 @@ spec:
         - containerPort: "<cluster-health-check-port from ConfigMap>"
           protocol: TCP
           name: ngx-health
-        - containerPort: "<cluster-frontend-port from ConfigMap>"
+        - containerPort: "<node-frontend-port from ConfigMap>"
           protocol: TCP
         - containerPort: "<tm-pub-key-access from ConfigMap>"
           protocol: TCP

--- a/k8s/nginx-http/nginx-http-svc.yaml
+++ b/k8s/nginx-http/nginx-http-svc.yaml
@@ -13,9 +13,9 @@ spec:
   selector:
     app: ngx-instance-0-dep
   ports:
-  - port: "<cluster-frontend-port from ConfigMap>"
-    targetPort: "<cluster-frontend-port from ConfigMap>"
-    name: public-cluster-port
+  - port: "<node-frontend-port from ConfigMap>"
+    targetPort: "<node-frontend-port from ConfigMap>"
+    name: public-node-port
     protocol: TCP
   - port: "<tm-pub-key-access from ConfigMap>"
     targetPort: "<tm-pub-key-access from ConfigMap>"

--- a/k8s/nginx-https/container/nginx.conf.template
+++ b/k8s/nginx-https/container/nginx.conf.template
@@ -61,7 +61,7 @@ http {
 
   # Frontend server for the external clients; acts as HTTPS termination point.
   server {
-    listen CLUSTER_FRONTEND_PORT ssl;
+    listen NODE_FRONTEND_PORT ssl;
     server_name "NODE_FQDN";
 
     ssl_certificate /etc/nginx/ssl/cert.pem;
@@ -86,6 +86,7 @@ http {
     # Forward other URL paths as per business logic/use case to BDB or
     # OpenResty instance.
     location / {
+      set $auth_check 1; #Flag to authorize POST requests
       proxy_ignore_client_abort on;
       proxy_set_header X-Real-IP  $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -93,35 +94,39 @@ http {
       # max client request body size: avg transaction size.
       client_max_body_size 15k;
 
+      if ($request_method = 'OPTIONS') {
+          add_header 'Access-Control-Allow-Origin' '*';
+          add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+          add_header 'Access-Control-Allow-Headers' 'DNT,X-Secret-Access-Token,User-Agent';
+          add_header 'Access-Control-Max-Age' 43200;
+          add_header 'Content-Type' 'text/plain charset=UTF-8';
+          add_header 'Content-Length' 0;
+          return 204;
+      }
+
+      if ( $http_x_secret_access_token != "SECRET_ACCESS_TOKEN" ) {
+          set $auth_check 0;
+      }
+      if ($request_method = POST ) {
+          set $auth_check "${auth_check}1";
+      }
+
+      if ( $auth_check = "01" ) {
+          return 403;
+      }
+
       # No auth for GETs, forward directly to BDB.
       if ($request_method = GET) {
-        proxy_pass http://$bdb_backend:BIGCHAINDB_API_PORT;
+        proxy_pass http://$bdb_backend:9984;
       }
 
-      # OPTIONS requests handling for CORS.
-      if ($request_method = 'OPTIONS') {
-        add_header 'Access-Control-Allow-Origin' '*';
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-        add_header 'Access-Control-Allow-Headers' 'DNT,X-Secret-Access-Token,User-Agent';
-        add_header 'Access-Control-Max-Age' 43200;
-        add_header 'Content-Type' 'text/plain charset=UTF-8';
-        add_header 'Content-Length' 0;
-        return 204;
-      }
-
-      # Check for security header to authorize POST requests
-      if ( $http_x_secret_access_token != "SECRET_ACCESS_TOKEN" ) {
-        return 403;
-      }
-
-      # POST requests get forwarded to BDB.
       if ($request_method = POST ) {
-        proxy_pass http://$bdb_backend:BIGCHAINDB_API_PORT;
+          proxy_pass http://$bdb_backend:9984;
       }
 
       # Only return this reponse if request_method is neither POST|GET|OPTIONS
       if ($request_method !~ ^(GET|OPTIONS|POST)$) {
-        return 444;
+          return 444;
       }
     }
   }

--- a/k8s/nginx-https/container/nginx.conf.template
+++ b/k8s/nginx-https/container/nginx.conf.template
@@ -117,11 +117,11 @@ http {
 
       # No auth for GETs, forward directly to BDB.
       if ($request_method = GET) {
-        proxy_pass http://$bdb_backend:9984;
+        proxy_pass http://$bdb_backend:BIGCHAINDB_API_PORT;
       }
 
       if ($request_method = POST ) {
-          proxy_pass http://$bdb_backend:9984;
+          proxy_pass http://$bdb_backend:BIGCHAINDB_API_PORT;
       }
 
       # Only return this reponse if request_method is neither POST|GET|OPTIONS

--- a/k8s/nginx-https/container/nginx.conf.threescale.template
+++ b/k8s/nginx-https/container/nginx.conf.threescale.template
@@ -63,7 +63,7 @@ http {
 
   # Frontend server for the external clients; acts as HTTPS termination point.
   server {
-    listen CLUSTER_FRONTEND_PORT ssl;
+    listen NODE_FRONTEND_PORT ssl;
     server_name "NODE_FQDN";
 
     ssl_certificate /etc/nginx/ssl/cert.pem;

--- a/k8s/nginx-https/container/nginx_entrypoint.bash
+++ b/k8s/nginx-https/container/nginx_entrypoint.bash
@@ -8,7 +8,7 @@ secret_token_auth_mode="secret-token"
 
 # Cluster vars
 node_fqdn=`printenv NODE_FQDN`
-cluster_frontend_port=`printenv CLUSTER_FRONTEND_PORT`
+node_frontend_port=`printenv NODE_FRONTEND_PORT`
 
 
 # NGINX vars
@@ -36,7 +36,7 @@ tm_p2p_port=`printenv TM_P2P_PORT`
 
 
 # sanity check
-if [[ -z "${cluster_frontend_port:?CLUSTER_FRONTEND_PORT not specified. Exiting!}" || \
+if [[ -z "${node_frontend_port:?NODE_FRONTEND_PORT not specified. Exiting!}" || \
       -z "${mongo_backend_host:?MONGODB_BACKEND_HOST not specified. Exiting!}" || \
       -z "${mongo_backend_port:?MONGODB_BACKEND_PORT not specified. Exiting!}" || \
       -z "${openresty_backend_port:?OPENRESTY_BACKEND_PORT not specified. Exiting!}" || \
@@ -54,7 +54,7 @@ if [[ -z "${cluster_frontend_port:?CLUSTER_FRONTEND_PORT not specified. Exiting!
   exit 1
 else
   echo NODE_FQDN="$node_fqdn"
-  echo CLUSTER_FRONTEND_PORT="$cluster_frontend_port"
+  echo NODE_FRONTEND_PORT="$node_frontend_port"
   echo DNS_SERVER="$dns_server"
   echo HEALTH_CHECK_PORT="$health_check_port"
   echo MONGODB_BACKEND_HOST="$mongo_backend_host"
@@ -84,7 +84,7 @@ fi
 
 # configure the nginx.conf file with env variables
 sed -i "s|NODE_FQDN|${node_fqdn}|g" ${NGINX_CONF_FILE}
-sed -i "s|CLUSTER_FRONTEND_PORT|${cluster_frontend_port}|g" ${NGINX_CONF_FILE}
+sed -i "s|NODE_FRONTEND_PORT|${node_frontend_port}|g" ${NGINX_CONF_FILE}
 sed -i "s|MONGODB_BACKEND_HOST|${mongo_backend_host}|g" ${NGINX_CONF_FILE}
 sed -i "s|MONGODB_BACKEND_PORT|${mongo_backend_port}|g" ${NGINX_CONF_FILE}
 sed -i "s|BIGCHAINDB_BACKEND_HOST|${bdb_backend_host}|g" ${NGINX_CONF_FILE}

--- a/k8s/nginx-https/nginx-https-dep.yaml
+++ b/k8s/nginx-https/nginx-https-dep.yaml
@@ -15,11 +15,11 @@ spec:
         image: bigchaindb/nginx_https:unstable
         imagePullPolicy: Always
         env:
-        - name: CLUSTER_FRONTEND_PORT
+        - name: NODE_FRONTEND_PORT
           valueFrom:
             configMapKeyRef:
               name: vars
-              key: cluster-frontend-port
+              key: node-frontend-port
         - name: HEALTH_CHECK_PORT
           valueFrom:
             configMapKeyRef:

--- a/k8s/scripts/functions
+++ b/k8s/scripts/functions
@@ -238,9 +238,9 @@ data:
   # node-fqdn is the DNS name registered for your HTTPS certificate.
   node-fqdn: "${node_fqdn}"
 
-  # cluster-frontend-port is the port number on which this node's services
+  # node-frontend-port is the port number on which this node's services
   # are available to external clients.
-  cluster-frontend-port: "443"
+  node-frontend-port: "443"
 
   # cluster-health-check-port is the port number on which an external load
   # balancer can check the status/liveness of the external/public server.


### PR DESCRIPTION
## Description
- K8s deployment with secret-access-token based authorization instead of three-scale should expect Secret-Access-Token header to be set only for POST calls. But currently it expects the same header for GET calls as well.
- Naming inconsistency for cluster-fqdn causing issues
- Change cluster-frontend-port to node-frontend-port