### PR TITLE
Revert 2179 iss/check python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,7 @@ For full docs visit https://docs.bigchaindb.com
 
 """
 from setuptools import setup, find_packages
-import sys
 
-
-if sys.version_info < (3, 6):
-    sys.exit('Please use python version 3.6 or higher')
 
 # get the version
 version = {}
@@ -111,7 +107,7 @@ setup(
     author_email='dev@bigchaindb.com',
     license='Apache Software License 2.0',
     zip_safe=False,
-    python_requires='>=3.6',
+
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
The driver docs were failing because the server doesn't support python 3.5 anymore

@vrde proposed a solution for the problem discussed [here](https://github.com/bigchaindb/bigchaindb-driver/pull/393#pullrequestreview-109975830)
> To me the problem is another one: _We broke compatibility with Python 3.5, how do we restore it_.
> Some (exclusive) solutions:
> 1. Since the driver imports BigchainDB Server :woman_facepalming:, let's make BigchainDB Server compatible with Python 3.5 by reverting [bigchaindb#2179] (https://github.com/bigchaindb/bigchaindb/pull/2179)—and eventually formatting with [`f-strings`](https://www.python.org/dev/peps/pep-0498/) if this is the only compatibility issue.
> 2. Refactor `common`, and move it out from `BigchainDB Server`.
> 3. Copy paste `common` in the driver.
> The fastest :racehorse: solution is 1. The best :1st_place_medal: solution is 2. The :hankey: solution is 3.