### PR TITLE
Problem: Arbitrary max_tries in bigchaindb when connecting to tendermint ws

### DIFF
--- a/bigchaindb/tendermint/event_stream.py
+++ b/bigchaindb/tendermint/event_stream.py
@@ -67,22 +67,19 @@ def subscribe_events(ws, stream_id):
 
 
 @asyncio.coroutine
-def try_connect_and_recv(event_queue, max_tries):
+def try_connect_and_recv(event_queue):
     try:
         yield from connect_and_recv(event_queue)
 
     except Exception as e:
-        if max_tries:
-            logger.warning('WebSocket connection failed with exception %s', e)
-            time.sleep(3)
-            yield from try_connect_and_recv(event_queue, max_tries-1)
-        else:
-            logger.exception('WebSocket connection failed with exception %s', e)
+        logger.warning('WebSocket connection failed with exception %s', e)
+        time.sleep(3)
+        yield from try_connect_and_recv(event_queue)
 
 
 def start(event_queue):
     loop = asyncio.get_event_loop()
     try:
-        loop.run_until_complete(try_connect_and_recv(event_queue, 10))
+        loop.run_until_complete(try_connect_and_recv(event_queue))
     except (KeyboardInterrupt, SystemExit):
         logger.info('Shutting down Tendermint event stream connection')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - "9985:9985"
       - "46658"
     healthcheck:
-      test: ["CMD", "bash", "-c", "curl http://bigchaindb:9984 && curl http://tendermint:46657/abci_query"]
+      test: ["CMD", "bash", "-c", "curl http://bigchaindb:9984"]
       interval: 3s
       timeout: 5s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - "9985:9985"
       - "46658"
     healthcheck:
-      test: ["CMD", "bash", "-c", "curl http://bigchaindb:9984"]
+      test: ["CMD", "bash", "-c", "curl http://bigchaindb:9984 && curl http://tendermint:46657/abci_query"]
       interval: 3s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
**Solution:** When bigchaindb service start it starts a pyabci server app and tries to connect with tendermint over a websocket and fails after 10 max_tries.

Tendermint on the other hand when it starts tries to connect with bigchaindb pyabci app and waits indefinitely until the app server becomes available.

So there is a cyclic dependency between two services but the arbitraty limit of max_tries from bigchaindb service adds un-necessary constraint for tendermint service to be started first.

Issues Resolved: #2240 
