### PR TITLE
Problem: pylint's GPL license isn't Apache2-compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ tests_require = [
     'flake8-quotes==0.8.1',
     'hypothesis~=3.18.5',
     'hypothesis-regex',
-    'pylint',
+    # Removed pylint because its GPL license isn't Apache2-compatible
     'pytest>=3.0.0',
     'pytest-cov>=2.2.1',
     'pytest-mock',


### PR DESCRIPTION
I did an audit of all the licenses of the Python packages in `setup.py` (and the licenses of the software they use). I only found one whose license wasn't compatible with the Apache v2 license: [pylint](https://pypi.org/project/pylint/). It seems we're not using `pylint` anyway. I couldn't find any reference to it anywhere else in this repo.

Therefore I propose that we remove pylint from the list of "requirements" in `setup.py`. That's what this PR does.