### PR TITLE
Copy-edited & updated the page on Running a Local Dev Node as Processes

### DIFF
--- a/docs/contributing/source/dev-setup-coding-and-contribution-process/run-node-as-processes.md
+++ b/docs/contributing/source/dev-setup-coding-and-contribution-process/run-node-as-processes.md
@@ -9,24 +9,33 @@ There are two crucial dependencies required to start a local node:
 
 and of course you also need to install BigchainDB Sever from the local code you just developed.
 
+## Install and Run MongoDB
 
-## Installing MongoDB
-
-MongoDB can be easily installed, just refer their [installation documentation](https://docs.mongodb.com/manual/installation/) for your distro. 
-We know MongoDB 3.4 works with BigchainDB.
-MongoDB 3.6 _might_ work, or it might not. You could try it.
+MongoDB can be easily installed, just refer to their [installation documentation](https://docs.mongodb.com/manual/installation/) for your distro. 
+We know MongoDB 3.4 and 3.6 work with BigchainDB.
 After the installation of MongoDB is complete, run MongoDB using `sudo mongod`
 
+## Install and Run Tendermint
 
-## Installing Tendermint
+### Installing a Tendermint Executable
+
+Find [the version number of the latest Tendermint release](https://github.com/tendermint/tendermint/releases) and install it using the following, where 0.19.3 should be replaced by the latest released version number:
+
+```bash
+$ sudo apt install -y unzip
+$ wget https://github.com/tendermint/tendermint/releases/download/v0.19.3/tendermint_0.19.3_linux_amd64.zip
+$ unzip tendermint_0.19.3_linux_amd64.zip
+$ rm tendermint_0.19.3_linux_amd64.zip
+$ sudo mv tendermint /usr/local/bin
+```
 
 ### Installing Tendermint Using Docker
 
 Tendermint can be run directly using the docker image. Refer [here](https://hub.docker.com/r/tendermint/tendermint/) for more details.
 
-
 ### Installing Tendermint from Source
-- Before we can begin installing Tendermint one should ensure that the Golang is installed on system and `$GOPATH` should be set in the `.bashrc` or `.zshrc`. An example setup is shown below
+
+Before we can begin installing Tendermint one should ensure that the Golang is installed on system and `$GOPATH` should be set in the `.bashrc` or `.zshrc`. An example setup is shown below
 
 ```bash
 
@@ -74,6 +83,7 @@ Available Commands:
 ```
 
 ### Running Tendermint
+
 - We can initialize and run tendermint as follows,
 ```bash
 $ tendermint init
@@ -90,17 +100,15 @@ The argument `--consensus.create_empty_blocks=false` specifies that Tendermint s
 $ tendermint unsafe_reset_all
 ```
 
-## Installing BigchainDB
+## Install BigchainDB
 
 To install BigchainDB from source (for dev), clone the repo and execute the following command, (it is better that you create a virtual env for this)
 
 ```bash
 $ git clone https://github.com/bigchaindb/bigchaindb.git
-...
-$ git checkout tendermint
+$ cd bigchaindb
 $ pip install -e .[dev]  #  or  pip install -e '.[dev]'  # for zsh
 ```
-
 
 ## Running All Tests
 
@@ -121,17 +129,3 @@ $ docker-compose run --rm --no-deps bdb pytest -v --cov=bigchaindb
 ```
 
 NOTE: before executing the above command the user must ensure that they reset the Tendermint container by executing `tendermint usafe_reset_all` command in the Tendermint container.
-
-
-### Closing Notes
-
-How to check `bigchaindb upsert-validator` (which was first specified in [BEP-3](https://github.com/bigchaindb/BEPs/tree/master/3)):
-
-- Clean bigchaindb (`bigchaindb drop`, `bigchaindb init`) and execute `bigchaindb upsert-validator B0E42D2589A455EAD339A035D6CE1C8C3E25863F268120AA0162AD7D003A4014 10`
-- Start Tendermint
- - `tendermint init`
- - `tendermint unsafe_reset_all`
- - `tendermint node --consensus.create_empty_blocks=false`
-- Start BigchainDB with `bichaindb start`
-- Execute `curl http://localhost:46657/validators`
-


### PR DESCRIPTION
- We know MongoDB 3.6 works now, for sure.
- Added instructions to install the Tendermint executable, in case the reader prefers to do it that way.
- After cloning the bigchaindb/bigchaindb repo, they don't need to switch to the `tendermint` branch any more. The default (`master`) branch will work.
- Removed the section at the end about how to check `bigchaindb upsert-validator` 