### PR TITLE
Problem: validation runs redundant queries

### DIFF
--- a/bigchaindb/tendermint/lib.py
+++ b/bigchaindb/tendermint/lib.py
@@ -254,10 +254,10 @@ class BigchainDB(object):
 
     def get_transaction(self, transaction_id, include_status=False):
         transaction = backend.query.get_transaction(self.connection, transaction_id)
-        asset = backend.query.get_asset(self.connection, transaction_id)
-        metadata = backend.query.get_metadata(self.connection, [transaction_id])
 
         if transaction:
+            asset = backend.query.get_asset(self.connection, transaction_id)
+            metadata = backend.query.get_metadata(self.connection, [transaction_id])
             if asset:
                 transaction['asset'] = asset
 


### PR DESCRIPTION
Solution: when a transaction is stored, the system splits it in three
components, data, metadata, and the other fields of the transaction.
When the system retrieves a transaction, it needs to make three
different queries to reconstruct the original transaction. If a
transaction does not exist, the system does three queries anyway, even
if just one query is enough. This patch fixes this by doing the
additional queries if and only if the transaction exists.