### PR TITLE
Problem: Acceptance tests on CI failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ matrix:
     - BIGCHAINDB_DATABASE_BACKEND=localmongodb
     - BIGCHAINDB_DATABASE_SSL=
     - BIGCHAINDB_CI_ABCI=enable
-  - env:
+  - python: 3.6
+    env:
     - BIGCHAINDB_ACCEPTANCE_TEST=enable
 
 before_install: sudo .ci/travis-before-install.sh


### PR DESCRIPTION
## Description
Acceptance tests on Travis are failing because the following command fails during `travis-install.sh`

```
/bin/sh -c pip install --no-cache-dir --process-dependency-links -e .[dev]
```

More details in the [travis build](https://travis-ci.org/bigchaindb/bigchaindb/jobs/373963887).

## Solution

Update the travis matrix to enable acceptance tests for python36
