### PR TITLE
Revert: `bigchaindb configure` does not write the correct configuration

### DIFF
--- a/bigchaindb/commands/bigchaindb.py
+++ b/bigchaindb/commands/bigchaindb.py
@@ -68,6 +68,7 @@ def run_configure(args):
     print('Generating default configuration for backend {}'
           .format(args.backend), file=sys.stderr)
     database_keys = bigchaindb._database_keys_map[args.backend]
+    conf['database'] = bigchaindb._database_map[args.backend]
 
     if not args.yes:
         for key in ('bind', ):


### PR DESCRIPTION
Why? Change made with incomplete understand of the workflow covered with BigchainDB docs[[1]](https://docs.bigchaindb.com/projects/server/en/master/server-reference/bigchaindb-cli.html#bigchaindb-configure)[[2]](https://docs.bigchaindb.com/projects/server/en/master/server-reference/configuration.html).

Also, if a ENV variable is exposed, it will always be picked up by the configuration. Config file becomes irrelevant in that scenario.