### PR TITLE
Problem: Not enough logs to debug an issue while developing

### DIFF
--- a/.ci/entrypoint.sh
+++ b/.ci/entrypoint.sh
@@ -5,5 +5,5 @@ set -e -x
 if [[ ${BIGCHAINDB_CI_ABCI} == 'enable' ]]; then
     sleep 3600
 else
-    bigchaindb start
+    bigchaindb -l DEBUG start
 fi


### PR DESCRIPTION
## Solution
Start bigchaindb with debug flag i.e. `bigchaindb -l DEBUG start`
