### PR TITLE
Problem: abci_info liveness probe check is not enough

### DIFF
--- a/k8s/bigchaindb/bigchaindb-ss.yaml
+++ b/k8s/bigchaindb/bigchaindb-ss.yaml
@@ -136,7 +136,8 @@ spec:
             - /bin/bash
             - "-c"
             - |
-              curl -s --fail --max-time 10 "http://${TM_INSTANCE_NAME}:${TM_RPC_PORT}/abci_info" > /dev/null
+              curl -s --fail --max-time 10 "http://${TM_INSTANCE_NAME}:${TM_RPC_PORT}/abci_info" > /dev/null && \
+                  curl -s --fail --max-time 10 "http://${TM_INSTANCE_NAME}:${TM_RPC_PORT}/status" > /dev/null
               ERR=$?
               if [ "$ERR" == 28 ]; then
                 exit 1


### PR DESCRIPTION
## Description

Only using `abci_info` endpoint to check the status of the system is not enough, sometimes the connection is not broken between BigchainDB and Tendermint but Tendermint still behaves incorrectly and is not restarted appropriately.

## Solution

Add a `/status` liveness probe to the mix
