### PR TITLE
Problem: upsert-validator feature is error prone

### DIFF
--- a/bigchaindb/backend/localmongodb/query.py
+++ b/bigchaindb/backend/localmongodb/query.py
@@ -186,6 +186,18 @@ def get_owned_ids(conn, owner):
 
 
 @register_query(LocalMongoDBConnection)
+def get_asset_owned_ids(conn, asset_id, owner):
+    cursor = conn.run(
+        conn.collection('transactions').aggregate([
+            {'$match': {'outputs.public_keys': owner,
+                        'operation': 'TRANSFER',
+                        'asset.id': asset_id}},
+            {'$project': {'_id': False}}
+        ]))
+    return cursor
+
+
+@register_query(LocalMongoDBConnection)
 def get_spending_transactions(conn, inputs):
     cursor = conn.run(
         conn.collection('transactions').aggregate([

--- a/bigchaindb/backend/query.py
+++ b/bigchaindb/backend/query.py
@@ -161,6 +161,21 @@ def get_owned_ids(connection, owner):
 
 
 @singledispatch
+def get_asset_owned_ids(connection, asset_id, owner):
+    """Retrieve a list of TRANSFER `txids` with asset.id as `asset_id`
+       that can we used has inputs.
+
+    Args:
+        asset_id (str): Id of the asset.
+        owner (str): base58 encoded public key.
+
+    Returns:
+        Iterator of transaction that list given owner in conditions.
+    """
+    raise NotImplementedError
+
+
+@singledispatch
 def get_block(connection, block_id):
     """Get a block from the bigchain table.
 

--- a/bigchaindb/common/crypto.py
+++ b/bigchaindb/common/crypto.py
@@ -30,3 +30,15 @@ def generate_key_pair():
 
 PrivateKey = crypto.Ed25519SigningKey
 PublicKey = crypto.Ed25519VerifyingKey
+
+
+def key_pair_from_ed35519_key(hex_private_key):
+    priv_key = crypto.Ed25519SigningKey(bytes.fromhex(hex_private_key)[:32], encoding='bytes')
+    public_key = priv_key.get_verifying_key()
+    return CryptoKeypair(private_key=priv_key.encode(encoding='base58').decode('utf-8'),
+                         public_key=public_key.encode(encoding='base58').decode('utf-8'))
+
+
+def public_key_from_ed35519_key(hex_public_key):
+    priv_key = crypto.Ed25519VerifyingKey(bytes.fromhex(hex_public_key), encoding='bytes')
+    return priv_key.encode(encoding='base58').decode('utf-8')

--- a/bigchaindb/common/crypto.py
+++ b/bigchaindb/common/crypto.py
@@ -33,6 +33,7 @@ PublicKey = crypto.Ed25519VerifyingKey
 
 
 def key_pair_from_ed25519_key(hex_private_key):
+    """Generate base58 encode public-private key pair from a hex encoded private key"""
     priv_key = crypto.Ed25519SigningKey(bytes.fromhex(hex_private_key)[:32], encoding='bytes')
     public_key = priv_key.get_verifying_key()
     return CryptoKeypair(private_key=priv_key.encode(encoding='base58').decode('utf-8'),
@@ -40,5 +41,6 @@ def key_pair_from_ed25519_key(hex_private_key):
 
 
 def public_key_from_ed25519_key(hex_public_key):
-    priv_key = crypto.Ed25519VerifyingKey(bytes.fromhex(hex_public_key), encoding='bytes')
-    return priv_key.encode(encoding='base58').decode('utf-8')
+    """Generate base58 public key from hex encoded public key"""
+    public_key = crypto.Ed25519VerifyingKey(bytes.fromhex(hex_public_key), encoding='bytes')
+    return public_key.encode(encoding='base58').decode('utf-8')

--- a/bigchaindb/common/crypto.py
+++ b/bigchaindb/common/crypto.py
@@ -32,13 +32,13 @@ PrivateKey = crypto.Ed25519SigningKey
 PublicKey = crypto.Ed25519VerifyingKey
 
 
-def key_pair_from_ed35519_key(hex_private_key):
+def key_pair_from_ed25519_key(hex_private_key):
     priv_key = crypto.Ed25519SigningKey(bytes.fromhex(hex_private_key)[:32], encoding='bytes')
     public_key = priv_key.get_verifying_key()
     return CryptoKeypair(private_key=priv_key.encode(encoding='base58').decode('utf-8'),
                          public_key=public_key.encode(encoding='base58').decode('utf-8'))
 
 
-def public_key_from_ed35519_key(hex_public_key):
+def public_key_from_ed25519_key(hex_public_key):
     priv_key = crypto.Ed25519VerifyingKey(bytes.fromhex(hex_public_key), encoding='bytes')
     return priv_key.encode(encoding='base58').decode('utf-8')

--- a/bigchaindb/common/exceptions.py
+++ b/bigchaindb/common/exceptions.py
@@ -60,6 +60,10 @@ class InvalidHash(ValidationError):
     """
 
 
+class UnsupportedPublicKeyTypeError(ValidationError):
+    """Raised if there was any error validating an object's schema"""
+
+
 class SchemaValidationError(ValidationError):
     """Raised if there was any error validating an object's schema"""
 

--- a/bigchaindb/tendermint/fastquery.py
+++ b/bigchaindb/tendermint/fastquery.py
@@ -21,6 +21,17 @@ class FastQuery():
                 if condition_details_has_owner(output['condition']['details'],
                                                public_key)]
 
+    def get_asset_outputs_by_public_key(self, asset_id, public_key):
+        """
+        Get asset_id outputs for a public key
+        """
+        txs = list(query.get_asset_owned_ids(self.connection, asset_id, public_key))
+        return [(TransactionLink(tx['id'], index), tx)
+                for tx in txs
+                for index, output in enumerate(tx['outputs'])
+                if condition_details_has_owner(output['condition']['details'],
+                                               public_key)]
+
     def filter_spent_outputs(self, outputs):
         """
         Remove outputs that have been spent

--- a/bigchaindb/tendermint/fastquery.py
+++ b/bigchaindb/tendermint/fastquery.py
@@ -26,7 +26,7 @@ class FastQuery():
         Get asset_id outputs for a public key
         """
         txs = list(query.get_asset_owned_ids(self.connection, asset_id, public_key))
-        return [(TransactionLink(tx['id'], index), tx)
+        return [TransactionLink(tx['id'], index)
                 for tx in txs
                 for index, output in enumerate(tx['outputs'])
                 if condition_details_has_owner(output['condition']['details'],

--- a/bigchaindb/tendermint/lib.py
+++ b/bigchaindb/tendermint/lib.py
@@ -249,17 +249,20 @@ class BigchainDB(Bigchain):
                 '`{}` was spent more than once. There is a problem'
                 ' with the chain'.format(txid))
 
+        current_spent_transactions = []
         for ctxn in current_transactions:
             for ctxn_input in ctxn.inputs:
                 if ctxn_input.fulfills.txid == txid and\
                    ctxn_input.fulfills.output == output:
-                    transactions.append(ctxn.to_dict())
+                    current_spent_transactions.append(ctxn)
 
         transaction = None
-        if len(transactions) > 1:
+        if len(transactions) + len(current_spent_transactions) > 1:
             raise DoubleSpend('tx "{}" spends inputs twice'.format(txid))
         elif transactions:
             transaction = Transaction.from_db(self, transactions[0])
+        elif current_spent_transactions:
+            transaction = current_spent_transactions[0]
 
         return transaction
 

--- a/bigchaindb/tendermint/utils.py
+++ b/bigchaindb/tendermint/utils.py
@@ -9,6 +9,8 @@ except ImportError:
     from sha3 import sha3_256
 
 
+GO_AMINO_ED25519 = "AC26791624DE60"
+
 def encode_transaction(value):
     """Encode a transaction (dict) to Base64."""
 

--- a/bigchaindb/tendermint/utils.py
+++ b/bigchaindb/tendermint/utils.py
@@ -11,6 +11,7 @@ except ImportError:
 
 GO_AMINO_ED25519 = "AC26791624DE60"
 
+
 def encode_transaction(value):
     """Encode a transaction (dict) to Base64."""
 
@@ -78,12 +79,20 @@ def public_key64_to_address(base64_public_key):
 
 
 def public_key_from_base64(base64_public_key):
-    return base64.b64decode(base64_public_key).hex().upper()
+    return key_from_base64(base64_public_key)
+
+
+def key_from_base64(base64_key):
+    return base64.b64decode(base64_key).hex().upper()
 
 
 def public_key_to_base64(ed25519_public_key):
-    ed25519_public_key = bytes.fromhex(ed25519_public_key)
-    return base64.b64encode(ed25519_public_key).decode('utf-8')
+    return key_to_base64(ed25519_public_key)
+
+
+def key_to_base64(ed25519_key):
+    ed25519_key = bytes.fromhex(ed25519_key)
+    return base64.b64encode(ed25519_key).decode('utf-8')
 
 
 def amino_encoded_public_key(ed25519_public_key):

--- a/bigchaindb/tep/transactional_election.py
+++ b/bigchaindb/tep/transactional_election.py
@@ -1,0 +1,38 @@
+
+class TransactionalElection(object):
+
+    version = '0.0'
+    name = 'base-class'
+
+    def __init__(self):
+        pass
+
+    def propose(self, election_object):
+        """Initiate a new election"""
+
+        raise NotImplementedError
+
+    def list(self, election_id):
+        """List the election with id `election_id`"""
+
+        raise NotImplementedError
+
+    def is_valid_proposal(self, election_object):
+        """Check if the `election_object` is a valid election"""
+
+        raise NotImplementedError
+
+    def vote(self, election_id, node_key_path):
+        """Vote on the given `election_id`"""
+
+        raise NotImplementedError
+
+    def is_valid_vote(self, vote):
+        """Validate the casted vote"""
+
+        raise NotImplementedError
+
+    def is_concluded(self, election_id, current_votes=[]):
+        """Check if the Election with `election_id` has reached consensus"""
+
+        raise NotImplementedError

--- a/bigchaindb/tep/transactional_election.py
+++ b/bigchaindb/tep/transactional_election.py
@@ -7,13 +7,13 @@ class TransactionalElection(object):
     def __init__(self):
         pass
 
-    def propose(self, election_object):
+    def propose(self, election_object, node_key_path):
         """Initiate a new election"""
 
         raise NotImplementedError
 
-    def list(self, election_id):
-        """List the election with id `election_id`"""
+    def show(self, election_id):
+        """Show the election with id `election_id`"""
 
         raise NotImplementedError
 
@@ -32,7 +32,7 @@ class TransactionalElection(object):
 
         raise NotImplementedError
 
-    def is_concluded(self, election_id, current_votes=[]):
+    def get_election_status(self, election_id, current_votes=[]):
         """Check if the Election with `election_id` has reached consensus"""
 
         raise NotImplementedError

--- a/bigchaindb/tep/transactional_election.py
+++ b/bigchaindb/tep/transactional_election.py
@@ -1,4 +1,6 @@
 
+
+# Base class for creating Transaction Election Process
 class TransactionalElection(object):
 
     version = '0.0'

--- a/bigchaindb/tep/upsert_validator.py
+++ b/bigchaindb/tep/upsert_validator.py
@@ -87,7 +87,7 @@ class UpsertValidator(TransactionalElection):
         return (True if code == 202 else False)
 
     def propose(self, validator_data, node_key_path):
-        validator_public_key = validator_data['pub_key']
+        validator_public_key = validator_data['public_key']
         validator_power = validator_data['power']
         validator_node_id = validator_data['node_id']
 
@@ -193,8 +193,10 @@ class UpsertValidator(TransactionalElection):
         total_votes = sum(current_validators.values())
         votes = 0
         #  Aggregate vote count for `election_id`
-        for output in tx_election.outputs:
-            vote = self.bigchain.get_spent(self.election_id(tx_election_id), output.to_dict(), current_votes)
+
+        for output_id, output in enumerate(tx_election.outputs):
+            vote = self.bigchain.get_spent(tx_election_id, output_id, current_votes)
+
             if vote:
                 votes = votes + vote.outputs[0].amount
 

--- a/bigchaindb/tep/upsert_validator.py
+++ b/bigchaindb/tep/upsert_validator.py
@@ -195,6 +195,8 @@ class UpsertValidator(TransactionalElection):
 
         election_public_key = self.public_key(tx_election.id)
         total_votes = sum(current_validators.values())
+
+        # Get all unspent outputs for `election_public_key` with asset id as `tx_election.id`
         casted_votes = self.bigchain.get_asset_outputs_filtered(tx_election.id,
                                                                 election_public_key,
                                                                 spent=False)

--- a/bigchaindb/tep/upsert_validator.py
+++ b/bigchaindb/tep/upsert_validator.py
@@ -86,8 +86,7 @@ class UpsertValidator(TransactionalElection):
         return base58.b58encode(bytes.fromhex(tx_election_id))
 
     def _execute_action(self, tx):
-        (code, msg) = self.bigchain.write_transaction(tx, 'broadcast_tx_commit')
-        return (True if code == 202 else False)
+        return self.bigchain.write_transaction(tx, 'broadcast_tx_commit')
 
     def propose(self, validator_data, node_key_path):
         validator_public_key = validator_data['public_key']

--- a/bigchaindb/tep/upsert_validator.py
+++ b/bigchaindb/tep/upsert_validator.py
@@ -1,0 +1,186 @@
+import json
+
+from bigchaindb.tep.transactional_election import TransactionalElection
+from bigchaindb.tendermint.lib import BigchainDB
+from bigchaindb.models import Transaction
+from bigchaindb.tendermint.utils import GO_AMINO_ED25519, public_key_from_base64
+
+
+class UpsertValidator(TransactionalElection):
+
+    version = '1.0'
+    name = 'upsert-validator'
+
+    def __init__(self, bigchain=None):
+        if not bigchain:
+            bigchain = BigchainDB()
+
+        self.bigchain = bigchain
+
+    def _new_election_object(self, args):
+        new_election_object = {
+            'type': 'election',
+            'name': self.name,
+            'version': self.version,
+            'args': args
+        }
+        return new_election_object
+
+    def _recipients(self):
+        """Convert validator dictionary to a recipient list for `Transaction`"""
+
+        recipients = []
+        for public_key, voting_power in self._validators():
+            recipients.push(([public_key], voting_power))
+
+        return recipients
+
+    def _validators(self):
+        """Return a dictionary of validators with key as `public_key` and
+           value as the `voting_power`
+        """
+
+        validators = {}
+        for validator in self.bigchain.get_validators():
+            if validator['pub_key']['type'] == GO_AMINO_ED25519:
+                public_key = public_key_from_base64(validator['pub_key']['value'])
+                validators[public_key] = validator['voting_power']
+            else:
+                # TODO: use appropriate exception
+                raise NotImplementedError
+
+        return validators
+
+    def _get_vote(self, tx_election, public_key):
+        """For a given `public_key` return the `input` and `amount` as
+           voting power
+        """
+
+        for i, tx_input in enumerate(tx_election.to_inputs()):
+            if tx_input.owners_before == [public_key] and \
+               tx_election.output[i].public_keys == [public_key]:
+                return ([tx_input], tx_election.output[i].amount)
+
+        return ([], 0)
+
+    def _is_same_topology(current_topology, election_topology):
+
+        voters = {}
+        for voter in election_topology:
+            [public_key] = voter.public_keys
+            voting_power = voter.amount
+            voters[public_key] = voting_power
+
+        # Check whether the voters and their votes is same to that of the
+        # validators and their voting power in the network
+        return (current_topology.items() == voters.items())
+
+    def _execute_action(self, tx):
+        (code, msg) = self.bigchain.write_transaction(tx, 'broadcast_tx_commit')
+        return (True if code == 202 else False)
+
+    def propose(self, validator_data, node_key_path):
+        validator_public_key = validator_data['public_key']
+        validator_power = validator_data['power']
+        validator_node_id = validator_data['node_id']
+
+        (node_public_key,
+         node_private_key) = load_private_key(node_key_path)
+
+        args = {
+            'public_key': validator_public_key,
+            'power': validator_power,
+            'node_id': validator_node_id
+        }
+
+        asset = {
+            'data': self._new_election_object(args)
+        }
+
+        tx = Transaction.create([node_public_key],
+                                self._recipients(),
+                                asset=asset)\
+                        .sign([node_private_key])
+        self._execute_action(tx)
+
+    def is_valid_proposal(self, tx_election):
+        """Check if `tx_election` is a valid election"""
+        current_validators = self._validators()
+
+        # Check if the `owners_before` public key is a part of the validator set
+        [election_initiator_node_pub_key] = tx_election.inputs[0].owners_before
+        if election_initiator_node_pub_key not in current_validators.keys():
+            return False
+
+        # Check if all outputs are part of the validator set
+        return self._is_same_topology(current_validators, tx_election.outputs)
+
+    def vote(self, election_id, node_key_path):
+        """Vote on the given `election_id`"""
+
+        tx_election = self.bigchain.get_transaction(election_id)
+        (node_public_key,
+         node_private_key) = load_private_key(node_key_path)
+        (tx_vote_input,
+         voting_power) = self._get_vote(tx_election, node_public_key)
+
+        tx_vote = Transaction.transfer(tx_vote_input,
+                                       [([election_id], voting_power)],
+                                       metadata={'type': 'vote'},
+                                       asset_id=tx_election.id)\
+                             .sign([node_private_key])
+        return self._execute_action(tx_vote)
+
+    def is_valid_vote(self, tx_vote):
+        """Validate casted vote.
+
+           NOTE: We don't need to check the amount of votes since the same has been validated when
+           the election was initiated
+        """
+
+        if not (isinstance(tx_vote.metadata, dict) and
+                tx_vote.metadata.get('type', None) == 'vote'):
+            return False
+
+        validators = self._validators().keys()
+        [input_vote_owner] = tx_vote.inputs[0].owners_before
+
+        # If the voter is no longer a part of the validator set then return
+        if input_vote_owner not in validators:
+            return False
+
+        return True
+
+    def is_concluded(self, election_id, current_votes=[]):
+        """Check if the Election with `election_id` has gained majority vote"""
+
+        tx_election = self.bigchain.get_transaction(election_id)
+        current_validators = self._validators()
+        # Check if network topology is exactly same to when the election was initiated
+        if not self._is_same_topology(current_validators, tx_election.outputs):
+            return (False, None)
+
+        total_votes = sum(current_validators.values())
+        votes = 0
+        #  Aggregate vote count for `election_id`
+        for output in tx_election.outputs:
+            vote = self.bigchain.get_spent(election_id, output.to_dict(), current_votes)
+            if vote:
+                votes = votes + vote.outputs[0].amount
+
+        # Check if >2/3 of total votes have been casted
+        if votes > (2/3)*total_votes:
+            return (True, tx_election.asset['data'])
+
+        return (False, None)
+
+
+# Load Tendermint's public and private key from the file path
+def load_private_key(path):
+    with open(path) as json_data:
+        priv_validator = json.load(json_data)
+        priv_key = priv_validator['priv_key']['value']
+        pub_key = priv_validator['pub_key']['value']
+
+    return (public_key_from_base64(pub_key),
+            public_key_from_base64(priv_key))

--- a/docs/root/source/production-ready.md
+++ b/docs/root/source/production-ready.md
@@ -1,3 +1,6 @@
 # Production-Ready?
 
 Depending on your use case, BigchainDB may or may not be production-ready. You should ask your service provider.
+If you want to go live (into production) with BigchainDB, please consult with your service provider.
+
+Note: BigchainDB has an open source license with a "no warranty" section that is typical of open source licenses. This is standard in the software industry. For example, the Linux kernel is used in production by billions of machines even though its license includes a "no warranty" section. Warranties are usually provided above the level of the software license, by service providers.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ Tasks:
 2. delete test database after running the tests
 """
 
+import json
 import os
 import copy
 import random
@@ -626,3 +627,35 @@ def utxoset(dummy_unspent_outputs, utxo_collection):
     assert res.acknowledged
     assert len(res.inserted_ids) == 3
     return dummy_unspent_outputs, utxo_collection
+
+
+@pytest.fixture(scope='session')
+def priv_validator_path():
+    priv_validator = {
+        'address': '84F787D95E196DC5DE5F972666CFECCA36801426',
+        'pub_key': {
+            'type': 'AC26791624DE60',
+            'value': 'JbfwrLvCVIwOPm8tj8936ki7IYbmGHjPiKb6nAZegRA='
+        },
+        'last_height': 0,
+        'last_round': 0,
+        'last_step': 0,
+        'priv_key': {
+            'type': '954568A3288910',
+            'value': '83VINXdj2ynOHuhvSZz5tGuOE5oYzIi0mEximkX1KYMlt/Csu8JUjA4+by2Pz3fqSLshhuYYeM+IpvqcBl6BEA=='
+        }
+    }
+
+    with open('/tmp/priv_validator.json', 'w') as outfile:
+        json.dump(priv_validator, outfile)
+
+    return '/tmp/priv_validator.json'
+
+
+@pytest.fixture
+def network_validators():
+    return {
+        '/qBKIW7GURV8ID0XN4XMXq8mJWNIoLzWkvno6fPnohs=': 10,
+        'FkCp5pbZiHamdIWcg7TOILv8bdY7Ah/2dqCEw//t1P8=': 7,
+        'JbfwrLvCVIwOPm8tj8936ki7IYbmGHjPiKb6nAZegRA=': 8
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -659,3 +659,16 @@ def network_validators():
         'FkCp5pbZiHamdIWcg7TOILv8bdY7Ah/2dqCEw//t1P8=': 7,
         'JbfwrLvCVIwOPm8tj8936ki7IYbmGHjPiKb6nAZegRA=': 8
     }
+
+
+@pytest.fixture
+def network_validators58(network_validators):
+    from bigchaindb.common.crypto import public_key_from_ed25519_key
+    from bigchaindb.tendermint.utils import key_from_base64
+
+    network_validators_base58 = {}
+    for p, v in network_validators.items():
+        p = public_key_from_ed25519_key(key_from_base64(p))
+        network_validators_base58[p] = v
+
+    return network_validators_base58

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import random
 from collections import namedtuple
 from logging import getLogger
 from logging.config import dictConfig
+import tempfile
 
 import pytest
 from pymongo import MongoClient
@@ -651,20 +652,20 @@ def priv_validator_path(node_keys):
         }
     }
 
-    with open('/tmp/priv_validator.json', 'w') as outfile:
-        json.dump(priv_validator, outfile)
+    fd, path = tempfile.mkstemp()
+    socket = os.fdopen(fd, 'w')
+    json.dump(priv_validator, socket)
+    socket.close()
 
-    return '/tmp/priv_validator.json'
+    return path
 
 
 @pytest.fixture
 def network_validators(node_keys):
     validator_pub_power = {}
-    i = 0
     voting_power = [8, 10, 7, 9]
     for pub, priv in node_keys.items():
-        validator_pub_power[pub] = voting_power[i]
-        i += 1
+        validator_pub_power[pub] = voting_power.pop()
 
     return validator_pub_power
 

--- a/tests/tendermint/test_lib.py
+++ b/tests/tendermint/test_lib.py
@@ -377,6 +377,8 @@ def test_get_spent_transaction_critical_double_spend(b, alice, bob, carol):
 
     b.store_bulk_transactions([tx])
 
+    assert b.get_spent(tx.id, tx_transfer.inputs[0].fulfills.output, [tx_transfer])
+
     with pytest.raises(DoubleSpend):
         b.get_spent(tx.id, tx_transfer.inputs[0].fulfills.output,
                     [tx_transfer, double_spend])

--- a/tests/tep/conftest.py
+++ b/tests/tep/conftest.py
@@ -18,6 +18,17 @@ def validator_election(b_mock):
     return validator_election
 
 
+@pytest.fixture
+def new_validator():
+    public_key = '1718D2DBFF00158A0852A17A01C78F4DCF3BA8E4FB7B8586807FAC182A535034'
+    power = 1
+    node_id = 'fake_node_id'
+
+    return {'public_key': public_key,
+            'power': power,
+            'node_id': node_id}
+
+
 def mock_execute_action(tx):
     return tx
 

--- a/tests/tep/conftest.py
+++ b/tests/tep/conftest.py
@@ -1,0 +1,39 @@
+import pytest
+from bigchaindb.tep.upsert_validator import UpsertValidator
+
+
+@pytest.fixture
+def b_mock(b, network_validators):
+    b.write_transaction = mock_write_transaction
+    b.get_validators = mock_get_validators(network_validators)
+
+    return b
+
+
+@pytest.fixture
+def validator_election(b_mock):
+    validator_election = UpsertValidator(bigchain=b_mock)
+    validator_election._execute_action = mock_execute_action
+
+    return validator_election
+
+
+def mock_execute_action(tx):
+    return tx
+
+
+def mock_write_transaction(tx):
+    return (202, '')
+
+
+def mock_get_validators(network_validators):
+    def validator_set():
+        validators = []
+        for public_key, power in network_validators.items():
+            validators.append({
+                'pub_key': {'type': 'AC26791624DE60', 'value': public_key},
+                'voting_power': power
+            })
+        return validators
+
+    return validator_set

--- a/tests/tep/test_upsert_validator.py
+++ b/tests/tep/test_upsert_validator.py
@@ -1,37 +1,10 @@
 import pytest
-from unittest.mock import Mock
+
+from bigchaindb.models import Transaction
 
 
-@pytest.mark.execute
 @pytest.mark.tendermint
-def test_upsert_validator_election(b, priv_validator_path, network_validators):
-    from bigchaindb.tep.upsert_validator import UpsertValidator
-    from bigchaindb.tendermint.lib import BigchainDB
-    from bigchaindb.tendermint.utils import key_from_base64
-    from bigchaindb.common.crypto import public_key_from_ed35519_key
-
-    def mock_execute_action(tx):
-        return tx
-
-    def mock_get_validators():
-        validators = []
-        for public_key, power in network_validators.items():
-            validators.append({
-                'pub_key': {'type': 'AC26791624DE60', 'value': public_key},
-                'voting_power': power
-            })
-        return validators
-
-    def mock_write_transaction(tx):
-        return (202, '')
-
-    b_mock = BigchainDB()
-    b_mock = Mock(spec=b_mock, write_transaction=mock_write_transaction,
-                  get_validators=mock_get_validators)
-
-    validator_election = UpsertValidator(bigchain=b_mock)
-    validator_election._execute_action = mock_execute_action
-
+def test_upsert_validator_valid_election(validator_election, priv_validator_path, network_validators58):
     public_key = '1718D2DBFF00158A0852A17A01C78F4DCF3BA8E4FB7B8586807FAC182A535034'
     power = 1
     node_id = 'fake_node_id'
@@ -40,18 +13,13 @@ def test_upsert_validator_election(b, priv_validator_path, network_validators):
                  'power': power,
                  'node_id': node_id}
 
+    # Create an election proposal to add a new validator
     tx_election = validator_election.propose(validator, priv_validator_path)
-
-    validators = {}
-    for validator_public_key, validator_power in network_validators.items():
-        validator_public_key = public_key_from_ed35519_key(key_from_base64(validator_public_key))
-        validators[validator_public_key] = validator_power
 
     voters = {}
     for output in tx_election.outputs:
         [output_public_key] = output.public_keys
         voters[output_public_key] = output.amount
-        # assert network_validators[output.public_keys[0]] == output.amount
 
     valid_asset = {
         'type': 'election',
@@ -63,5 +31,37 @@ def test_upsert_validator_election(b, priv_validator_path, network_validators):
             'node_id': node_id
         }
     }
-    assert validators == voters
+
+    assert voters == network_validators58
     assert tx_election.asset['data'] == valid_asset
+    assert validator_election.is_valid_proposal(tx_election)
+
+
+@pytest.mark.tendermint
+def test_upsert_validator_invalid_election(validator_election, priv_validator_path, network_validators58):
+    from bigchaindb.tep.upsert_validator import load_node_key
+
+    public_key = '1718D2DBFF00158A0852A17A01C78F4DCF3BA8E4FB7B8586807FAC182A535034'
+    power = 1
+    node_id = 'fake_node_id'
+
+    validator = {'pub_key': public_key,
+                 'power': power,
+                 'node_id': node_id}
+
+    node_key = load_node_key(priv_validator_path)
+    asset = validator_election._new_election_object(validator)
+    recipients = validator_election._recipients()
+
+    altered_recipients = []
+    for r in recipients:
+        ([r_public_key], voting_power) = r
+        altered_recipients.append(([r_public_key], voting_power - 1))
+
+    # Create a transaction which doesn't enfore the network power
+    tx_election = Transaction.create([node_key.public_key],
+                                     altered_recipients,
+                                     asset=asset)\
+                             .sign([node_key.private_key])
+
+    assert not validator_election.is_valid_proposal(tx_election)

--- a/tests/tep/test_upsert_validator.py
+++ b/tests/tep/test_upsert_validator.py
@@ -4,17 +4,11 @@ from bigchaindb.models import Transaction
 
 
 @pytest.mark.tendermint
-def test_upsert_validator_valid_election(validator_election, priv_validator_path, network_validators58):
-    public_key = '1718D2DBFF00158A0852A17A01C78F4DCF3BA8E4FB7B8586807FAC182A535034'
-    power = 1
-    node_id = 'fake_node_id'
-
-    validator = {'pub_key': public_key,
-                 'power': power,
-                 'node_id': node_id}
+def test_upsert_validator_valid_election(validator_election, priv_validator_path,
+                                         network_validators58, new_validator):
 
     # Create an election proposal to add a new validator
-    tx_election = validator_election.propose(validator, priv_validator_path)
+    tx_election = validator_election.propose(new_validator, priv_validator_path)
 
     voters = {}
     for output in tx_election.outputs:
@@ -25,11 +19,7 @@ def test_upsert_validator_valid_election(validator_election, priv_validator_path
         'type': 'election',
         'name': 'upsert-validator',
         'version': '1.0',
-        'args': {
-            'public_key': public_key,
-            'power': power,
-            'node_id': node_id
-        }
+        'args': new_validator
     }
 
     assert voters == network_validators58
@@ -38,19 +28,12 @@ def test_upsert_validator_valid_election(validator_election, priv_validator_path
 
 
 @pytest.mark.tendermint
-def test_upsert_validator_invalid_election(validator_election, priv_validator_path, network_validators58):
+def test_upsert_validator_invalid_election(b, validator_election, priv_validator_path,
+                                           network_validators58, new_validator, node_keys58):
     from bigchaindb.tep.upsert_validator import load_node_key
 
-    public_key = '1718D2DBFF00158A0852A17A01C78F4DCF3BA8E4FB7B8586807FAC182A535034'
-    power = 1
-    node_id = 'fake_node_id'
-
-    validator = {'pub_key': public_key,
-                 'power': power,
-                 'node_id': node_id}
-
     node_key = load_node_key(priv_validator_path)
-    asset = validator_election._new_election_object(validator)
+    asset = validator_election._new_election_object(new_validator)
     recipients = validator_election._recipients()
 
     altered_recipients = []
@@ -65,3 +48,94 @@ def test_upsert_validator_invalid_election(validator_election, priv_validator_pa
                              .sign([node_key.private_key])
 
     assert not validator_election.is_valid_proposal(tx_election)
+
+    # Assume that `tx_election` was valid election at the time of creation
+    b.store_bulk_transactions([tx_election])
+    votes = prepare_node_votes(node_keys58, validator_election, tx_election)
+    configs = [[0], [1], [2], [3],
+               [0, 1], [0, 2], [0, 3],
+               [1, 2], [1, 3], [2, 3]]
+
+    for vote_config in configs:
+        curr_votes = []
+        for index in vote_config:
+            curr_votes.append(votes[index])
+
+        (concluded, msg) = validator_election.is_concluded(tx_election.id, curr_votes)
+        assert not concluded
+        assert msg == 'inconsistant_topology'
+
+
+@pytest.mark.tendermint
+def test_upsert_validator_valid_vote(b, validator_election, priv_validator_path,
+                                     network_validators58, new_validator):
+
+    tx_election = validator_election.propose(new_validator, priv_validator_path)
+    b.store_bulk_transactions([tx_election])
+
+    # Create vote for election_id
+    tx_vote = validator_election.vote(tx_election.id, priv_validator_path)
+
+    assert tx_vote.metadata == {'type': 'vote'}
+
+    [tx_vote_input_public_key] = tx_vote.inputs[0].owners_before
+    [tx_vote_ouput_public_key] = tx_vote.outputs[0].public_keys
+    tx_voter_votes = tx_vote.outputs[0].amount
+
+    election_id = validator_election.election_id(tx_election.id)
+
+    # The vote should be casted to the election id
+    assert tx_vote_ouput_public_key == election_id
+    assert network_validators58[tx_vote_input_public_key] == tx_voter_votes
+    assert validator_election.is_valid_vote(tx_vote)
+
+
+@pytest.mark.tendermint
+def test_upsert_validator_conclude_election(b, validator_election, priv_validator_path,
+                                            network_validators58, new_validator, node_keys58):
+
+    tx_election = validator_election.propose(new_validator, priv_validator_path)
+    b.store_bulk_transactions([tx_election])
+
+    votes = prepare_node_votes(node_keys58, validator_election, tx_election)
+    assert len(votes) == 4
+
+    # Non concluding vote configs
+    configs = [[0], [1], [2], [3],
+               [0, 1], [0, 2], [0, 3],
+               [1, 2], [1, 3], [2, 3]]
+
+    for vote_config in configs:
+        curr_votes = []
+        for index in vote_config:
+            curr_votes.append(votes[index])
+
+        (concluded, msg) = validator_election.is_concluded(tx_election.id, curr_votes)
+        assert not concluded
+        assert msg == 'insufficient_votes'
+
+    # Concluding vote configs
+    configs = [[0, 1, 2], [0, 2, 3], [0, 1, 3], [1, 2, 3]]
+
+    for vote_config in configs:
+        curr_votes = []
+        for index in vote_config:
+            curr_votes.append(votes[index])
+
+        (concluded, msg) = validator_election.is_concluded(tx_election.id, curr_votes)
+        assert concluded
+
+
+def prepare_node_votes(node_keys58, validator_election, tx_election):
+    votes = []
+    election_id = validator_election.election_id(tx_election.id)
+    for node_key in node_keys58:
+        (tx_vote_input,
+         voting_power) = validator_election._get_vote(tx_election, node_key.public_key)
+        tx_vote = Transaction.transfer(tx_vote_input,
+                                       [([election_id], voting_power)],
+                                       metadata={'type': 'vote'},
+                                       asset_id=tx_election.id)\
+                             .sign([node_key.private_key])
+        votes.append(tx_vote)
+    return votes

--- a/tests/tep/test_upsert_validator.py
+++ b/tests/tep/test_upsert_validator.py
@@ -2,8 +2,9 @@ import pytest
 
 from bigchaindb.models import Transaction
 
+pytestmark = [pytest.mark.tendermint, pytest.mark.bdb]
 
-@pytest.mark.tendermint
+
 def test_upsert_validator_valid_election(validator_election, priv_validator_path,
                                          network_validators58, new_validator):
 
@@ -27,7 +28,6 @@ def test_upsert_validator_valid_election(validator_election, priv_validator_path
     assert validator_election.is_valid_proposal(tx_election)
 
 
-@pytest.mark.tendermint
 def test_upsert_validator_invalid_election(b, validator_election, priv_validator_path,
                                            network_validators58, new_validator, node_keys58):
     from bigchaindb.tep.upsert_validator import load_node_key
@@ -66,7 +66,6 @@ def test_upsert_validator_invalid_election(b, validator_election, priv_validator
         assert msg == 'inconsistant_topology'
 
 
-@pytest.mark.tendermint
 def test_upsert_validator_valid_vote(b, validator_election, priv_validator_path,
                                      network_validators58, new_validator):
 
@@ -90,7 +89,6 @@ def test_upsert_validator_valid_vote(b, validator_election, priv_validator_path,
     assert validator_election.is_valid_vote(tx_vote)
 
 
-@pytest.mark.tendermint
 def test_upsert_validator_conclude_election(b, validator_election, priv_validator_path,
                                             network_validators58, new_validator, node_keys58):
 

--- a/tests/tep/test_upsert_validator.py
+++ b/tests/tep/test_upsert_validator.py
@@ -1,0 +1,67 @@
+import pytest
+from unittest.mock import Mock
+
+
+@pytest.mark.execute
+@pytest.mark.tendermint
+def test_upsert_validator_election(b, priv_validator_path, network_validators):
+    from bigchaindb.tep.upsert_validator import UpsertValidator
+    from bigchaindb.tendermint.lib import BigchainDB
+    from bigchaindb.tendermint.utils import key_from_base64
+    from bigchaindb.common.crypto import public_key_from_ed35519_key
+
+    def mock_execute_action(tx):
+        return tx
+
+    def mock_get_validators():
+        validators = []
+        for public_key, power in network_validators.items():
+            validators.append({
+                'pub_key': {'type': 'AC26791624DE60', 'value': public_key},
+                'voting_power': power
+            })
+        return validators
+
+    def mock_write_transaction(tx):
+        return (202, '')
+
+    b_mock = BigchainDB()
+    b_mock = Mock(spec=b_mock, write_transaction=mock_write_transaction,
+                  get_validators=mock_get_validators)
+
+    validator_election = UpsertValidator(bigchain=b_mock)
+    validator_election._execute_action = mock_execute_action
+
+    public_key = '1718D2DBFF00158A0852A17A01C78F4DCF3BA8E4FB7B8586807FAC182A535034'
+    power = 1
+    node_id = 'fake_node_id'
+
+    validator = {'pub_key': public_key,
+                 'power': power,
+                 'node_id': node_id}
+
+    tx_election = validator_election.propose(validator, priv_validator_path)
+
+    validators = {}
+    for validator_public_key, validator_power in network_validators.items():
+        validator_public_key = public_key_from_ed35519_key(key_from_base64(validator_public_key))
+        validators[validator_public_key] = validator_power
+
+    voters = {}
+    for output in tx_election.outputs:
+        [output_public_key] = output.public_keys
+        voters[output_public_key] = output.amount
+        # assert network_validators[output.public_keys[0]] == output.amount
+
+    valid_asset = {
+        'type': 'election',
+        'name': 'upsert-validator',
+        'version': '1.0',
+        'args': {
+            'public_key': public_key,
+            'power': power,
+            'node_id': node_id
+        }
+    }
+    assert validators == voters
+    assert tx_election.asset['data'] == valid_asset

--- a/tests/tep/test_upsert_validator.py
+++ b/tests/tep/test_upsert_validator.py
@@ -61,9 +61,9 @@ def test_upsert_validator_invalid_election(b, validator_election, priv_validator
         for index in vote_config:
             curr_votes.append(votes[index])
 
-        (concluded, msg) = validator_election.is_concluded(tx_election.id, curr_votes)
+        (concluded, msg) = validator_election.get_election_status(tx_election.id, curr_votes)
         assert not concluded
-        assert msg == 'inconsistant_topology'
+        assert msg == 'inconsistent_topology'
 
 
 def test_upsert_validator_valid_vote(b, validator_election, priv_validator_path,
@@ -108,7 +108,7 @@ def test_upsert_validator_conclude_election(b, validator_election, priv_validato
         for index in vote_config:
             curr_votes.append(votes[index])
 
-        (concluded, msg) = validator_election.is_concluded(tx_election.id, curr_votes)
+        (concluded, msg) = validator_election.get_election_status(tx_election.id, curr_votes)
         assert not concluded
         assert msg == 'insufficient_votes'
 
@@ -120,7 +120,7 @@ def test_upsert_validator_conclude_election(b, validator_election, priv_validato
         for index in vote_config:
             curr_votes.append(votes[index])
 
-        (concluded, msg) = validator_election.is_concluded(tx_election.id, curr_votes)
+        (concluded, msg) = validator_election.get_election_status(tx_election.id, curr_votes)
         assert concluded
 
 

--- a/tests/tep/test_upsert_validator.py
+++ b/tests/tep/test_upsert_validator.py
@@ -81,7 +81,7 @@ def test_upsert_validator_valid_vote(b, validator_election, priv_validator_path,
     [tx_vote_ouput_public_key] = tx_vote.outputs[0].public_keys
     tx_voter_votes = tx_vote.outputs[0].amount
 
-    election_id = validator_election.election_id(tx_election.id)
+    election_id = validator_election.public_key(tx_election.id)
 
     # The vote should be casted to the election id
     assert tx_vote_ouput_public_key == election_id
@@ -98,35 +98,111 @@ def test_upsert_validator_conclude_election(b, validator_election, priv_validato
     votes = prepare_node_votes(node_keys58, validator_election, tx_election)
     assert len(votes) == 4
 
+    def assert_not_concluded(vote_configs):
+        for vote_config in vote_configs:
+            curr_votes = []
+            for index in vote_config:
+                curr_votes.append(votes[index])
+
+            (concluded, msg) = validator_election.get_election_status(tx_election.id, curr_votes)
+            assert not concluded
+            assert msg == 'insufficient_votes'
+
+    def assert_concluded(vote_configs):
+        for vote_config in vote_configs:
+            curr_votes = []
+            for index in vote_config:
+                curr_votes.append(votes[index])
+
+            (concluded, msg) = validator_election.get_election_status(tx_election.id, curr_votes)
+            assert concluded
+
     # Non concluding vote configs
     configs = [[0], [1], [2], [3],
                [0, 1], [0, 2], [0, 3],
                [1, 2], [1, 3], [2, 3]]
+    assert_not_concluded(configs)
 
-    for vote_config in configs:
-        curr_votes = []
-        for index in vote_config:
-            curr_votes.append(votes[index])
-
-        (concluded, msg) = validator_election.get_election_status(tx_election.id, curr_votes)
-        assert not concluded
-        assert msg == 'insufficient_votes'
-
-    # Concluding vote configs
     configs = [[0, 1, 2], [0, 2, 3], [0, 1, 3], [1, 2, 3]]
+    assert_concluded(configs)
 
-    for vote_config in configs:
-        curr_votes = []
-        for index in vote_config:
-            curr_votes.append(votes[index])
+    b.store_bulk_transactions([votes[0]])
 
-        (concluded, msg) = validator_election.get_election_status(tx_election.id, curr_votes)
-        assert concluded
+    configs = [[1], [2], [3]]
+    assert_not_concluded(configs)
+
+    configs = [[1, 2], [1, 3], [2, 3]]
+    assert_concluded(configs)
+
+    b.store_bulk_transactions([votes[1]])
+
+    configs = [[1], [2], [3]]
+    assert_concluded(configs)
+
+
+def test_upsert_validator_delegate_vote(b, validator_election, priv_validator_path,
+                                        network_validators58, new_validator, node_keys58):
+    from bigchaindb.common.crypto import generate_key_pair
+
+    non_validator = generate_key_pair()
+
+    tx_election = validator_election.propose(new_validator, priv_validator_path)
+    b.store_bulk_transactions([tx_election])
+
+    election_public_key = validator_election.public_key(tx_election.id)
+
+    def delegate_vote(delegator_priv_key, delegatee_public_key, election_id,
+                      tx_vote_input, voting_power):
+        return Transaction.transfer(tx_vote_input,
+                                    [([delegatee_public_key], voting_power)],
+                                    asset_id=election_id)\
+                          .sign([delegator_priv_key])
+
+    def cast_delegated_vote(private_key, election_pk, tx_vote_input, voting_power):
+        return Transaction.transfer(tx_vote_input,
+                                    [([election_pk], voting_power)],
+                                    metadata={'type': 'vote'},
+                                    asset_id=tx_election.id)\
+                          .sign([private_key])
+
+    node0 = node_keys58[0]
+    # node1 = node_keys58[1]
+
+    (node0_tx_vote_input,
+     node0_voting_power) = validator_election._get_vote(tx_election, node0.public_key)
+
+    non_validator_dvote_node0 = delegate_vote(node0.private_key,
+                                              non_validator.public_key,
+                                              tx_election.id,
+                                              node0_tx_vote_input,
+                                              node0_voting_power)
+
+    votes = prepare_node_votes(node_keys58[2:], validator_election, tx_election)
+
+    assert validator_election.get_election_status(tx_election.id, votes) == (False, 'insufficient_votes')
+
+    b.store_bulk_transactions([non_validator_dvote_node0])
+
+    non_validator_vote = cast_delegated_vote(non_validator.private_key, election_public_key,
+                                             non_validator_dvote_node0.to_inputs(),
+                                             node0_voting_power)
+
+    (concluded, msg) = validator_election.get_election_status(tx_election.id, votes)
+    assert not concluded
+    assert msg == 'insufficient_votes'
+
+    (concluded, msg) = validator_election.get_election_status(tx_election.id, votes + [non_validator_vote])
+    assert concluded
+
+    b.store_bulk_transactions([non_validator_vote])
+
+    (concluded, msg) = validator_election.get_election_status(tx_election.id, votes)
+    assert concluded
 
 
 def prepare_node_votes(node_keys58, validator_election, tx_election):
     votes = []
-    election_id = validator_election.election_id(tx_election.id)
+    election_id = validator_election.public_key(tx_election.id)
     for node_key in node_keys58:
         (tx_vote_input,
          voting_power) = validator_election._get_vote(tx_election, node_key.public_key)


### PR DESCRIPTION
Solution: Implement [BEP-19](https://github.com/bigchaindb/BEPs/pull/45) to fix the behavour.

TODO:
- [x] Implement `UpsertValidator` election class
    - [x] Implement and test election proposal.
    - [x] Implement and test election vote.
    - [x] Implement and test election conclusion.

NOTE: Even though BEP-19 (and [BEP-18](https://github.com/bigchaindb/BEPs/pull/44)) aren't stable yet, this PR implements the general ideas suggested in both the BEPs.