### PR TITLE
Problem: BigchainDB server configuration causing failure

### DIFF
--- a/k8s/bigchaindb/bigchaindb-dep.yaml
+++ b/k8s/bigchaindb/bigchaindb-dep.yaml
@@ -84,6 +84,10 @@ spec:
             configMapKeyRef:
               name: bdb-config
               key: bigchaindb-log-level
+        - name: BIGCHAINDB_SERVER_WORKERS
+          value: "1"
+        - name: BIGCHAINDB_SERVER_THREADS
+          value: "1"
         - name: BIGCHAINDB_DATABASE_SSL
           value: "true"
         - name: BIGCHAINDB_DATABASE_CA_CERT

--- a/k8s/tendermint/tendermint_container/tendermint_entrypoint.bash
+++ b/k8s/tendermint/tendermint_container/tendermint_entrypoint.bash
@@ -106,4 +106,4 @@ seeds=$(IFS=','; echo "${seeds[*]}")
 
 # start nginx
 echo "INFO: starting tendermint..."
-exec tendermint node --p2p.seeds="$seeds" --moniker="`hostname`" --proxy_app="tcp://$tm_proxy_app:$tm_abci_port"
+exec tendermint node --p2p.seeds="$seeds" --moniker="`hostname`" --proxy_app="tcp://$tm_proxy_app:$tm_abci_port" --log_level debug


### PR DESCRIPTION
## Solution
Update BigchainDB server configuration i.e. threads/workers to `1` and update log level of `tendermint` for better debugging.
- Update bigchaindb server threads/workers to `1`
- Configure `debug` log-level for tendermint

