### PR TITLE
Problem: Inconsistent HTTP API docs

### DIFF
--- a/docs/server/source/http-client-server-api.rst
+++ b/docs/server/source/http-client-server-api.rst
@@ -301,7 +301,7 @@ Assets
 
         Currently this endpoint is only supported if using MongoDB.
 
-.. http:get:: /api/v1/assets?search={search}
+.. http:get:: /api/v1/assets/?search={search}
 
     Return all assets that match a given text search.
     
@@ -309,6 +309,10 @@ Assets
     
        The ``id`` of the asset
        is the same ``id`` of the CREATE transaction that created the asset.
+
+    .. note::
+    
+       You can use ``assets/?search`` or ``assets?search``.
 
     If no assets match the text search it returns an empty list.
 
@@ -424,6 +428,10 @@ Transaction Metadata
 
        The ``id`` of the metadata
        is the same ``id`` of the transaction where it was defined.
+
+    .. note::
+    
+       You can use ``metadata/?search`` or ``metadata?search``.
 
     If no metadata objects match the text search it returns an empty list.
 


### PR DESCRIPTION
- Made the title of the asset search section consistent with the example (and consistent with the metadata search title and example).
- Added a note that one can use `asset?search` or `asset/?search`, and a similar note for the metadata search.
