### PR TITLE
Problem: Tendermint 0.19.0 missing crucial fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       retries: 3
     entrypoint: '.ci/entrypoint.sh'
   tendermint:
-    image: tendermint/tendermint:0.19.0
+    image: tendermint/tendermint:0.19.2
     # volumes:
     #   - ./tmdata:/tendermint
     entrypoint: ''

--- a/docs/server/source/production-deployment-template/workflow.rst
+++ b/docs/server/source/production-deployment-template/workflow.rst
@@ -44,7 +44,7 @@ you can do this:
 .. code::
 
    $ mkdir $(pwd)/tmdata
-   $ docker run --rm -v $(pwd)/tmdata:/tendermint tendermint/tendermint:0.13 init
+   $ docker run --rm -v $(pwd)/tmdata:/tendermint/config tendermint/tendermint:0.19.2 init
    $ cat $(pwd)/tmdata/genesis.json
 
 You should see something that looks like:

--- a/k8s/bigchaindb/tendermint_container/Dockerfile
+++ b/k8s/bigchaindb/tendermint_container/Dockerfile
@@ -1,4 +1,4 @@
-FROM tendermint/tendermint:0.19.0
+FROM tendermint/tendermint:0.19.2
 LABEL maintainer "dev@bigchaindb.com"
 WORKDIR /
 USER root


### PR DESCRIPTION
## Description

After the integration of BigchainDB v2.0 with Tendermint v0.19.0, there are some crucial fixes missing.
One of the most important being:

- [p2p] Fix reconnect to persistent peer when first dial fails
- Rest can be checked out in the [CHANGELOG](https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md)

## Solution

Start using `v0.19.2`
