### PR TITLE
Problem: Docs say Crypto Conditions are part of ILP

### DIFF
--- a/docs/root/source/smart-contracts.rst
+++ b/docs/root/source/smart-contracts.rst
@@ -3,7 +3,7 @@ BigchainDB and Smart Contracts
 
 One can store the source code of any smart contract (i.e. a computer program) in BigchainDB, but BigchainDB won't run arbitrary smart contracts.
 
-BigchainDB will run the subset of smart contracts expressible using `Crypto-Conditions <https://tools.ietf.org/html/draft-thomas-crypto-conditions-03>`_. Crypto-conditions are part of the `Interledger Protocol <https://interledger.org/>`_.
+BigchainDB will run the subset of smart contracts expressible using `Crypto-Conditions <https://tools.ietf.org/html/draft-thomas-crypto-conditions-03>`_.
 
 The owners of an asset can impose conditions on it that must be met for the asset to be transferred to new owners. Examples of possible conditions (crypto-conditions) include:
 

--- a/docs/root/source/transaction-concepts.md
+++ b/docs/root/source/transaction-concepts.md
@@ -27,9 +27,8 @@ and the other output might have 15 oak trees for another set of owners.
 
 Each output also has an associated condition: the condition that must be met
 (by a TRANSFER transaction) to transfer/spend the output.
-BigchainDB supports a variety of conditions,
-a subset of the [Interledger Protocol (ILP)](https://interledger.org/)
-crypto-conditions. For details, see
+BigchainDB supports a variety of conditions.
+For details, see
 the section titled **Transaction Components: Conditions**
 in the relevant
 [BigchainDB Transactions Spec](https://github.com/bigchaindb/BEPs/tree/master/tx-specs/).


### PR DESCRIPTION
Solution: Edit the docs so they no longer say that

For background on why Crypto Conditions were removed from the Interledger Protocol (ILP), see section 6 in the Interleger blog post at https://medium.com/interledger-blog/simplifying-interledger-the-graveyard-of-possible-protocol-features-b35bf67439be 
