### PR TITLE
Problem: Event stream test failing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -567,7 +567,7 @@ def abci_http(_setup_database, _configure_bigchaindb, abci_server,
     import requests
     import time
 
-    for i in range(5):
+    for i in range(300):
         try:
             uri = 'http://{}:{}/abci_info'.format(tendermint_host, tendermint_port)
             requests.get(uri)

--- a/tests/tendermint/test_event_stream.py
+++ b/tests/tendermint/test_event_stream.py
@@ -77,8 +77,8 @@ def test_process_unknown_event():
     assert event_queue.empty()
 
 
-@pytest.mark.abci
 @pytest.mark.asyncio
+@pytest.mark.abci
 async def test_subscribe_events(tendermint_ws_url, b):
     from bigchaindb.tendermint.event_stream import subscribe_events
     from bigchaindb.common.crypto import generate_key_pair


### PR DESCRIPTION
Solution: Extend the wait time so that Tendermint can start
