### PR TITLE
Problem: abci dependency not processed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ COPY . /usr/src/app/
 WORKDIR /usr/src/app
 RUN apt-get -qq update \
     && apt-get -y upgrade \
+    && apt-get install -y jq \
+    && pip install --no-cache-dir --process-dependency-links . \
     && pip install --no-cache-dir . \
     && apt-get autoremove \
     && apt-get clean


### PR DESCRIPTION
## Solution

- Process the dependency linked added for `py-abci`
- Install `jq` in the BigchainDB container

