### PR TITLE
Upgrade Tendermint to 0.19.7, except for Docker image still at 0.19.2

### DIFF
--- a/bigchaindb/tendermint/utils.py
+++ b/bigchaindb/tendermint/utils.py
@@ -39,8 +39,7 @@ def calculate_hash(key_list):
 
 
 def merkleroot(hashes):
-    """
-    Computes the merkle root for a given list.
+    """Computes the merkle root for a given list.
 
     Args:
         hashes (:obj:`list` of :obj:`bytes`): The leaves of the tree.
@@ -69,7 +68,7 @@ def merkleroot(hashes):
 
 
 def public_key64_to_address(base64_public_key):
-    """Note this only compatibile with Tendermint 0.19.0 """
+    """Note this only compatibile with Tendermint 0.19.0"""
     ed25519_public_key = public_key_from_base64(base64_public_key)
     encoded_public_key = amino_encoded_public_key(ed25519_public_key)
     return hashlib.new('ripemd160', encoded_public_key).hexdigest().upper()

--- a/bigchaindb/tendermint/utils.py
+++ b/bigchaindb/tendermint/utils.py
@@ -68,7 +68,7 @@ def merkleroot(hashes):
 
 
 def public_key64_to_address(base64_public_key):
-    """Note this only compatibile with Tendermint 0.19.0"""
+    """Note this only compatible with Tendermint 0.19.x"""
     ed25519_public_key = public_key_from_base64(base64_public_key)
     encoded_public_key = amino_encoded_public_key(ed25519_public_key)
     return hashlib.new('ripemd160', encoded_public_key).hexdigest().upper()

--- a/docs/contributing/source/dev-setup-coding-and-contribution-process/run-node-as-processes.md
+++ b/docs/contributing/source/dev-setup-coding-and-contribution-process/run-node-as-processes.md
@@ -19,13 +19,13 @@ After the installation of MongoDB is complete, run MongoDB using `sudo mongod`
 
 ### Installing a Tendermint Executable
 
-Find [the version number of the latest Tendermint release](https://github.com/tendermint/tendermint/releases) and install it using the following, where 0.19.3 should be replaced by the latest released version number:
+Find [the version number of the latest Tendermint release](https://github.com/tendermint/tendermint/releases) and install it using the following, where 0.19.7 should be replaced by the latest released version number:
 
 ```bash
 $ sudo apt install -y unzip
-$ wget https://github.com/tendermint/tendermint/releases/download/v0.19.3/tendermint_0.19.3_linux_amd64.zip
-$ unzip tendermint_0.19.3_linux_amd64.zip
-$ rm tendermint_0.19.3_linux_amd64.zip
+$ wget https://github.com/tendermint/tendermint/releases/download/v0.19.7/tendermint_0.19.7_linux_amd64.zip
+$ unzip tendermint_0.19.7_linux_amd64.zip
+$ rm tendermint_0.19.7_linux_amd64.zip
 $ sudo mv tendermint /usr/local/bin
 ```
 

--- a/docs/server/source/simple-network-setup.md
+++ b/docs/server/source/simple-network-setup.md
@@ -61,9 +61,9 @@ Install a [recent version of Tendermint][tendermint:releases]. BigchainDB Server
 
 ```
 sudo apt install -y unzip
-wget https://github.com/tendermint/tendermint/releases/download/v0.19.3/tendermint_0.19.3_linux_amd64.zip
-unzip tendermint_0.19.3_linux_amd64.zip
-rm tendermint_0.19.3_linux_amd64.zip
+wget https://github.com/tendermint/tendermint/releases/download/v0.19.7/tendermint_0.19.7_linux_amd64.zip
+unzip tendermint_0.19.7_linux_amd64.zip
+rm tendermint_0.19.7_linux_amd64.zip
 sudo mv tendermint /usr/local/bin
 ```
 

--- a/pkg/configuration/roles/tendermint/files/Dockerfile
+++ b/pkg/configuration/roles/tendermint/files/Dockerfile
@@ -1,4 +1,4 @@
-ARG tm_version=0.19.3
+ARG tm_version=0.19.2
 FROM tendermint/tendermint:${tm_version}
 LABEL maintainer "dev@bigchaindb.com"
 WORKDIR /


### PR DESCRIPTION
The last-tagged tendermint/tendermint Docker image is 0.19.2 so we can't upgrade it to 0.19.7 yet.

This PR also fixes two minor PEP257 compliance errors (in Python docstrings) that pre-commit was complaining about.