### PR TITLE
Remove vote.yaml & all vote schema validation code

### DIFF
--- a/bigchaindb/common/schema/README.md
+++ b/bigchaindb/common/schema/README.md
@@ -20,7 +20,11 @@ you must add it to the IPDB Transaction Spec first.
 Those were used to validate old transactions
 and are needed to re-check those transactions.)
 
-The file defining the JSON Schema for votes (`vote.yaml`) is BigchainDB-specific.
+There used to be a file defining the JSON Schema for votes, named `vote.yaml`.
+It was used by BigchainDB version 1.3.0 and earlier.
+If you want a copy of the latest `vote.yaml` file,
+then you can get it from the version 1.3.0 release on GitHub, at
+[https://github.com/bigchaindb/bigchaindb/blob/v1.3.0/bigchaindb/common/schema/vote.yaml](https://github.com/bigchaindb/bigchaindb/blob/v1.3.0/bigchaindb/common/schema/vote.yaml).
 
 ## Learn about JSON Schema
 

--- a/bigchaindb/common/schema/__init__.py
+++ b/bigchaindb/common/schema/__init__.py
@@ -30,7 +30,6 @@ _, TX_SCHEMA_CREATE = _load_schema('transaction_create_' +
                                    TX_SCHEMA_VERSION)
 _, TX_SCHEMA_TRANSFER = _load_schema('transaction_transfer_' +
                                      TX_SCHEMA_VERSION)
-VOTE_SCHEMA_PATH, VOTE_SCHEMA = _load_schema('vote')
 
 
 def _validate_schema(schema, body):
@@ -69,8 +68,3 @@ def validate_transaction_schema(tx):
         _validate_schema(TX_SCHEMA_TRANSFER, tx)
     else:
         _validate_schema(TX_SCHEMA_CREATE, tx)
-
-
-def validate_vote_schema(vote):
-    """Validate a vote dict"""
-    _validate_schema(VOTE_SCHEMA, vote)

--- a/bigchaindb/voting.py
+++ b/bigchaindb/voting.py
@@ -1,6 +1,5 @@
 import collections
 
-from bigchaindb.common.schema import SchemaValidationError, validate_vote_schema
 from bigchaindb.exceptions import CriticalDuplicateVote
 from bigchaindb.common.utils import serialize
 from bigchaindb.common.crypto import PublicKey
@@ -79,10 +78,6 @@ class Voting:
         malformed = []
 
         for vote in by_voter.values():
-            if not cls.verify_vote_schema(vote):
-                malformed.append(vote)
-                continue
-
             if vote['vote']['is_block_valid'] is True:
                 prev_blocks[vote['vote']['previous_block']] += 1
 
@@ -131,13 +126,3 @@ class Voting:
         public_key = PublicKey(pk_base58)
         body = serialize(vote['vote']).encode()
         return public_key.verify(body, signature)
-
-    @classmethod
-    def verify_vote_schema(cls, vote):
-        # I'm not sure this is the correct approach. Maybe we should allow
-        # duck typing w/r/t votes.
-        try:
-            validate_vote_schema(vote)
-            return True
-        except SchemaValidationError as e:
-            return False

--- a/tests/common/test_schema.py
+++ b/tests/common/test_schema.py
@@ -10,8 +10,9 @@ from pytest import raises
 
 from bigchaindb.common.exceptions import SchemaValidationError
 from bigchaindb.common.schema import (
-    TX_SCHEMA_COMMON, VOTE_SCHEMA,
-    validate_transaction_schema, validate_vote_schema)
+    TX_SCHEMA_COMMON,
+    validate_transaction_schema,
+)
 
 SUPPORTED_CRYPTOCONDITION_TYPES = ('threshold-sha-256', 'ed25519-sha-256')
 UNSUPPORTED_CRYPTOCONDITION_TYPES = (
@@ -38,10 +39,6 @@ def _test_additionalproperties(node, path=''):
 
 def test_transaction_schema_additionalproperties():
     _test_additionalproperties(TX_SCHEMA_COMMON)
-
-
-def test_vote_schema_additionalproperties():
-    _test_additionalproperties(VOTE_SCHEMA)
 
 
 ################################################################################
@@ -126,16 +123,3 @@ def test_condition_uri_with_unknown_subtype(dummy_transaction, condition_uri):
     dummy_transaction['outputs'][0]['condition']['uri'] = condition_uri
     with raises(SchemaValidationError):
         validate_transaction_schema(dummy_transaction)
-
-
-################################################################################
-# Test call vote schema
-
-
-def test_validate_vote(structurally_valid_vote):
-    validate_vote_schema(structurally_valid_vote)
-
-
-def test_validate_vote_fails():
-    with raises(SchemaValidationError):
-        validate_vote_schema({})


### PR DESCRIPTION
This is just general cleanup of old code. There's still a lot of old voting code around. This PR just removes the code related to vote schema validation.

This PR replaces PR #2233 

