### PR TITLE
Problem: There are old links to the IPDB tx spec

### DIFF
--- a/docs/contributing/source/ways-to-contribute/write-docs.md
+++ b/docs/contributing/source/ways-to-contribute/write-docs.md
@@ -16,7 +16,7 @@ You can certainly do that!
 - There are docs for the JavaScript driver under ``bigchaindb/js-bigchaindb-driver`` in the ``bigchaindb/js-bigchaindb-driver`` repo.
 - The source code for the BigchainDB website is in a private repo, but we can give you access if you ask.
 
-The IPDB Transaction Spec currently lives in the ``ipdb/ipdb-tx-spec`` repo, but we'll probably move it.
+The [BigchainDB Transactions Specs](https://github.com/bigchaindb/BEPs/tree/master/tx-specs/) (one for each spec version) are in the ``bigchaindb/BEPs`` repo.
 
 You can write the docs using Markdown (MD) or RestructuredText (RST). Sphinx can understand both. RST is more powerful.
 

--- a/docs/root/source/assets.rst
+++ b/docs/root/source/assets.rst
@@ -13,4 +13,4 @@ BigchainDB can store data of any kind (within reason), but it's designed to be p
 
 .. note::
 
-   We used the word "owners" somewhat loosely above. A more accurate word might be fulfillers, signers, controllers, or transfer-enablers. See the note about "owners" in the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.
+   We used the word "owners" somewhat loosely above. A more accurate word might be fulfillers, signers, controllers, or transfer-enablers. See the section titled **A Note about Owners** in the relevant `BigchainDB Transactions Spec <https://github.com/bigchaindb/BEPs/tree/master/tx-specs/>`_.

--- a/docs/root/source/permissions.rst
+++ b/docs/root/source/permissions.rst
@@ -15,8 +15,9 @@ To spend/transfer an unspent output, a user (or group of users) must fulfill the
 - "…three of these four people must sign."
 - "…either Bob must sign, or both Tom and Sylvia must sign."
 
-For details, see the section about conditions
-in the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.
+For details, see the section titled **Transaction Components: Conditions**
+in the relevant
+`BigchainDB Transactions Spec <https://github.com/bigchaindb/BEPs/tree/master/tx-specs/>`_.
 
 Once an output has been spent, it can't be spent again: *nobody* has permission to do that. That is, BigchainDB doesn't permit anyone to "double spend" an output.
 

--- a/docs/root/source/smart-contracts.rst
+++ b/docs/root/source/smart-contracts.rst
@@ -15,4 +15,4 @@ Crypto-conditions can be quite complex. They can't include loops or recursion an
 
 .. note::
 
-   We used the word "owners" somewhat loosely above. A more accurate word might be fulfillers, signers, controllers, or transfer-enablers. See the note about "owners" in the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.
+   We used the word "owners" somewhat loosely above. A more accurate word might be fulfillers, signers, controllers, or transfer-enablers. See the section titled **A Note about Owners** in the relevant `BigchainDB Transactions Spec <https://github.com/bigchaindb/BEPs/tree/master/tx-specs/>`_.

--- a/docs/root/source/transaction-concepts.md
+++ b/docs/root/source/transaction-concepts.md
@@ -30,14 +30,17 @@ Each output also has an associated condition: the condition that must be met
 BigchainDB supports a variety of conditions,
 a subset of the [Interledger Protocol (ILP)](https://interledger.org/)
 crypto-conditions. For details, see
-the section about conditions in the [IPDB Transaction Spec](https://github.com/ipdb/ipdb-tx-spec).
+the section titled **Transaction Components: Conditions**
+in the relevant
+[BigchainDB Transactions Spec](https://github.com/bigchaindb/BEPs/tree/master/tx-specs/).
 
 Each output also has a list of all the public keys associated
 with the conditions on that output.
 Loosely speaking, that list might be interpreted as the list of "owners."
 A more accurate word might be fulfillers, signers, controllers,
 or transfer-enablers.
-See the note about "owners" in the [IPDB Transaction Spec](https://github.com/ipdb/ipdb-tx-spec).
+See the section titled **A Note about Owners**
+in the relevant [BigchainDB Transactions Spec](https://github.com/bigchaindb/BEPs/tree/master/tx-specs/).
 
 A CREATE transaction must be signed by all the owners.
 (If you're looking for that signature,
@@ -87,7 +90,7 @@ things. We documented those things in a post on *The BigchainDB Blog*:
 ["What is a Valid Transaction in BigchainDB?"](https://blog.bigchaindb.com/what-is-a-valid-transaction-in-bigchaindb-9a1a075a9598)
 (Note: That post was about BigchainDB Server v1.0.0.)
 
-The [IPDB Transaction Spec](https://github.com/ipdb/ipdb-tx-spec) documents the conditions for a transaction to be valid.
+Each [BigchainDB Transactions Spec](https://github.com/bigchaindb/BEPs/tree/master/tx-specs/) documents the conditions for a transaction (of that version) to be valid.
 
 ## Example Transactions
 

--- a/docs/server/source/appendices/cryptography.rst
+++ b/docs/server/source/appendices/cryptography.rst
@@ -1,8 +1,8 @@
 Cryptography
 ============
 
-See the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_,
-especially the sections about:
+Use the following link to find the BigchainDB Transactions Spec (or Specs) that are relevant to you:
 
-- Cryptographic Hashes
-- Cryptographic Keys & Signatures
+`BigchainDB Transactions Specs <https://github.com/bigchaindb/BEPs/tree/master/tx-specs/>`_
+
+Then see the sections titled **Cryptographic Hashes** and **Cryptographic Keys and Signatures**.

--- a/docs/server/source/appendices/json-serialization.rst
+++ b/docs/server/source/appendices/json-serialization.rst
@@ -1,5 +1,8 @@
 JSON Serialization
 ==================
 
-See the section about JSON Serialization & Deserialization
-in the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.
+Use the following link to find the BigchainDB Transactions Spec (or Specs) that are relevant to you:
+
+`BigchainDB Transactions Specs <https://github.com/bigchaindb/BEPs/tree/master/tx-specs/>`_
+
+Then see the section titled **JSON Serialization and Deserialization**.

--- a/docs/server/source/data-models/asset-model.rst
+++ b/docs/server/source/data-models/asset-model.rst
@@ -1,4 +1,8 @@
 The Asset Model
 ===============
 
-See the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.
+Use the following link to find the BigchainDB Transactions Spec (or Specs) that are relevant to you:
+
+`BigchainDB Transactions Specs <https://github.com/bigchaindb/BEPs/tree/master/tx-specs/>`_
+
+Then see the section titled **Transaction Components: Asset**.

--- a/docs/server/source/data-models/conditions.rst
+++ b/docs/server/source/data-models/conditions.rst
@@ -1,4 +1,8 @@
 Conditions
 ==========
 
-See the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.
+Use the following link to find the BigchainDB Transactions Spec (or Specs) that are relevant to you:
+
+`BigchainDB Transactions Specs <https://github.com/bigchaindb/BEPs/tree/master/tx-specs/>`_
+
+Then see the section titled **Transaction Components: Conditions**.

--- a/docs/server/source/data-models/inputs-outputs.rst
+++ b/docs/server/source/data-models/inputs-outputs.rst
@@ -1,4 +1,8 @@
 Inputs and Outputs
 ==================
 
-See the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.
+Use the following link to find the BigchainDB Transactions Spec (or Specs) that are relevant to you:
+
+`BigchainDB Transactions Specs <https://github.com/bigchaindb/BEPs/tree/master/tx-specs/>`_
+
+Then see the sections titled **Transaction Components: Inputs** and **Transaction Components: Outputs**.

--- a/docs/server/source/data-models/transaction-model.rst
+++ b/docs/server/source/data-models/transaction-model.rst
@@ -3,4 +3,4 @@
 The Transaction Model
 =====================
 
-See the `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_.
+See the `BigchainDB Transactions Specs <https://github.com/bigchaindb/BEPs/tree/master/tx-specs/>`_.

--- a/docs/server/source/http-client-server-api.rst
+++ b/docs/server/source/http-client-server-api.rst
@@ -134,7 +134,8 @@ Transactions
    .. note::
    
        The posted transaction should be valid.
-       The `IPDB Transaction Spec <https://github.com/ipdb/ipdb-tx-spec>`_
+       The relevant
+       `BigchainDB Transactions Spec <https://github.com/bigchaindb/BEPs/tree/master/tx-specs/>`_
        explains how to build a valid transaction
        and how to check if a transaction is valid.
        One would normally use a driver such as the `BigchainDB Python Driver


### PR DESCRIPTION
Solution: Replace those links with appropriate links to the BigchainDB Transactions Specs

**Please don't merge this PR until after https://github.com/bigchaindb/BEPs/pull/42 has been merged.**