### PR TITLE
Problem: Websocket connection fails and retries are exhausted

### DIFF
--- a/bigchaindb/tendermint/event_stream.py
+++ b/bigchaindb/tendermint/event_stream.py
@@ -74,7 +74,7 @@ def try_connect_and_recv(event_queue, max_tries):
     except Exception as e:
         if max_tries:
             logger.warning('WebSocket connection failed with exception %s', e)
-            time.sleep(2)
+            time.sleep(3)
             yield from try_connect_and_recv(event_queue, max_tries-1)
         else:
             logger.exception('WebSocket connection failed with exception %s', e)
@@ -83,6 +83,6 @@ def try_connect_and_recv(event_queue, max_tries):
 def start(event_queue):
     loop = asyncio.get_event_loop()
     try:
-        loop.run_until_complete(try_connect_and_recv(event_queue, 5))
+        loop.run_until_complete(try_connect_and_recv(event_queue, 10))
     except (KeyboardInterrupt, SystemExit):
         logger.info('Shutting down Tendermint event stream connection')

--- a/k8s/tendermint/tendermint-ss.yaml
+++ b/k8s/tendermint/tendermint-ss.yaml
@@ -86,6 +86,11 @@ spec:
             configMapKeyRef:
               name: tendermint-config
               key: tm-p2p-port
+        - name: TM_INSTANCE_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: tendermint-config
+              key: tm-instance-name
         - name: TMHOME
           value: /tendermint
         - name: TM_PROXY_APP

--- a/k8s/tendermint/tendermint_container/tendermint_entrypoint.bash
+++ b/k8s/tendermint/tendermint_container/tendermint_entrypoint.bash
@@ -32,7 +32,7 @@ if [[ -z "${tm_seeds:?TM_SEEDS not specified. Exiting!}" || \
       -z "${tmhome:?TMHOME not specified. Exiting!}" || \
       -z "${tm_p2p_port:?TM_P2P_PORT not specified. Exiting!}" || \
       -z "${tm_abci_port:?TM_ABCI_PORT not specified. Exiting! }" || \
-      -z "${tm_instance_name:?TM_INSTANCE_NAME not specifiec. Exiting! }" ]]; then
+      -z "${tm_instance_name:?TM_INSTANCE_NAME not specified. Exiting! }" ]]; then
   echo "Missing required enviroment variables."
   exit 1
 else

--- a/k8s/tendermint/tendermint_container/tendermint_entrypoint.bash
+++ b/k8s/tendermint/tendermint_container/tendermint_entrypoint.bash
@@ -15,6 +15,7 @@ tm_p2p_port=`printenv TM_P2P_PORT`
 tmhome=`printenv TMHOME`
 tm_proxy_app=`printenv TM_PROXY_APP`
 tm_abci_port=`printenv TM_ABCI_PORT`
+tm_instance_name=`printenv TM_INSTANCE_NAME`
 
 # Container vars
 RETRIES=0
@@ -30,7 +31,8 @@ if [[ -z "${tm_seeds:?TM_SEEDS not specified. Exiting!}" || \
       -z "${tm_chain_id:?TM_CHAIN_ID not specified. Exiting!}" || \
       -z "${tmhome:?TMHOME not specified. Exiting!}" || \
       -z "${tm_p2p_port:?TM_P2P_PORT not specified. Exiting!}" || \
-      -z "${tm_abci_port:?TM_ABCI_PORT not specified. Exiting! }" ]]; then
+      -z "${tm_abci_port:?TM_ABCI_PORT not specified. Exiting! }" || \
+      -z "${tm_instance_name:?TM_INSTANCE_NAME not specifiec. Exiting! }" ]]; then
   echo "Missing required enviroment variables."
   exit 1
 else
@@ -43,6 +45,7 @@ else
   echo tmhome="$TMHOME"
   echo tm_p2p_port="$TM_P2P_PORT"
   echo tm_abci_port="$TM_ABCI_PORT"
+  echo tm_instance_name="$TM_INSTANCE_NAME"
 fi
 
 # copy template
@@ -106,4 +109,4 @@ seeds=$(IFS=','; echo "${seeds[*]}")
 
 # start nginx
 echo "INFO: starting tendermint..."
-exec tendermint node --p2p.seeds="$seeds" --moniker="`hostname`" --proxy_app="tcp://$tm_proxy_app:$tm_abci_port" --log_level debug
+exec tendermint node --p2p.seeds="$seeds" --moniker="$tm_instance_name" --proxy_app="tcp://$tm_proxy_app:$tm_abci_port" --log_level debug


### PR DESCRIPTION
In a Kubernetes deployment, websocket connection to tendermint fails and all the retries are burnt out, the reason is that BigchainDB spins up all the servers/modules asynchronously but the Tendermint connection with BigchainDB/abci is synchronous, hence before the abci connections are established the connections initiated from BigchainDB for websocket are exhausted.

Also adding `tm-instance-name` as `moniker` for Tendermint instances.
## Solution

- Make the minimum timeout to be 30 seconds(10(retries)*3(seconds)). 
- `moniker` should represent the `tm-instance-name` i.e. name of the Kubernetes service instead of `hostname`
