### PR TITLE
Problem: API returns 404 for existing empty blocks

### DIFF
--- a/bigchaindb/tendermint/lib.py
+++ b/bigchaindb/tendermint/lib.py
@@ -88,10 +88,6 @@ class BigchainDB(Bigchain):
     def _process_status_code(self, status_code, failure_msg):
         return (202, '') if status_code == 0 else (500, failure_msg)
 
-    def get_latest_block_height_from_tendermint(self):
-        r = requests.get(ENDPOINT + 'status')
-        return r.json()['result']['sync_info']['latest_block_height']
-
     def store_transaction(self, transaction):
         """Store a valid transaction to the transactions collection."""
 
@@ -284,8 +280,10 @@ class BigchainDB(Bigchain):
         """
 
         block = backend.query.get_block(self.connection, block_id)
+        latest_block = self.get_latest_block()
+        latest_block_height = latest_block['height'] if latest_block else 0
 
-        if not block and block_id > self.get_latest_block_height_from_tendermint():
+        if not block and block_id > latest_block_height:
             return
 
         result = {'height': block_id,

--- a/bigchaindb/tendermint/lib.py
+++ b/bigchaindb/tendermint/lib.py
@@ -280,7 +280,7 @@ class BigchainDB(Bigchain):
         found.
 
         Args:
-            block_id (str): block id of the block to get
+            block_id (int): block id of the block to get.
         """
 
         block = backend.query.get_block(self.connection, block_id)

--- a/bigchaindb/tendermint/lib.py
+++ b/bigchaindb/tendermint/lib.py
@@ -90,7 +90,7 @@ class BigchainDB(Bigchain):
 
     def get_latest_block_height_from_tendermint(self):
         r = requests.get(ENDPOINT + 'status')
-        return r.json()['result']['latest_block_height']
+        return r.json()['result']['sync_info']['latest_block_height']
 
     def store_transaction(self, transaction):
         """Store a valid transaction to the transactions collection."""
@@ -273,41 +273,29 @@ class BigchainDB(Bigchain):
 
         return backend.query.get_latest_block(self.connection)
 
-    def get_block(self, block_id, include_status=False):
-        """Get the block with the specified `block_id` (and optionally its status)
+    def get_block(self, block_id):
+        """Get the block with the specified `block_id`.
 
         Returns the block corresponding to `block_id` or None if no match is
         found.
 
         Args:
             block_id (str): block id of the block to get
-            include_status (bool): also return the status of the block
-                       the return value is then a tuple: (block, status)
         """
-        # get block from database
-        if isinstance(block_id, str):
-            block_id = int(block_id)
 
         block = backend.query.get_block(self.connection, block_id)
+
+        if not block and block_id > self.get_latest_block_height_from_tendermint():
+            return
+
+        result = {'height': block_id,
+                  'transactions': []}
+
         if block:
             transactions = backend.query.get_transactions(self.connection, block['transactions'])
-            transactions = Transaction.from_db(self, transactions)
+            result['transactions'] = [t.to_dict() for t in Transaction.from_db(self, transactions)]
 
-            block = {'height': block['height'],
-                     'transactions': []}
-            block_txns = block['transactions']
-            for txn in transactions:
-                block_txns.append(txn.to_dict())
-
-        status = None
-        if include_status:
-            # NOTE: (In Tendermint) a block is an abstract entity which
-            # exists only after it has been validated
-            if block:
-                status = self.BLOCK_VALID
-            return block, status
-        else:
-            return block
+        return result
 
     def get_block_containing_tx(self, txid):
         """Retrieve the list of blocks (block ids) containing a

--- a/bigchaindb/web/routes.py
+++ b/bigchaindb/web/routes.py
@@ -29,7 +29,7 @@ ROUTES_API_V1 = [
     r('/', info.ApiV1Index),
     r('assets/', assets.AssetListApi),
     r('metadata/', metadata.MetadataApi),
-    r('blocks/<string:block_id>', blocks.BlockApi),
+    r('blocks/<int:block_id>', blocks.BlockApi),
     r('blocks/', blocks.BlockListApi),
     r('transactions/<string:tx_id>', tx.TransactionApi),
     r('transactions', tx.TransactionListApi),

--- a/tests/tendermint/test_lib.py
+++ b/tests/tendermint/test_lib.py
@@ -61,6 +61,13 @@ def test_get_latest_block(tb):
     assert block['height'] == 9
 
 
+@pytest.mark.bdb
+@patch('bigchaindb.backend.query.get_block', return_value=None)
+@patch('bigchaindb.tendermint.lib.BigchainDB.get_latest_block_height_from_tendermint', return_value=10)
+def test_get_empty_block(_0, _1, tb):
+    assert tb.get_block(5) == {'height': 5, 'transactions': []}
+
+
 def test_validation_error(b):
     from bigchaindb.models import Transaction
     from bigchaindb.common.crypto import generate_key_pair

--- a/tests/tendermint/test_lib.py
+++ b/tests/tendermint/test_lib.py
@@ -63,7 +63,7 @@ def test_get_latest_block(tb):
 
 @pytest.mark.bdb
 @patch('bigchaindb.backend.query.get_block', return_value=None)
-@patch('bigchaindb.tendermint.lib.BigchainDB.get_latest_block_height_from_tendermint', return_value=10)
+@patch('bigchaindb.tendermint.lib.BigchainDB.get_latest_block', return_value={'height': 10})
 def test_get_empty_block(_0, _1, tb):
     assert tb.get_block(5) == {'height': 5, 'transactions': []}
 


### PR DESCRIPTION
Solution: Empty blocks are not store in MongoDB because Tendermint does not notify BigchainDB about them. In case a user requests a block that is not in our MongoDB, we check if the requested height is less than or equal to `latest_block_height`. If that's the case, we return an empty block. If the requested height is greater than `latest_block_height`, then we return 404.

Close #2190, Close #2204.