### PR TITLE
Problem: LICENSES.md file somehow reverted to old version (old license)

### DIFF
--- a/LICENSES.md
+++ b/LICENSES.md
@@ -1,27 +1,22 @@
-# Code Licenses
+# Copyrights and Licenses
 
-Except as noted in the **Exceptions** section below, for all code in this repository, BigchainDB GmbH ("We") either:
+## Copyrights
+
+Except as noted in the **Exceptions** section below, for all code and documentation in this repository, BigchainDB GmbH ("We") either:
 
 1. owns the copyright, or
 2. owns the right to sublicense it under any license (because all external contributors must agree to a Contributor License Agreement).
 
-Therefore We can choose how to license all the code in this repository (except for the Exceptions). We can license it to Joe Xname under one license and Company Yname under a different license.
+## Code Licenses
 
-The two general options are:
+All code in this repository, including short code snippets in the documentation, but not including the **Exceptions** noted below, is licensed under the Apache License, Version 2.0, the full text of which can be found at [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0).
 
-1. You can get it under a commercial license for a fee. We can negotiate the terms of that license. It's not like we have some standard take-it-or-leave it commercial license. If you want to modify it and keep your modifications private, then that's certainly possible. Just ask.
-2. You can get it under the AGPLv3 license for free. You don't even have to ask us. That's because all code in _this_ repository is licensed under the GNU Affero General Public License version 3 (AGPLv3), the full text of which can be found at [http://www.gnu.org/licenses/agpl.html](http://www.gnu.org/licenses/agpl.html).
+For the licenses on all other BigchainDB-related code (i.e. in other repositories), see the LICENSE file in the associated repository.
 
-If you don't like the AGPL license, then contact us to get a different license.
-
-All short code snippets embedded in the official BigchainDB _documentation_ are licensed under the Apache License, Version 2.0, the full text of which can be found at [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0).
-
-For the licenses on all other BigchainDB-related code, see the LICENSE file in the associated repository.
-
-# Documentation Licenses
+## Documentation Licenses
 
 The official BigchainDB documentation, _except for the short code snippets embedded within it_, is licensed under a Creative Commons Attribution-ShareAlike 4.0 International license, the full text of which can be found at [http://creativecommons.org/licenses/by-sa/4.0/legalcode](http://creativecommons.org/licenses/by-sa/4.0/legalcode).
 
-# Exceptions
+## Exceptions
 
 The contents of the `k8s/nginx-openresty/` directory are licensed as described in the `LICENSE.md` file in that directory.


### PR DESCRIPTION
Solution: Change LICENSES.md to the new license, i.e. Apache v2.

## Background 

I changed the license on all BigchainDB Server code from AGPL v3 to Apache v2 in January. See pull request #2020

Somehow since then, the license got changed back to the old license without us noticing. It was noticed by @dscook who asked us about it on Gitter, see https://gitter.im/bigchaindb/bigchaindb?at=5ad0cfc66d7e07082bef276b 

This pull request changes the license back to Apache v2, which is what it should have been ever since January.