### PR TITLE
Problem: arbitrary big transactions might fail

### DIFF
--- a/acceptance/python/src/test_max_transaction_size.py
+++ b/acceptance/python/src/test_max_transaction_size.py
@@ -1,0 +1,93 @@
+# # Transaction Size Tes
+# BigchainDB allows to limit the maximum size of a transaction. This acceptance
+# test make sure that this is happening.
+
+import os
+
+import pytest
+import requests
+
+from bigchaindb_driver import exceptions, BigchainDB
+from bigchaindb_driver.crypto import generate_keypair
+
+## Helper functions
+
+# Helper function to normalize the URL to connect to a BigchainDB node.
+def normalize_url(url):
+    from urllib.parse import urlparse, urlunparse
+    if '://' not in url:
+        url = 'http://' + url
+    p = urlparse(url)
+    if not p.port:
+        p = p._replace(netloc=p.hostname + ':9984')
+    return urlunparse(p)
+
+
+BIGCHAINDB_ENDPOINT = normalize_url(os.environ.get('BIGCHAINDB_ENDPOINT', 'http://localhost:9984'))
+bdb = BigchainDB(BIGCHAINDB_ENDPOINT)
+
+
+# Helper function to generate a transaction with an approximated size. Note
+# that the final size of the transaction will be bigger, since this function
+# does not consider the size of all other fields of the transaction model such
+# as `id`, `inputs`, `outputs`, and more.
+def generate_transaction_by_size(size):
+    keypair = generate_keypair()
+
+    asset = {'data': {'_': 'x' * size}}
+
+    prepared_creation_tx = bdb.transactions.prepare(
+            operation='CREATE',
+            signers=keypair.public_key,
+            asset=asset)
+
+    fulfilled_creation_tx = bdb.transactions.fulfill(
+            prepared_creation_tx,
+            private_keys=keypair.private_key)
+
+    return fulfilled_creation_tx
+
+## Testing time!
+def test_max_transaction_size():
+    # First, we retrieve the maximum size of a transaction from the API.
+    max_transaction_size = requests.get(BIGCHAINDB_ENDPOINT).json()['max_transaction_size']
+
+    # We then generate a first, valid transaction, and verify that it has been
+    # accepted.
+    transaction = generate_transaction_by_size(1)
+    sent_transfer_tx = bdb.transactions.send(transaction)
+    assert bdb.transactions.retrieve(transaction['id']) == sent_transfer_tx
+
+    # Now we generate another transaction, double the size of the allowed upper
+    # bound.
+    transaction = generate_transaction_by_size(max_transaction_size * 2)
+    try:
+        sent_transfer_tx = bdb.transactions.send(transaction)
+    except exceptions.TransportError as e:
+        # We expect an exception with status code `413`, that is **Entity too
+        # large**.
+        assert e.status_code == 413
+
+    # Just to be 100% sure, we also check that the transaction has not been
+    # stored in BigchainDB.
+    with pytest.raises(exceptions.NotFoundError):
+        assert bdb.transactions.retrieve(transaction['id'])
+
+    # Now let's play the 1337 h4x0r card. We generate another transaction
+    # double the size of the allowed limit first.
+    transaction = generate_transaction_by_size(max_transaction_size * 2)
+
+    # Then we handcraft an HTTP request and we spoof the `Content-Length` header, saying
+    # that the total size of the request is just one byte. (Make sure to wear
+    # leather gloves to not leave your fingerprints on the keyboard, you don't
+    # want NSA to catch you!)
+    req = requests.post(
+        BIGCHAINDB_ENDPOINT + '/api/v1/transactions?mode=commit',
+        json=transaction,
+        headers={'Content-Length': '1'})
+
+    # This should fail as well, so we check that we get a `413` and no
+    # transaction has been stored in BigchainDB.
+    assert req.status_code == 413
+    with pytest.raises(exceptions.NotFoundError):
+        assert bdb.transactions.retrieve(transaction['id'])

--- a/bigchaindb/__init__.py
+++ b/bigchaindb/__init__.py
@@ -63,6 +63,7 @@ config = {
         'host': 'localhost',
         'port': 26657,
     },
