### PR TITLE
Problem: Kubernetes template broken for threescale/apicast deployment

### DIFF
--- a/k8s/configuration/config-map.yaml
+++ b/k8s/configuration/config-map.yaml
@@ -57,11 +57,12 @@ data:
   # available/listening for requests.
   mongodb-backend-port: "27017"
 
+  # TODO: Change `openresty` to `apicast`
   # openresty-backend-port is the port number on which OpenResty is listening
   # for requests. This is used by the NGINX instance to forward the requests to
   # the right port, and by OpenResty instance to bind to the correct port to
   # receive requests from NGINX instance.
-  openresty-backend-port: "80"
+  openresty-backend-port: "8080"
 
   # BigchainDB configuration parameters
   # Refer https://docs.bigchaindb.com/projects/server/en/latest/server-reference/configuration.html

--- a/k8s/scripts/functions
+++ b/k8s/scripts/functions
@@ -228,6 +228,7 @@ function generate_config_map(){
     tm_chain_id="${8}"
     tm_instance_name="${9}"
     dns_resolver_k8s="${10}"
+    auth_mode="${11}"
 
     cat > config-map.yaml << EOF
 apiVersion: v1
@@ -282,11 +283,12 @@ data:
   # available/listening for requests.
   mongodb-backend-port: "27017"
 
+  # TODO: Change `openresty` to `apicast`
   # openresty-backend-port is the port number on which OpenResty is listening
   # for requests. This is used by the NGINX instance to forward the requests to
   # the right port, and by OpenResty instance to bind to the correct port to
   # receive requests from NGINX instance.
-  openresty-backend-port: "80"
+  openresty-backend-port: "8080"
 
   # BigchainDB configuration parameters
   # Refer https://docs.bigchaindb.com/projects/server/en/latest/server-reference/configuration.html
@@ -318,7 +320,7 @@ data:
   storage-engine-cache-size: ""
 
   # POST API authorization mode [threescale | secret-token]
-  authorization-mode: "secret-token"
+  authorization-mode: "${auth_mode}"
 
 ---
 apiVersion: v1

--- a/k8s/scripts/generate_configs.sh
+++ b/k8s/scripts/generate_configs.sh
@@ -15,6 +15,7 @@ INDEX='0'
 CONFIGURE_CA='true'
 CONFIGURE_MEMBER='true'
 CONFIGURE_CLIENT='true'
+SECRET_TOKEN=${SECRET_TOKEN:="secret-token"}
 
 function show_help(){
 cat > /dev/stdout << END
@@ -49,6 +50,17 @@ done
 # sanity checks
 if [[ -z "${CERT_DIR}" ]] ; then
     echo "Missing required argument CERT_DIR"
+    exit 1
+fi
+
+if [[ -z "${AUTH_MODE}" ]]; then
+    echo "Missing required argument AUTH_MODE"
+    exit 1
+fi
+
+if [[ "${AUTH_MODE}" != "secret-token" && \
+    "${AUTH_MODE}" != "threescale" ]]; then
+    echo "Invalid AUTH_MODE configuration, only accepted values are: [secret-token, threescale]"
     exit 1
 fi
 
@@ -87,4 +99,5 @@ convert_b64 $BASE_K8S_DIR $BASE_CA_DIR/$BASE_EASY_RSA_PATH $BASE_CLIENT_CERT_DIR
 get_users $BASE_USERS_DIR $BASE_CA_DIR/$BASE_EASY_RSA_PATH
 generate_secretes_no_threescale $BASE_K8S_DIR $SECRET_TOKEN $HTTPS_CERT_KEY_FILE_NAME $HTTPS_CERT_CHAIN_FILE_NAME $MDB_ADMIN_PASSWORD
 
-generate_config_map $BASE_USERS_DIR $MDB_ADMIN_USER $NODE_FQDN $TM_SEEDS $TM_VALIDATORS $TM_VALIDATOR_POWERS $TM_GENESIS_TIME $TM_CHAIN_ID $TM_INSTANCE_NAME $NODE_DNS_SERVER
+generate_config_map $BASE_USERS_DIR $MDB_ADMIN_USER $NODE_FQDN $TM_SEEDS $TM_VALIDATORS $TM_VALIDATOR_POWERS $TM_GENESIS_TIME \
+    $TM_CHAIN_ID $TM_INSTANCE_NAME $NODE_DNS_SERVER $AUTH_MODE

--- a/k8s/scripts/vars
+++ b/k8s/scripts/vars
@@ -1,8 +1,12 @@
 # DNS name of the bigchaindb node
 NODE_FQDN="test-node.bigchaindb.com"
 
+# Authorization mode: [secret-token, threescale]
+AUTH_MODE="secret-token"
+
 # Secret token used for authorization of
 # POST requests to the bigchaindb node
+# Only required when AUTH_MODE=secret-token
 SECRET_TOKEN="test-secret"
 
 # Absolute path for the SSL certificate key


### PR DESCRIPTION
## Solution
- The `nginx-https` i.e. node entrypoint proxy has an invalid configuration of for the `nginx-threescale.conf`
  - `OPENRESTY_BACKEND_PORT` is set to `80` by default and the `proxy_pass http://$openresty_backend:OPENRESTY_BACKEND_PORT` directive in nginx forwards it to openresty instance running on port `80` instead it should be `8080` because the `apicast-gateway` is working/listening on `8080`.
- There is no way to configure `authorization-mode` in `config-map.yaml` using `bigchaindb/k8s/scripts/generate_configs.sh` since we do not take `authorization-mode` as a configurable parameter in `bigchaindb/k8s/scripts/vars`, it always writes `authorization-mode: secret-token`
  - The above concern needs to be addressed as well.

Partially Resolves #2202
