### PR TITLE
Problem: Can't connect to local MongoDB when `make start`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   mongodb:
     image: mongo:3.6
     ports:
-      - "27017"
+      - "27017:27017"
     command: mongod
   bigchaindb:
     depends_on:


### PR DESCRIPTION
Solution: Expose MongoDB port 27017 when using `make start`, i.e. when using `docker-compose.yml`

If you start BigchainDB, MongoDB and Tendermint using `make start`, it uses Docker Compose to make all that run locally (in Docker containers). If you want to connect to the MongoDB database, without going inside the MongoDB container, you couldn't just do that before, because MongoDB port 27017 wasn't being exposed. That meant, for example, that if you did
```text
$ make start
$ mongo
```
you would get an error because `mongo` (the MongoDB Shell) couldn't connect to MongoDB on port 27017.

Once this pull request gets merged, you'll be able to use `mongo` and other tools to connect to the local MongoDB database on port 27017.