### PR TITLE
Problem: Tendermint creates empty blocks in the Docker-based setup.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     ports:
       - "46656"
       - "46657"
-    command: sh -c "tendermint init && tendermint node --proxy_app=tcp://bigchaindb:46658"
+    command: sh -c "tendermint init && tendermint node --consensus.create_empty_blocks=false --proxy_app=tcp://bigchaindb:46658"
   bdb:
     image: busybox
     depends_on:


### PR DESCRIPTION
Solution: Set the --consensus.create_empty_blocks=false option in docker-compose.yml.

A short-term remedy for #2204. Let's keep it open to wait for a long-term solution.