### PR TITLE
Problem: a valid transaction is detected as double spend

### DIFF
--- a/bigchaindb/backend/localmongodb/query.py
+++ b/bigchaindb/backend/localmongodb/query.py
@@ -99,11 +99,13 @@ def get_assets(conn, asset_ids):
 
 @register_query(LocalMongoDBConnection)
 def get_spent(conn, transaction_id, output):
+    query = {'inputs.fulfills': {
+        'transaction_id': transaction_id,
+        'output_index': output}}
+
     return conn.run(
         conn.collection('transactions')
-        .find({'inputs.fulfills.transaction_id': transaction_id,
-               'inputs.fulfills.output_index': output},
-              {'_id': 0}))
+            .find(query, {'_id': 0}))
 
 
 @register_query(LocalMongoDBConnection)


### PR DESCRIPTION
Solution: query the wanted data per input

see #1271

To add more details:
In the test we have 5 transactions, one create and 4 transfer. In the first 4 transaction Bob only receives tokens and in the fifth he wants to spend the first two tokens he got.

When validating the fifth transaction in the query we check if the `transaction_id` and the `output` are in `inputs`. The `inputs` contains two `input`s, one that matches the `transaction_id` and the other one that matches the `output`, thus we found a match and the fifth transaction is a double spend. 
Which it is obviously not. 
So @kansi and me changed the query accordingly and we now match the `transaction_id` and the `output` for every `input` in `inputs`.

I needed to skip the other tests in this file, they're not related to this issue and should be activated separately (related to https://github.com/bigchaindb/bigchaindb/issues/2381) 