### PR TITLE
Problem: `bigchaindb configure` does not write the correct configuration

### DIFF
--- a/bigchaindb/commands/bigchaindb.py
+++ b/bigchaindb/commands/bigchaindb.py
@@ -68,7 +68,6 @@ def run_configure(args):
     print('Generating default configuration for backend {}'
           .format(args.backend), file=sys.stderr)
     database_keys = bigchaindb._database_keys_map[args.backend]
-    conf['database'] = bigchaindb._database_map[args.backend]
 
     if not args.yes:
         for key in ('bind', ):


### PR DESCRIPTION
Running `bigchaindb -y configure localmongodb` with some ENV(BIGCHAINDB_DATABASE_HOST) var(s), resulted in invalid writing of the `.bigchaindb` configuration file i.e. only the defaults values were being written.


```
$ export BIGCHAINDB_DATABASE_HOST=example
$ bigchaindb -y configure localmongodb
Generating default configuration for backend localmongodb
Configuration written to /Users/<username>/.bigchaindb
Ready to go!
$ cat /Users/<username>/.bigchaindb
{
    "server": {
        "bind": "localhost:9984",
        "loglevel": "info",
        "workers": null
    },
    "wsserver": {
        "scheme": "ws",
        "host": "localhost",
        "port": 9985,
        "advertised_scheme": "ws",
        "advertised_host": "localhost",
        "advertised_port": 9985
    },
    "database": {
        "backend": "localmongodb",
        "connection_timeout": 5000,
        "max_tries": 3,
        "ssl": false,
        "ca_cert": null,
        "certfile": null,
        "keyfile": null,
        "keyfile_passphrase": null,
        "crlfile": null,
        "host": "localhost", # Should be `example`
        "port": 27017,
        "name": "bigchain",
        "replicaset": null,
        "login": null,
        "password": null
    },
    "keypair": {
        "public": null,
        "private": null
    },
    "keyring": [],
    "backlog_reassign_delay": 120,
    "log": {
        "file": "/Users/<username>/bigchaindb.log",
        "error_file": "/Users/<username>/bigchaindb-errors.log",
        "level_console": "info",
        "level_logfile": "info",
        "datefmt_console": "%Y-%m-%d %H:%M:%S",
        "datefmt_logfile": "%Y-%m-%d %H:%M:%S",
        "fmt_console": "[%(asctime)s] [%(levelname)s] (%(name)s) %(message)s (%(processName)-10s - pid: %(process)d)",
        "fmt_logfile": "[%(asctime)s] [%(levelname)s] (%(name)s) %(message)s (%(processName)-10s - pid: %(process)d)",
        "granular_levels": {},
        "port": 9020
    },
    "CONFIGURED": true
}
```

