### PR TITLE
Problem: bigchaindb upsert-validator labelled "insecure"

### DIFF
--- a/docs/server/source/server-reference/bigchaindb-cli.md
+++ b/docs/server/source/server-reference/bigchaindb-cli.md
@@ -75,7 +75,7 @@ configuration file as documented under
 [Configuration Settings](configuration.html).
 
 
-## bigchaindb upsert-validator (insecure)
+## bigchaindb upsert-validator
 Add, update, or remove a validator from the validators set of the local node. The command implements [3/UPSERT-VALIDATORS](https://github.com/bigchaindb/BEPs/tree/master/3), check it out if you need more details on how this is orchestrated.
 
 Below is the command line syntax,


### PR DESCRIPTION
Solution: Remove the "insecure" label from the docs on `bigchaindb upsert-validator`

I already made a similar change in the bigchaindb/BEPs repo: https://github.com/bigchaindb/BEPs/pull/28 
