### PR TITLE
Remove "Post-Release Steps" from release process

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -75,7 +75,3 @@ The following steps are what we do to release a new version of _BigchainDB Serve
      of previous releases like that.
 
 Congratulations, you have released a new version of BigchainDB Server!
-
-## Post-Release Steps
-
-In the `master` branch, open `bigchaindb/version.py` and increment the minor version to the next planned release, e.g. `0.10.0.dev`. Note: If you just released `X.Y.Zrc1` then increment the minor version to `X.Y.Zrc2`. This step is so people reading the latest docs will know that they're for the latest (`master` branch) version of BigchainDB Server, not the docs at the time of the most recent release (which are also available).


### PR DESCRIPTION
The release process had some "Post-Release Steps" but I haven't been doing them lately.

The idea was to change the version number so that someone working on the `master` branch would see a version number reflecting what the `master` branch is. For example, if version 0.9.0 was just released, then the `master` branch would be changed to have the version number 0.10.0.dev, to indicate that it's the in-development version of 0.10.0.

My thinking now is that if someone is developing new code, then they don't need the version number to help them remember what they're doing. Moreover, if someone purposefully changes the docs to view the `master` branch docs, then they probably know what that means, and they don't need help from a version number.