### PR TITLE
Problem: Multi-threading not configured

### DIFF
--- a/bigchaindb/__init__.py
+++ b/bigchaindb/__init__.py
@@ -89,7 +89,8 @@ config = {
         'bind': 'localhost:9984',
         'loglevel': logging.getLevelName(
             log_config['handlers']['console']['level']).lower(),
-        'workers': None,  # if none, the value will be cpu_count * 2 + 1
+        'threads': 1,
+        'workers': 1,  # if None, the value will be cpu_count * 2 + 1
     },
     'wsserver': {
         'scheme': 'ws',

--- a/docs/server/source/server-reference/configuration.md
+++ b/docs/server/source/server-reference/configuration.md
@@ -103,7 +103,7 @@ These settings are for the [Gunicorn HTTP server](http://gunicorn.org/), which i
 [Gunicorn's documentation](http://docs.gunicorn.org/en/latest/settings.html#loglevel)
 for more information.
 
-`server.workers` is [the number of worker processes](http://docs.gunicorn.org/en/stable/settings.html#workers) for handling requests. If `None` (the default), the value will be (2 × cpu_count + 1). Each worker process has a single thread. The HTTP server will be able to handle `server.workers` requests simultaneously.
+`server.workers` is [the number of worker processes](http://docs.gunicorn.org/en/stable/settings.html#workers) for handling requests. If set to `None`, the value will be (2 × cpu_count + 1). Each worker process has a single thread. The HTTP server will be able to handle `server.workers` requests simultaneously.
 
 **Example using environment variables**
 ```text
@@ -126,7 +126,7 @@ export BIGCHAINDB_SERVER_WORKERS=5
 "server": {
     "bind": "localhost:9984",
     "loglevel": "info",
-    "workers": null,
+    "workers": 1,
 }
 ```
 


### PR DESCRIPTION
Solution: Auto-generate multi-threading config with default threads and workers set to 1

