### PR TITLE
Problem: Empty blocks not being retrieved from BigchainDB

### DIFF
--- a/k8s/tendermint/tendermint_container/tendermint_entrypoint.bash
+++ b/k8s/tendermint/tendermint_container/tendermint_entrypoint.bash
@@ -109,4 +109,4 @@ seeds=$(IFS=','; echo "${seeds[*]}")
 
 # start nginx
 echo "INFO: starting tendermint..."
-exec tendermint node --p2p.seeds="$seeds" --moniker="$tm_instance_name" --proxy_app="tcp://$tm_proxy_app:$tm_abci_port" --log_level debug
+exec tendermint node --p2p.seeds="$seeds" --moniker="$tm_instance_name" --proxy_app="tcp://$tm_proxy_app:$tm_abci_port" --consensus.create_empty_blocks=false


### PR DESCRIPTION
## Solution

To keep a consistent state between what BigchainDB and Tendermint, run Tendermint with a configuration such that it does not create empty blocks and that can be done by setting `--consensus.create_empty_blocks` to false.

*Side note*: Also removed the `log-level->debug` because it was producing tremendous amount of logs and OMS complained about logs being full for free-tier in a couple of hours.

Fixes #2204 

