### PR TITLE
Problem: Typo with get kube-dns IP

### DIFF
--- a/docs/server/source/production-deployment-template/node-config-map-and-secrets.rst
+++ b/docs/server/source/production-deployment-template/node-config-map-and-secrets.rst
@@ -78,7 +78,7 @@ to resolve the hostnames of all the services running in the k8s cluster.
 .. code::
 
    # retrieval via commandline.
-   $ kubectl get pods --namespace=kube-system -l k8s-app=kube-dns
+   $ kubectl get services --namespace=kube-system -l k8s-app=kube-dns
 
 
 .. _generate-config:

--- a/k8s/scripts/vars
+++ b/k8s/scripts/vars
@@ -42,5 +42,5 @@ TM_CHAIN_ID='test-chain-rwcPML'
 
 # IP Address of the resolver(DNS server).
 # i.e. IP of `kube-dns`, can be retrieved using:
-# $ kubectl get pods --namespace=kube-system -l k8s-app=kube-dns
+# $ kubectl get services --namespace=kube-system -l k8s-app=kube-dns
 NODE_DNS_SERVER='10.0.0.10'


### PR DESCRIPTION
## Solution
The correct command is: `kubectl get services --namespace=kube-system -l k8s-app=kube-dns` **instead of** `kubectl get pods --namespace=kube-system -l k8s-app=kube-dns`