+    'max_transaction_size': 1048576,
     # FIXME: hardcoding to localmongodb for now
     'database': _database_map['localmongodb'],
     'log': {

--- a/bigchaindb/web/server.py
+++ b/bigchaindb/web/server.py
@@ -10,7 +10,7 @@ from flask import Flask
 from flask_cors import CORS
 import gunicorn.app.base
 
-from bigchaindb import utils
+from bigchaindb import config, utils
 from bigchaindb.tendermint import BigchainDB
 from bigchaindb.web.routes import add_routes
 from bigchaindb.web.strip_content_type_middleware import StripContentTypeMiddleware
@@ -55,7 +55,7 @@ class StandaloneApplication(gunicorn.app.base.BaseApplication):
         return self.application
 
 
-def create_app(*, debug=False, threads=1, bigchaindb_factory=None):
+def create_app(*, debug=False, threads=1, max_content_length=None, bigchaindb_factory=None):
     """Return an instance of the Flask application.
 
     Args:
@@ -76,6 +76,7 @@ def create_app(*, debug=False, threads=1, bigchaindb_factory=None):
 
     app.debug = debug
 
+    app.config['MAX_CONTENT_LENGTH'] = max_content_length
     app.config['bigchain_pool'] = utils.pool(bigchaindb_factory, size=threads)
 
     add_routes(app)
@@ -108,6 +109,7 @@ def create_server(settings, log_config=None, bigchaindb_factory=None):
     settings['custom_log_config'] = log_config
     app = create_app(debug=settings.get('debug', False),
                      threads=settings['threads'],
+                     max_content_length=config['max_transaction_size'],
                      bigchaindb_factory=bigchaindb_factory)
     standalone = StandaloneApplication(app, options=settings)
     return standalone

--- a/bigchaindb/web/views/info.py
+++ b/bigchaindb/web/views/info.py
@@ -4,7 +4,7 @@ import flask
 from flask_restful import Resource
 
 from bigchaindb.web.views.base import base_ws_uri
-from bigchaindb import version
+from bigchaindb import config, version
 from bigchaindb.web.websocket_server import EVENTS_ENDPOINT
 
 
@@ -19,6 +19,7 @@ class RootIndex(Resource):
                 'v1': get_api_v1_info('/api/v1/')
             },
             'docs': ''.join(docs_url),
+            'max_transaction_size': config['max_transaction_size'],
             'software': 'BigchainDB',
             'version': version.__version__,
         })

--- a/tests/web/test_transactions.py
+++ b/tests/web/test_transactions.py
@@ -28,6 +28,31 @@ def test_get_transaction_returns_404_if_not_found(client):
     assert res.status_code == 404
 
 
+@pytest.mark.tendermint
+def test_post_transaction_size(b, live_server, config):
+    import requests
+    from bigchaindb.models import Transaction
+    user_priv, user_pub = crypto.generate_key_pair()
+
+    def by_size(size):
+        tx = Transaction.create(
+                [user_pub],
+                [([user_pub], 1)],
+                asset={'_': 'x' * size}).sign([user_priv])
+        return json.dumps(tx.to_dict())
+
+    from pprint import pprint
+
+    res = requests.post(TX_ENDPOINT, data=by_size(10))
+    assert res.status_code == 202
+
+    res = requests.post(TX_ENDPOINT, data=by_size(2048))
+    assert res.status_code == 202
+
+    pprint(config)
+    1/0
+
+
 @pytest.mark.abci
 def test_post_create_transaction_endpoint(b, client):
     from bigchaindb.models import Transaction


### PR DESCRIPTION
Solution: add a new configuration parameter `max_transaction_size` to
limit the size of transactions accepted by the web API. The parameter is
also exposed by the root API endpoint using the same key
`max_transaction_size`, so drivers can act accordingly and eventually
fail early if the transaction to be sent is bigger than the upper limit.
This issue was first reported in #2222.

By default Flask will accept file uploads to an unlimited amount of
memory, but you can limit that by setting the [`MAX_CONTENT_LENGTH`
config key][1]. Spoofing the `Content-Length` is also considered: see the
integration test under
`acceptance/python/src/test_max_transaction_size.py`.

I had troubles creating a unit test to check this feature. It seems that
the pytest fixture for testing Flask ignores the `MAX_CONTENT_LENGTH`
setting. If you have better ideas on how to test that, please make a
patch.

To be honest, I'm not sure that having the parameter
`max_transaction_size` in the BigchainDB configuration file is a good
idea. It should be a Network wide configuration parameter, shared and
accepted by every non-byzantine node. We should have something like the
`genesis.json` file in Tendermint, and it should be updated using the
Election Process specified by [BEP-18][2]. If we do that, then
`max_transaction_size` should be checked also in the validation rules.

[1]: http://flask.pocoo.org/docs/1.0/patterns/fileuploads/#improving-uploads
[2]: https://github.com/bigchaindb/BEPs/tree/master/18