### PR TITLE
Problem: abruptly closed sockets still in memory

### DIFF
--- a/bigchaindb/web/websocket_server.py
+++ b/bigchaindb/web/websocket_server.py
@@ -16,6 +16,7 @@ import asyncio
 import logging
 import threading
 from uuid import uuid4
+from concurrent.futures import CancelledError
 
 import aiohttp
 from aiohttp import web
@@ -124,6 +125,9 @@ def websocket_handler(request):
             msg = yield from websocket.receive()
         except RuntimeError as e:
             logger.debug('Websocket exception: %s', str(e))
+            break
+        except CancelledError as e:
+            logger.debug('Websocket closed')
             break
         if msg.type == aiohttp.WSMsgType.CLOSED:
             logger.debug('Websocket closed')


### PR DESCRIPTION
Solution: Catch the proper exception and remove socket from memory.

The problem looks like this in the console:
```
[2018-07-25 11:54:06] [WARNING] (asyncio) socket.send() raised exception. (bigchaindb_ws - pid: 86105)
[2018-07-25 11:54:06] [WARNING] (asyncio) socket.send() raised exception. (bigchaindb_ws - pid: 86105)
[2018-07-25 11:54:06] [WARNING] (asyncio) socket.send() raised exception. (bigchaindb_ws - pid: 86105)
[2018-07-25 11:54:06] [WARNING] (asyncio) socket.send() raised exception. (bigchaindb_ws - pid: 86105)
[2018-07-25 11:54:06] [WARNING] (asyncio) socket.send() raised exception. (bigchaindb_ws - pid: 86105)
[2018-07-25 11:54:06] [WARNING] (asyncio) socket.send() raised exception. (bigchaindb_ws - pid: 86105)
[2018-07-25 11:54:06] [WARNING] (asyncio) socket.send() raised exception. (bigchaindb_ws - pid: 86105)
[2018-07-25 11:54:06] [WARNING] (asyncio) socket.send() raised exception. (bigchaindb_ws - pid: 86105)
[2018-07-25 11:54:06] [WARNING] (asyncio) socket.send() raised exception. (bigchaindb_ws - pid: 86105)
[2018-07-25 11:54:06] [WARNING] (asyncio) socket.send() raised exception. (bigchaindb_ws - pid: 86105)
[2018-07-25 11:54:06] [WARNING] (asyncio) socket.send() raised exception. (bigchaindb_ws - pid: 86105)
[2018-07-25 11:54:06] [WARNING] (asyncio) socket.send() raised exception. (bigchaindb_ws - pid: 86105)
```

Note for myself: asyncio and exceptions goes well like :cat2: and :dog2: 