### PR TITLE
Problem: Outdated docker image tags for 2.0.0-alpha release

### DIFF
--- a/k8s/bigchaindb/bigchaindb-dep.yaml
+++ b/k8s/bigchaindb/bigchaindb-dep.yaml
@@ -12,7 +12,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: bigchaindb
-        image: bigchaindb/bigchaindb:unstable
+        image: bigchaindb/bigchaindb:2.0.0-alpha
         imagePullPolicy: Always
         args:
         - start

--- a/k8s/mongodb-monitoring-agent/container/docker_build_and_push.bash
+++ b/k8s/mongodb-monitoring-agent/container/docker_build_and_push.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-docker build -t bigchaindb/mongodb-monitoring-agent:3.1 .
+docker build -t bigchaindb/mongodb-monitoring-agent:2.0.0-alpha .
 
-docker push bigchaindb/mongodb-monitoring-agent:3.1
+docker push bigchaindb/mongodb-monitoring-agent:2.0.0-alpha

--- a/k8s/mongodb-monitoring-agent/mongo-mon-dep.yaml
+++ b/k8s/mongodb-monitoring-agent/mongo-mon-dep.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: mdb-mon
-        image: bigchaindb/mongodb-monitoring-agent:3.1
+        image: bigchaindb/mongodb-monitoring-agent:2.0.0-alpha
         imagePullPolicy: IfNotPresent
         env:
         - name: MMS_API_KEYFILE_PATH

--- a/k8s/mongodb/container/docker_build_and_push.bash
+++ b/k8s/mongodb/container/docker_build_and_push.bash
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-docker build -t bigchaindb/localmongodb:unstable .
-docker push bigchaindb/localmongodb:unstable
+docker build -t bigchaindb/localmongodb:2.0.0-alpha .
+docker push bigchaindb/localmongodb:2.0.0-alpha

--- a/k8s/mongodb/mongo-ss.yaml
+++ b/k8s/mongodb/mongo-ss.yaml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: mongodb
-        image: bigchaindb/localmongodb:unstable
+        image: bigchaindb/localmongodb:2.0.0-alpha
         imagePullPolicy: Always
         env:
         - name: MONGODB_FQDN

--- a/k8s/nginx-http/container/docker_build_and_push.bash
+++ b/k8s/nginx-http/container/docker_build_and_push.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-docker build -t bigchaindb/nginx_http:unstable .
+docker build -t bigchaindb/nginx_http:2.0.0-alpha .
 
-docker push bigchaindb/nginx_http:unstable
+docker push bigchaindb/nginx_http:2.0.0-alpha

--- a/k8s/nginx-http/nginx-http-dep.yaml
+++ b/k8s/nginx-http/nginx-http-dep.yaml
@@ -12,7 +12,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: nginx
-        image: bigchaindb/nginx_http:unstable
+        image: bigchaindb/nginx_http:2.0.0-alpha
         imagePullPolicy: Always
         env:
         - name: NODE_FRONTEND_PORT

--- a/k8s/nginx-https/container/docker_build_and_push.bash
+++ b/k8s/nginx-https/container/docker_build_and_push.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-docker build -t bigchaindb/nginx_https:unstable .
+docker build -t bigchaindb/nginx_https:2.0.0-alpha .
 
-docker push bigchaindb/nginx_https:unstable
+docker push bigchaindb/nginx_https:2.0.0-alpha

--- a/k8s/nginx-https/nginx-https-dep.yaml
+++ b/k8s/nginx-https/nginx-https-dep.yaml
@@ -12,7 +12,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: nginx
-        image: bigchaindb/nginx_https:unstable
+        image: bigchaindb/nginx_https:2.0.0-alpha
         imagePullPolicy: Always
         env:
         - name: NODE_FRONTEND_PORT

--- a/k8s/nginx-openresty/container/docker_build_and_push.bash
+++ b/k8s/nginx-openresty/container/docker_build_and_push.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-docker build -t bigchaindb/nginx_3scale:3.1 .
+docker build -t bigchaindb/nginx_3scale:2.0.0-alpha .
 
-docker push bigchaindb/nginx_3scale:3.1
+docker push bigchaindb/nginx_3scale:2.0.0-alpha

--- a/k8s/nginx-openresty/nginx-openresty-dep.yaml
+++ b/k8s/nginx-openresty/nginx-openresty-dep.yaml
@@ -12,7 +12,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: nginx-openresty
-        image: bigchaindb/nginx_3scale:3.0
+        image: bigchaindb/nginx_3scale:2.0.0-alpha
         imagePullPolicy: IfNotPresent
         env:
         - name: DNS_SERVER

--- a/k8s/tendermint/nginx_container/docker_build_and_push.bash
+++ b/k8s/tendermint/nginx_container/docker_build_and_push.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-docker build -t bigchaindb/nginx_pub_key_access:unstable .
+docker build -t bigchaindb/nginx_pub_key_access:2.0.0-alpha .
 
-docker push bigchaindb/nginx_pub_key_access:unstable
+docker push bigchaindb/nginx_pub_key_access:2.0.0-alpha

--- a/k8s/tendermint/tendermint-ss.yaml
+++ b/k8s/tendermint/tendermint-ss.yaml
@@ -32,7 +32,7 @@ spec:
       # Nginx container for hosting public key of this ndoe
       - name: nginx
         imagePullPolicy: Always
-        image: bigchaindb/nginx_pub_key_access:unstable
+        image: bigchaindb/nginx_pub_key_access:2.0.0-alpha
         env:
         - name: TM_PUB_KEY_ACCESS_PORT
           valueFrom:
@@ -49,7 +49,7 @@ spec:
       #Tendermint container
       - name: tendermint
         imagePullPolicy: Always
-        image: bigchaindb/tendermint:unstable
+        image: bigchaindb/tendermint:2.0.0-alpha
         env:
         - name: TM_SEEDS
           valueFrom:

--- a/k8s/tendermint/tendermint_container/docker_build_and_push.bash
+++ b/k8s/tendermint/tendermint_container/docker_build_and_push.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-docker build -t bigchaindb/tendermint:unstable .
+docker build -t bigchaindb/tendermint:2.0.0-alpha .
 
-docker push bigchaindb/tendermint:unstable
+docker push bigchaindb/tendermint:2.0.0-alpha


### PR DESCRIPTION
## Solution
- Update the default docker images to be used with the Kubernetes configuration files.
- Update the docker build and push scripts to the latest image.

## Issues Resolved
Resolves #1955 
