### PR TITLE
Problem: Still using "team bot" after installing Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,13 +1,6 @@
 codecov:
   branch: master     # the branch to show by default
 
-  # The help text for bot says:
-  # "the username that will consume any oauth requests
-  # must have previously logged into Codecov"
-  # In GitHub - BigchainDB organization settings - Third-party access,
-  # it says, for Codecov: "approval requested by r-marques"
-  bot: r-marques
-
 coverage:
   precision: 2
   round: down


### PR DESCRIPTION
Solution: Remove the "team bot" from the `codecov.yml` file.

I installed Codecov on all "bigchaindb" (GitHub organization) repos today, so we can remove the "team bot", according to [the Codecov docs](https://docs.codecov.io/docs/team-bot), i.e.

> The best way to integrate with Codecov is to Install Codecov's GitHub Integration. Once installed, you are done! You do not need to set a Team Bot because Codecov will use the integration to post statuses and comments.
