### PR TITLE
Problem: No link back to Root Docs from Contrib. Docs

### DIFF
--- a/docs/contributing/source/index.rst
+++ b/docs/contributing/source/index.rst
@@ -17,6 +17,7 @@ Contents
 .. toctree::
    :maxdepth: 2
 
+   ← Back to All BigchainDB Docs <https://docs.bigchaindb.com/en/latest/index.html>
    ways-to-contribute/index
    dev-setup-coding-and-contribution-process/index
    cross-project-policies/index


### PR DESCRIPTION
Solution: Add a link back to the Root Docs from the 'Contributing to BigchainDB' Docs

Other docs, such as the BigchainDB Server Docs, already had a convenient top-level link (in the Table of Contents) to take the reader back to the Root Docs. This PR puts a similar link in the 'Contributing to BigchainDB' Docs.