### PR TITLE
Problem: Some marketing copy (text blurbs) was old

### DIFF
--- a/docs/server/source/conf.py
+++ b/docs/server/source/conf.py
@@ -305,7 +305,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     (master_doc, 'bigchaindb-server', 'BigchainDB Server Documentation',
-     author, 'bigchaindb-server', 'A scalable blockchain database.',
+     author, 'bigchaindb-server', 'The blockchain database.',
      'Miscellaneous'),
 ]
 

--- a/docs/server/source/production-nodes/node-components.md
+++ b/docs/server/source/production-nodes/node-components.md
@@ -5,7 +5,7 @@ A production BigchainDB node must include:
 * BigchainDB Server
 * MongoDB Server 3.4+ (mongod)
 * Tendermint
-* Scalable storage for MongoDB and Tendermint
+* Storage for MongoDB and Tendermint
 
 It could also include several other components, including:
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 """
-BigchainDB: A Scalable Blockchain Database
+BigchainDB: The Blockchain Database
 
 For full docs visit https://docs.bigchaindb.com
 
@@ -91,16 +91,16 @@ install_requires = [
 setup(
     name='BigchainDB',
     version=version['__version__'],
-    description='BigchainDB: A Scalable Blockchain Database',
+    description='BigchainDB: The Blockchain Database',
     long_description=(
         "BigchainDB allows developers and enterprises to deploy blockchain "
-        "proof-of-concepts, platforms and applications with a scalable blockchain "
+        "proof-of-concepts, platforms and applications with a blockchain "
         "database. BigchainDB supports a wide range of industries and use cases "
         "from identity and intellectual property to supply chains, energy, IoT "
-        "and financial ecosystems. With high throughput, sub-second latency and "
-        "powerful functionality to automate business processes, BigchainDB looks, "
-        "acts and feels like a database but has the core blockchain "
-        "characteristics that enterprises want."
+        "and financial ecosystems. With high throughput, low latency, powerful "
+        "query functionality, decentralized control, immutable data storage and "
+        "built-in asset support, BigchainDB is like a database with blockchain "
+        "characteristics."
         ),
     url='https://github.com/BigchainDB/bigchaindb/',
     author='BigchainDB Contributors',

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,10 +1,11 @@
 name: bigchaindb
 version: git
-summary: a scalable blockchain database
+summary: The blockchain database
 description: |
-  With high throughput, sub-second latency and powerful functionality to
-  automate business processes, BigchainDB looks, acts and feels like a database
-  with added blockchain characteristics.
+  With high throughput, low latency, powerful query functionality,
+  decentralized control, immutable data storage and built-in asset
+  support, BigchainDB is like a database with blockchain
+  characteristics.
 
 # grade must be 'stable' to release into candidate/stable channels
 grade: devel


### PR DESCRIPTION
Solution: Update the old marketing copy.

- Changed "A scalable blockchain database" to "The blockchain database" (or similar). I did a search for `scalable`, then edited the results as appropriate.
- Updated the blurb about automating business processes to the new one that Matthias will be putting on bigchaindb.com soon.
