### PR TITLE
Problem: we don't have any tests for malicious strings

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -33,6 +33,5 @@ RUN mkdir -p /usr/src/app
 COPY . /usr/src/app/
 WORKDIR /usr/src/app
 RUN pip install --no-cache-dir --process-dependency-links -e .[dev]
-RUN pip install blns
 RUN bigchaindb -y configure
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -33,5 +33,6 @@ RUN mkdir -p /usr/src/app
 COPY . /usr/src/app/
 WORKDIR /usr/src/app
 RUN pip install --no-cache-dir --process-dependency-links -e .[dev]
-RUN bigchaindb -y configure "$backend"
+RUN pip install blns
+RUN bigchaindb -y configure
 

--- a/acceptance/python/Dockerfile
+++ b/acceptance/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.3
+FROM python:3.6
 
 RUN mkdir -p /src
 RUN pip install --upgrade \
@@ -6,3 +6,5 @@ RUN pip install --upgrade \
 	websocket-client~=0.47.0 \
 	pytest~=3.0 \
 	bigchaindb-driver==0.5.0a4
+RUN pip install --upgrade pip
+RUN pip install blns

--- a/acceptance/python/src/test_naughty_strings.py
+++ b/acceptance/python/src/test_naughty_strings.py
@@ -1,0 +1,87 @@
+# ## Testing potentially hazardous strings
+# This test uses a library of `naughty` strings (code injections, weird unicode chars., etc.) as both keys and values.
+# We look for either a successful tx, or in the case that we use a naughty string as a key, and it violates some key
+# constraints, we expect to receive a well formatted error message.
+
+# ## Imports
+# We need some utils from the `os` package, we will interact with
+# env variables.
+import os
+
+# Since the naughty strings get encoded and decoded in odd ways, we'll use a regex to sweep those details under the rug.
+import re
+
+# We'll use a nice library of naughty strings...
+from blns import blns
+
+# And parameterize our test so each one is treated as a separate test case
+import pytest
+
+# For this test case we import and use the Python Driver.
+from bigchaindb_driver import BigchainDB
+from bigchaindb_driver.crypto import generate_keypair
+from bigchaindb_driver.exceptions import BadRequest
+
+naughty_strings = blns.all()
+
+
+# This is our base test case, but we'll reuse it to send naughty strings as both keys and values.
+def send_naughty_tx(asset, metadata):
+    # ## Set up a connection to BigchainDB
+    # Check [test_basic.py](./test_basic.html) to get some more details
+    # about the endpoint.
+    bdb = BigchainDB(os.environ.get('BIGCHAINDB_ENDPOINT'))
+
+    # Here's Alice.
+    alice = generate_keypair()
+
+    # Alice is in a naughty mood today, so she creates a tx with some naughty strings
+    prepared_transaction = bdb.transactions.prepare(
+        operation='CREATE',
+        signers=alice.public_key,
+        asset=asset,
+        metadata=metadata)
+
+    # She fulfills the transaction
+    fulfilled_transaction = bdb.transactions.fulfill(
+        prepared_transaction,
+        private_keys=alice.private_key)
+
+    # The fulfilled tx gets sent to the BDB network
+    try:
+        sent_transaction = bdb.transactions.send(fulfilled_transaction)
+    except BadRequest as e:
+        sent_transaction = e
+
+    # Then she checks that either her transaction was written to the block chain,
+    # or she got back a nice error message
+    if type(sent_transaction) == dict:
+        if 'id' in sent_transaction.keys():
+            tx_id = sent_transaction['id']
+            assert bdb.transactions.retrieve(tx_id), sent_transaction
+    elif type(sent_transaction) == BadRequest:
+        status_code = sent_transaction.status_code
+        error = sent_transaction.error
+        regex = '\{"message":"Invalid transaction \\(ValidationError\\): Invalid key name .* in asset object. The key name cannot contain characters .* or null characters","status":400\}\n'
+        assert status_code == 400, status_code
+        assert re.fullmatch(regex, error), error
+    else:
+        raise TypeError(sent_transaction)
+
+
+@pytest.mark.parametrize("naughty_string", naughty_strings, ids=naughty_strings)
+def test_naughty_keys(naughty_string):
+
+    asset = {'data': {naughty_string: 'naughty_value'}}
+    metadata = {naughty_string: 'naughty_value'}
+
+    send_naughty_tx(asset, metadata)
+
+
+@pytest.mark.parametrize("naughty_string", naughty_strings, ids=naughty_strings)
+def test_naughty_values(naughty_string):
+
+    asset = {'data': {'naughty_key': naughty_string}}
+    metadata = {'naughty_key': naughty_string}
+
+    send_naughty_tx(asset, metadata)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-dev
-      args:
-        backend: localmongodb
     volumes:
       - ./bigchaindb:/usr/src/app/bigchaindb
       - ./tests:/usr/src/app/tests


### PR DESCRIPTION
## Solution

Use a parameterized test that fuzzes over a library of potentially hazardous strings. I'm using the 'big_list_of_naughty_strings', which includes some nice sql-injections, some crazy unicode sequences, and some invocations to elder gods... This up shot is, the work of maintaining the 'naughty strings' is off-loaded, and the test file generates individual tests for each string, so we should stay compliant if any new attack vectors open up.

## Issues Resolved

Contributing as part of the stability push for release of beta

## BEPs Implemented

NA