### PR TITLE
Problem: `make doc` doesn't build the /contributing docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ cov: check-deps ## Check code coverage and open the result in the browser
 doc: check-deps ## Generate HTML documentation and open it in the browser
 	@$(DC) run --rm --no-deps bdocs make -C docs/root html
 	@$(DC) run --rm --no-deps bdocs make -C docs/server html
+	@$(DC) run --rm --no-deps bdocs make -C docs/contributing html
 	$(BROWSER) docs/root/build/html/index.html
 
 doc-acceptance: check-deps ## Create documentation for acceptance tests


### PR DESCRIPTION
Solution: Make `make doc` build the docs in docs/contributing as well
