### PR TITLE
Problem: FastQuery not working

### DIFF
--- a/bigchaindb/tendermint/fastquery.py
+++ b/bigchaindb/tendermint/fastquery.py
@@ -7,6 +7,8 @@ class FastQuery():
     """
     Database queries that join on block results from a single node.
     """
+    def __init__(self, connection):
+        self.connection = connection
 
     def get_outputs_by_public_key(self, public_key):
         """

--- a/bigchaindb/tendermint/lib.py
+++ b/bigchaindb/tendermint/lib.py
@@ -330,7 +330,7 @@ class BigchainDB(Bigchain):
 
     @property
     def fastquery(self):
-        return fastquery.FastQuery(self.connection, self.me)
+        return fastquery.FastQuery(self.connection)
 
 
 Block = namedtuple('Block', ('app_hash', 'height', 'transactions'))

--- a/tests/tendermint/test_fastquery.py
+++ b/tests/tendermint/test_fastquery.py
@@ -1,0 +1,27 @@
+import pytest
+
+from bigchaindb.common.transaction import TransactionLink
+from bigchaindb.models import Transaction
+
+pytestmark = [pytest.mark.bdb, pytest.mark.tendermint]
+
+
+@pytest.fixture
+def txns(b, user_pk, user_sk, user2_pk, user2_sk):
+    txs = [Transaction.create([user_pk], [([user2_pk], 1)]).sign([user_sk]),
+           Transaction.create([user2_pk], [([user_pk], 1)]).sign([user2_sk]),
+           Transaction.create([user_pk], [([user_pk], 1), ([user2_pk], 1)])
+           .sign([user_sk])]
+    b.store_bulk_transactions(txs)
+    return txs
+
+
+def test_get_outputs_by_public_key(b, user_pk, user2_pk, txns):
+    assert b.fastquery.get_outputs_by_public_key(user_pk) == [
+        TransactionLink(txns[1].id, 0),
+        TransactionLink(txns[2].id, 0)
+    ]
+    assert b.fastquery.get_outputs_by_public_key(user2_pk) == [
+        TransactionLink(txns[0].id, 0),
+        TransactionLink(txns[2].id, 1),
+    ]


### PR DESCRIPTION
The call to HTTP API `/api/v1/outputs?public_key=` resuts in an error in `FastQuery` class because of improper class initialization.

Solution: Fix `FastQuery` initialization and write tests for the same.
