### PR TITLE
Problem: No debug statement for post transaciton

### DIFF
--- a/bigchaindb/tendermint/lib.py
+++ b/bigchaindb/tendermint/lib.py
@@ -61,6 +61,7 @@ class BigchainDB(Bigchain):
         return self._process_post_response(response.json(), mode)
 
     def _process_post_response(self, response, mode):
+        logger.debug(response)
         result = response['result']
         if mode == MODE_LIST[1]:
             status_code = result['check_tx']['code']


### PR DESCRIPTION
Solution: write debug statement for response received from POST transaction

#### Description
The reponses received when POSTing a transaction to Tendermint are not fully documented in Tendermint's docs. So a debug statement is required for handling listing and handling unkown responses.