### PR TITLE
Last PR before releasing version 2.0.0a6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ For reference, the possible headings are:
 * **External Contributors** to list contributors outside of BigchainDB GmbH.
 * **Notes**
 
+## [2.0 Alpha 6] - 2018-05-17
+
+Tag name: v2.0.0a6
+
+### Changed
+
+Upgraded PyMongo to version 3.6 (which is compatible with MongoDB 3.6, 3.4 [and more](https://docs.mongodb.com/ecosystem/drivers/driver-compatibility-reference/#python-driver-compatibility)). [Pull request #2298](https://github.com/bigchaindb/bigchaindb/pull/2298)
+
+### Fixed
+
+When deploying a node using our Docker Compose file, it didn't expose port 46656, which is used by Tendermint for inter-node communications, so the node couldn't communicate with other nodes. We fixed that in [pull request #2299](https://github.com/bigchaindb/bigchaindb/pull/2299)
+
+### Notes
+
+We ran all our tests using MongoDB 3.6 and they all passed, so it seems safe to use BigchainDB with MongoDB 3.6 from now on.
+
 ## [2.0 Alpha 5] - 2018-05-11
 
 Tag name: v2.0.0a5

--- a/bigchaindb/version.py
+++ b/bigchaindb/version.py
@@ -1,2 +1,2 @@
-__version__ = '2.0.0a5'
-__short_version__ = '2.0a5'
+__version__ = '2.0.0a6'
+__short_version__ = '2.0a6'

--- a/k8s/bigchaindb/bigchaindb-ss.yaml
+++ b/k8s/bigchaindb/bigchaindb-ss.yaml
@@ -154,7 +154,7 @@ spec:
           timeoutSeconds: 15
       # BigchainDB container
       - name: bigchaindb
-        image: bigchaindb/bigchaindb:2.0.0-alpha5
+        image: bigchaindb/bigchaindb:2.0.0-alpha6
         imagePullPolicy: Always
         args:
         - start

--- a/k8s/dev-setup/bigchaindb.yaml
+++ b/k8s/dev-setup/bigchaindb.yaml
@@ -34,7 +34,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: bigchaindb
-        image: bigchaindb/bigchaindb:2.0.0-alpha5
+        image: bigchaindb/bigchaindb:2.0.0-alpha6
         imagePullPolicy: Always
         args:
         - start


### PR DESCRIPTION
This pull request does the steps in the [release process](https://github.com/bigchaindb/bigchaindb/blob/master/RELEASE_PROCESS.md) to release version 2.0.0a6.