### PR TITLE
Problem: BigchainDB does not support newer MongoDB

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ benchmarks_require = [
 install_requires = [
     # TODO Consider not installing the db drivers, or putting them in extras.
     'rethinkdb~=2.3',  # i.e. a version between 2.3 and 3.0
-    'pymongo~=3.4',
+    'pymongo~=3.6',
     'pysha3~=1.0.2',
     'cryptoconditions~=0.6.0.dev',
     'python-rapidjson==0.0.11',


### PR DESCRIPTION
Solution: Update driver to the last version, that is compatible with all versions of MongoDB.

Related to @ttmc's [comment](https://github.com/bigchaindb/bigchaindb/pull/2296#pullrequestreview-120964718) on #2296.