### PR TITLE
Problem: BigchainDB and Tendermint tightly coupled and need some supervision

### DIFF
--- a/bigchaindb/config_utils.py
+++ b/bigchaindb/config_utils.py
@@ -99,6 +99,7 @@ def file_config(filename=None):
     if filename is None:
         filename = CONFIG_DEFAULT_PATH
 
+    logger.error(filename)
     logger.debug('file_config() will try to open `{}`'.format(filename))
     with open(filename) as f:
         try:
@@ -108,7 +109,7 @@ def file_config(filename=None):
                 'Failed to parse the JSON configuration from `{}`, {}'.format(filename, err)
             )
 
-    logger.info('Configuration loaded from `{}`'.format(filename))
+        logger.info('Configuration loaded from `{}`'.format(filename))
 
     return config
 

--- a/bigchaindb/config_utils.py
+++ b/bigchaindb/config_utils.py
@@ -99,7 +99,6 @@ def file_config(filename=None):
     if filename is None:
         filename = CONFIG_DEFAULT_PATH
 
-    logger.error(filename)
     logger.debug('file_config() will try to open `{}`'.format(filename))
     with open(filename) as f:
         try:

--- a/bigchaindb/log.py
+++ b/bigchaindb/log.py
@@ -3,10 +3,10 @@ import logging
 
 from bigchaindb.common.exceptions import ConfigurationError
 from logging.config import dictConfig as set_logging_config
-from os.path import expanduser, join
+import os
 
 
-DEFAULT_LOG_DIR = expanduser('~')
+DEFAULT_LOG_DIR = os.getcwd()
 BENCHMARK_LOG_LEVEL = 15
 
 
@@ -40,7 +40,7 @@ DEFAULT_LOGGING_CONFIG = {
         },
         'file': {
             'class': 'logging.handlers.RotatingFileHandler',
-            'filename': join(DEFAULT_LOG_DIR, 'bigchaindb.log'),
+            'filename': os.path.join(DEFAULT_LOG_DIR, 'bigchaindb.log'),
             'mode': 'w',
             'maxBytes':  209715200,
             'backupCount': 5,
@@ -49,7 +49,7 @@ DEFAULT_LOGGING_CONFIG = {
         },
         'errors': {
             'class': 'logging.handlers.RotatingFileHandler',
-            'filename': join(DEFAULT_LOG_DIR, 'bigchaindb-errors.log'),
+            'filename': os.path.join(DEFAULT_LOG_DIR, 'bigchaindb-errors.log'),
             'mode': 'w',
             'maxBytes':  209715200,
             'backupCount': 5,
@@ -58,7 +58,7 @@ DEFAULT_LOGGING_CONFIG = {
         },
         'benchmark': {
             'class': 'logging.handlers.RotatingFileHandler',
-            'filename': 'bigchaindb-benchmark.log',
+            'filename': os.path.join(DEFAULT_LOG_DIR, 'bigchaindb-benchmark.log'),
             'mode': 'w',
             'maxBytes':  209715200,
             'backupCount': 5,

--- a/docs/server/source/simple-network-setup.md
+++ b/docs/server/source/simple-network-setup.md
@@ -54,8 +54,8 @@ sudo apt install -y python3-pip libssl-dev
 
 Now install the latest version of BigchainDB. You can find the latest version by going to the [BigchainDB project release history page on PyPI][bdb:pypi]. For example, to install version 2.0.0b3, you would do:
 
-# Change 2.0.0b3 to the latest version as explained above:
 ```
+# Change 2.0.0b3 to the latest version as explained above:
 sudo pip3 install bigchaindb==2.0.0b3
 ```
 
@@ -249,7 +249,7 @@ If you followed the recommended approach and created startup scripts for Bigchai
 
 This section describes how to manage the BigchainDB and Tendermint processes using [Monit][monit] - a small open-source utility for managing and monitoring Unix processes.
 
-This section assumes that you followed the guide down to the [start MongoDB section](member-start-mongodb) inclusive.
+This section assumes that you followed the guide down to the [start MongoDB section](#member-start-mongodb) inclusive.
 
 Install Monit:
 

--- a/docs/server/source/simple-network-setup.md
+++ b/docs/server/source/simple-network-setup.md
@@ -54,8 +54,8 @@ sudo apt install -y python3-pip libssl-dev
 
 Now install the latest version of BigchainDB. You can find the latest version by going to the [BigchainDB project release history page on PyPI][bdb:pypi]. For example, to install version 2.0.0b3, you would do:
 
-```
 # Change 2.0.0b3 to the latest version as explained above:
+```
 sudo pip3 install bigchaindb==2.0.0b3
 ```
 
@@ -220,13 +220,17 @@ persistent_peers = "<Member 1 node id>@<Member 1 hostname>:26656,\
 <Member N node id>@<Member N hostname>:26656,"
 ```
 
-## Member: Start MongoDB, BigchainDB and Tendermint
+## Member: Start MongoDB
 
 If you installed MongoDB using `sudo apt install mongodb`, then MongoDB should already be running in the background. You can check using `systemctl status mongodb`.
 
 If MongoDB isn't running, then you can start it using the command `mongod`, but that will run it in the foreground. If you want to run it in the background (so it will continue running after you logout), you can use `mongod --fork --logpath /var/log/mongodb.log`. (You might have to create the `/var/log` directory if it doesn't already exist.)
 
 If you installed MongoDB using `sudo apt install mongodb`, then a MongoDB startup script should already be installed (so MongoDB will start automatically when the machine is restarted). Otherwise, you should install a startup script for MongoDB.
+
+## Member: Start BigchainDB and Tendermint
+
+If you want to use a process manager, jump to the [next section](member-start-bigchaindb-and-tendermint-using-monit).
 
 To start BigchainDB, one uses the command `bigchaindb start` but that will run it in the foreground. If you want to run it in the background (so it will continue running after you logout), you can use `nohup`, `tmux`, or `screen`. For example, `nohup bigchaindb start 2>&1 > bigchaindb.log &`
 
@@ -239,6 +243,45 @@ The _recommended_ approach is to create a startup script for Tendermint, so it w
 Note: We'll share some example startup scripts in the future. This document is a work in progress.
 
 If you followed the recommended approach and created startup scripts for BigchainDB and Tendermint, then you can reboot the machine now. MongoDB, BigchainDB and Tendermint should all start.
+
+
+### Member: Start BigchainDB and Tendermint using Monit
+
+This section describes how to manage the BigchainDB and Tendermint processes using [Monit][monit] - a small open-source utility for managing and monitoring Unix processes.
+
+This section assumes that you followed the guide down to the [start MongoDB section](member-start-mongodb) inclusive.
+
+Install Monit:
+
+```
+sudo apt install monit
+```
+
+If you installed the `bigchaindb` Python package, you should have the `bigchaindb-monit-config` script in your `PATH` now.
+
+Run the script:
+
+```
+bigchaindb-monit-config
+```
+
+The script builds a configuration file for Monit.
+
+Run Monit as a daemon, instructing it to wake up every second to check on processes:
+
+```
+monit -d 1
+```
+
+It will run the processes and restart them when they crash. If the root `bigchaindb_` process crashes, Monit will also restart the Tendermint process.
+
+Check the status by running `monit status` or `monit summary`.
+
+By default, it will collect program logs into the `~/.bigchaindb-monit/logs` folder.
+
+Consult `monit -h` or [the Monit documentation][monit-manual] to know more about the operational power you've just got the taste of.
+
+Check `bigchaindb-monit-config -h` if you want to arrange a different folder for logs or some of the Monit internal artifacts.
 
 ## How Others Can Access Your Node
 
@@ -273,3 +316,5 @@ TBD.
 [bdb:software]: https://github.com/bigchaindb/bigchaindb/
 [bdb:pypi]: https://pypi.org/project/BigchainDB/#history
 [tendermint:releases]: https://github.com/tendermint/tendermint/releases
+[monit]: https://www.mmonit.com/monit
+[monit-manual]: https://mmonit.com/monit/documentation/monit.html

--- a/pkg/scripts/bigchaindb-monit-config
+++ b/pkg/scripts/bigchaindb-monit-config
@@ -11,12 +11,6 @@ if [[ -n "$NOUNSET" ]]; then
         set -o nounset
 fi
 
-# TBD: Defaults to $HOME, otherwise if we want to address:
-# pid path could be /etc/pid_path
-# monit_script could be 
-# log_path /var/log/monit/
-# exec path(for monitrc) could be /etc/monitrc, /usr/local/etc/monitrc
-
 # Check if directory for monit logs exists
 if [ ! -d "$HOME/.bigchaindb-monit" ]; then
   mkdir -p "$HOME/.bigchaindb-monit"
@@ -25,7 +19,7 @@ fi
 monit_pid_path=${MONIT_PID_PATH:=$HOME/.bigchaindb-monit/monit_processes}
 monit_script_path=${MONIT_SCRIPT_PATH:=$HOME/.bigchaindb-monit/monit_script}
 monit_log_path=${MONIT_LOG_PATH:=$HOME/.bigchaindb-monit/logs}
-monit_exec_path=${MONIT_EXEC_PATH:=$HOME}
+monit_exec_path=${MONIT_EXEC_PATH:=$HOME/.monitrc}
 
 function usage() {
         cat <<EOM
@@ -37,21 +31,21 @@ function usage() {
     ENV[MONIT_PID_PATH] || --monit-pid-path PATH
 
     Absolute path to directory where the the program's pid-file will reside. 
-    The pid-file contains the ID(s) of the process(es).
+    The pid-file contains the ID(s) of the process(es). (default: ${monit_pid_path})
 
     ENV[MONIT_SCRIPT_PATH] || --monit-script-path PATH
 
     Absolute path to the directory where the executable program or
-    script is present.
+    script is present. (default: ${monit_script_path})
 
     ENV[MONIT_LOG_PATH] || --monit-log-path PATH
 
     Absolute path to the directory where all the logs for processes
-    monitored by Monit are stored.
+    monitored by Monit are stored. (default: ${monit_log_path})
 
     ENV[MONIT_EXEC_PATH] || --monit-exec-path PATH
 
-    Absolute path to the directory to run the script form.
+    Absolute path to the directory to run the script form. (default: ${monit_exec_path})
 
     -h|--help
         Show this help and exit.
@@ -144,28 +138,45 @@ exit 0
 EOF
 chmod +x ${monit_script_path}
 
+# Handling overwriting of control file interactively
+if [ -f "$monit_exec_path" ]; then
+    echo "$monit_exec_path already exists."
+    read -p "Overwrite[Y]? " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        echo "Overriding $monit_exec_path/.monitrc"
+    else
+        read -p "Enter absolute path to store Monit control file: " monit_exec_path
+        eval monit_exec_path="$monit_exec_path"
+        if [ ! -d "$(dirname $monit_exec_path)" ]; then
+            echo "Failed to save monit control file '$monit_exec_path': No such file or directory."
+            exit 1
+        fi
+    fi
+fi
+
 # configure monitrc
-cat >${monit_exec_path}/.monitrc <<EOF
+cat >${monit_exec_path} <<EOF
 set httpd
   port 2812
   allow localhost
 
 check process bigchaindb
     with pidfile ${monit_pid_path}/bigchaindb.pid
-    start program "${monit_script_path} start_bigchaindb $monit_pid_path/bigchaindb.pid ${monit_log_path} ${monit_exec_path}"
-    restart program "${monit_script_path} start_bigchaindb $monit_pid_path/bigchaindb.pid ${monit_log_path} ${monit_exec_path}"
-    stop program "${monit_script_path} stop_bigchaindb $monit_pid_path/bigchaindb.pid ${monit_log_path} ${monit_exec_path}"
+    start program "${monit_script_path} start_bigchaindb $monit_pid_path/bigchaindb.pid ${monit_log_path} ${monit_log_path}"
+    restart program "${monit_script_path} start_bigchaindb $monit_pid_path/bigchaindb.pid ${monit_log_path} ${monit_log_path}"
+    stop program "${monit_script_path} stop_bigchaindb $monit_pid_path/bigchaindb.pid ${monit_log_path} ${monit_log_path}"
 
 check process tendermint
     with pidfile ${monit_pid_path}/tendermint.pid
-    start program "${monit_script_path} start_tendermint ${monit_pid_path}/tendermint.pid ${monit_log_path} ${monit_exec_path}"
-    restart program "${monit_script_path} start_bigchaindb ${monit_pid_path}/bigchaindb.pid ${monit_log_path} ${monit_exec_path}"
-    stop program "${monit_script_path} stop_tendermint ${monit_pid_path}/tendermint.pid ${monit_log_path} ${monit_exec_path}"
+    start program "${monit_script_path} start_tendermint ${monit_pid_path}/tendermint.pid ${monit_log_path} ${monit_log_path}"
+    restart program "${monit_script_path} start_bigchaindb ${monit_pid_path}/bigchaindb.pid ${monit_log_path} ${monit_log_path}"
+    stop program "${monit_script_path} stop_tendermint ${monit_pid_path}/tendermint.pid ${monit_log_path} ${monit_log_path}"
     depends on bigchaindb
 EOF
 
 # Setting permissions for control file
-chmod 0700 ${monit_exec_path}/.monitrc
+chmod 0700 ${monit_exec_path}
 
 # Kill background processes on exit
 trap exit_trap EXIT

--- a/pkg/scripts/bigchaindb-monit-config
+++ b/pkg/scripts/bigchaindb-monit-config
@@ -10,7 +10,7 @@ fi
 monit_pid_path=${MONIT_PID_PATH:=$HOME/.bigchaindb-monit/monit_processes}
 monit_script_path=${MONIT_SCRIPT_PATH:=$HOME/.bigchaindb-monit/monit_script}
 monit_log_path=${MONIT_LOG_PATH:=$HOME/.bigchaindb-monit/logs}
-monit_exec_path=${MONIT_EXEC_PATH:=$HOME/.monitrc}
+monitrc_path=${MONITRC_PATH:=$HOME/.monitrc}
 
 function usage() {
         cat <<EOM
@@ -36,7 +36,7 @@ function usage() {
 
     ENV[MONIT_EXEC_PATH] || --monit-exec-path PATH
 
-    Absolute path to the directory to run the script form. (default: ${monit_exec_path})
+    Absolute path to the monit control file(monitrc). (default: ${monitrc_path})
 
     -h|--help
         Show this help and exit.
@@ -60,7 +60,7 @@ while [[ $# -gt 0 ]]; do
             shift
         ;;
         --monit-exec-path)
-            monit_exec_path="$2"
+            monitrc_path="$2"
             shift
         ;;
         -h|--help)
@@ -130,24 +130,24 @@ EOF
 chmod +x ${monit_script_path}
 
 # Handling overwriting of control file interactively
-if [ -f "$monit_exec_path" ]; then
-    echo "$monit_exec_path already exists."
+if [ -f "$monitrc_path" ]; then
+    echo "$monitrc_path already exists."
     read -p "Overwrite[Y]? " -n 1 -r
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]; then
-        echo "Overriding $monit_exec_path/.monitrc"
+        echo "Overriding $monitrc_path/.monitrc"
     else
-        read -p "Enter absolute path to store Monit control file: " monit_exec_path
-        eval monit_exec_path="$monit_exec_path"
-        if [ ! -d "$(dirname $monit_exec_path)" ]; then
-            echo "Failed to save monit control file '$monit_exec_path': No such file or directory."
+        read -p "Enter absolute path to store Monit control file: " monitrc_path
+        eval monitrc_path="$monitrc_path"
+        if [ ! -d "$(dirname $monitrc_path)" ]; then
+            echo "Failed to save monit control file '$monitrc_path': No such file or directory."
             exit 1
         fi
     fi
 fi
 
 # configure monitrc
-cat >${monit_exec_path} <<EOF
+cat >${monitrc_path} <<EOF
 set httpd
   port 2812
   allow localhost
@@ -167,7 +167,7 @@ check process tendermint
 EOF
 
 # Setting permissions for control file
-chmod 0700 ${monit_exec_path}
+chmod 0700 ${monitrc_path}
 
 echo -e "BigchainDB process manager configured!"
 set -o errexit

--- a/pkg/scripts/bigchaindb-monit-config
+++ b/pkg/scripts/bigchaindb-monit-config
@@ -17,9 +17,14 @@ fi
 # log_path /var/log/monit/
 # exec path(for monitrc) could be /etc/monitrc, /usr/local/etc/monitrc
 
-monit_pid_path=${MONIT_PID_PATH:=$HOME/monit_processes}
-monit_script_path=${MONIT_SCRIPT_PATH:=$HOME/monit_script}
-monit_log_path=${MONIT_LOG_PATH:=$HOME/logs}
+# Check if directory for monit logs exists
+if [ ! -d "$HOME/.bigchaindb-monit" ]; then
+  mkdir -p "$HOME/.bigchaindb-monit"
+fi
+
+monit_pid_path=${MONIT_PID_PATH:=$HOME/.bigchaindb-monit/monit_processes}
+monit_script_path=${MONIT_SCRIPT_PATH:=$HOME/.bigchaindb-monit/monit_script}
+monit_log_path=${MONIT_LOG_PATH:=$HOME/.bigchaindb-monit/logs}
 monit_exec_path=${MONIT_EXEC_PATH:=$HOME}
 
 function usage() {
@@ -46,7 +51,7 @@ function usage() {
 
     ENV[MONIT_EXEC_PATH] || --monit-exec-path PATH
 
-    Absolute path to the directory with monit control file.
+    Absolute path to the directory to run the script form.
 
     -h|--help
         Show this help and exit.
@@ -97,6 +102,7 @@ if [ ! -d "$monit_pid_path" ]; then
 fi
 
 cat >${monit_script_path} <<EOF
+#!/bin/bash
 case \$1 in
 
   start_bigchaindb)
@@ -160,3 +166,13 @@ EOF
 
 # Setting permissions for control file
 chmod 0700 ${monit_exec_path}/.monitrc
+
+# Kill background processes on exit
+trap exit_trap EXIT
+function exit_trap {
+    exit $?
+}
+# Exit on any errors so that errors don't compound and kill if any services already started
+
+echo -e "BigchainDB process manager configured!"
+set -o errexit

--- a/pkg/scripts/bigchaindb-monit-config
+++ b/pkg/scripts/bigchaindb-monit-config
@@ -2,9 +2,6 @@
 
 set -o nounset
 
-# Make sure umask is sane
-umask 022
-
 # Check for uninitialized variables
 NOUNSET=${NOUNSET:-}
 if [[ -n "$NOUNSET" ]]; then
@@ -179,11 +176,10 @@ EOF
 chmod 0700 ${monit_exec_path}
 
 # Kill background processes on exit
-trap exit_trap EXIT
 function exit_trap {
     exit $?
 }
-# Exit on any errors so that errors don't compound and kill if any services already started
+trap exit_trap EXIT
 
 echo -e "BigchainDB process manager configured!"
 set -o errexit

--- a/pkg/scripts/bigchaindb-monit-config
+++ b/pkg/scripts/bigchaindb-monit-config
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+set -o nounset
+
+# Make sure umask is sane
+umask 022
+
+# Check for uninitialized variables
+NOUNSET=${NOUNSET:-}
+if [[ -n "$NOUNSET" ]]; then
+        set -o nounset
+fi
+
+# TBD: Defaults to $HOME, otherwise if we want to address:
+# pid path could be /etc/pid_path
+# monit_script could be 
+# log_path /var/log/monit/
+# exec path(for monitrc) could be /etc/monitrc, /usr/local/etc/monitrc
+
+monit_pid_path=${MONIT_PID_PATH:=$HOME/monit_processes}
+monit_script_path=${MONIT_SCRIPT_PATH:=$HOME/monit_script}
+monit_log_path=${MONIT_LOG_PATH:=$HOME/logs}
+monit_exec_path=${MONIT_EXEC_PATH:=$HOME}
+
+function usage() {
+        cat <<EOM
+
+    Usage: ${0##*/} [-h]
+
+    Configure Monit for BigchainDB and Tendermint process management.
+
+    ENV[MONIT_PID_PATH] || --monit-pid-path PATH
+
+    Absolute path to directory where the the program's pid-file will reside. 
+    The pid-file contains the ID(s) of the process(es).
+
+    ENV[MONIT_SCRIPT_PATH] || --monit-script-path PATH
+
+    Absolute path to the directory where the executable program or
+    script is present.
+
+    ENV[MONIT_LOG_PATH] || --monit-log-path PATH
+
+    Absolute path to the directory where all the logs for processes
+    monitored by Monit are stored.
+
+    ENV[MONIT_EXEC_PATH] || --monit-exec-path PATH
+
+    Absolute path to the directory with monit control file.
+
+    -h|--help
+        Show this help and exit.
+
+EOM
+}
+
+while [[ $# -gt 0 ]]; do
+    arg="$1"
+    case $arg in
+        --monit-pid-path)
+            monit_pid_path="$2"
+            shift
+        ;;
+        --monit-script-path)
+            monit_script_path="$2"
+            shift
+        ;;
+        --monit-log-path)
+            monit_log_path="$2"
+            shift
+        ;;
+        --monit-exec-path)
+            monit_exec_path="$2"
+            shift
+        ;;
+        -h|--help)
+            usage
+            exit
+        ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            exit 1
+        ;;
+    esac
+    shift
+done
+
+# Check if directory for monit logs exists
+if [ ! -d "$monit_log_path" ]; then
+  mkdir -p "$monit_log_path"
+fi
+
+# Check if directory for monit pid files exists
+if [ ! -d "$monit_pid_path" ]; then
+  mkdir -p "$monit_pid_path"
+fi
+
+cat >${monit_script_path} <<EOF
+case \$1 in
+
+  start_bigchaindb)
+
+    pushd \$4
+      nohup bigchaindb start >> \$3/bigchaindb.out.log 2>> \$3/bigchaindb.err.log &
+
+      echo \$! > \$2
+    popd
+
+    ;;
+
+  stop_bigchaindb)
+
+    kill -2 \`cat \$2\`
+    rm -f \$2
+
+    ;;
+
+  start_tendermint)
+
+    pushd \$4
+      nohup tendermint node --consensus.create_empty_blocks=false >> \$3/tendermint.out.log 2>> \$3/tendermint.err.log &
+
+      echo \$! > \$2
+    popd
+
+    ;;
+
+  stop_tendermint)
+
+    kill -2 \`cat \$2\`
+    rm -f \$2
+
+    ;;
+
+esac
+exit 0
+EOF
+chmod +x ${monit_script_path}
+
+# configure monitrc
+cat >${monit_exec_path}/.monitrc <<EOF
+set httpd
+  port 2812
+  allow localhost
+
+check process bigchaindb
+    with pidfile ${monit_pid_path}/bigchaindb.pid
+    start program "${monit_script_path} start_bigchaindb $monit_pid_path/bigchaindb.pid ${monit_log_path} ${monit_exec_path}"
+    restart program "${monit_script_path} start_bigchaindb $monit_pid_path/bigchaindb.pid ${monit_log_path} ${monit_exec_path}"
+    stop program "${monit_script_path} stop_bigchaindb $monit_pid_path/bigchaindb.pid ${monit_log_path} ${monit_exec_path}"
+
+check process tendermint
+    with pidfile ${monit_pid_path}/tendermint.pid
+    start program "${monit_script_path} start_tendermint ${monit_pid_path}/tendermint.pid ${monit_log_path} ${monit_exec_path}"
+    restart program "${monit_script_path} start_bigchaindb ${monit_pid_path}/bigchaindb.pid ${monit_log_path} ${monit_exec_path}"
+    stop program "${monit_script_path} stop_tendermint ${monit_pid_path}/tendermint.pid ${monit_log_path} ${monit_exec_path}"
+    depends on bigchaindb
+EOF
+
+# Setting permissions for control file
+chmod 0700 ${monit_exec_path}/.monitrc

--- a/pkg/scripts/bigchaindb-monit-config
+++ b/pkg/scripts/bigchaindb-monit-config
@@ -2,12 +2,6 @@
 
 set -o nounset
 
-# Check for uninitialized variables
-NOUNSET=${NOUNSET:-}
-if [[ -n "$NOUNSET" ]]; then
-        set -o nounset
-fi
-
 # Check if directory for monit logs exists
 if [ ! -d "$HOME/.bigchaindb-monit" ]; then
   mkdir -p "$HOME/.bigchaindb-monit"
@@ -174,12 +168,6 @@ EOF
 
 # Setting permissions for control file
 chmod 0700 ${monit_exec_path}
-
-# Kill background processes on exit
-function exit_trap {
-    exit $?
-}
-trap exit_trap EXIT
 
 echo -e "BigchainDB process manager configured!"
 set -o errexit

--- a/pkg/scripts/bigchaindb-monit-config
+++ b/pkg/scripts/bigchaindb-monit-config
@@ -34,7 +34,7 @@ function usage() {
     Absolute path to the directory where all the logs for processes
     monitored by Monit are stored. (default: ${monit_log_path})
 
-    ENV[MONIT_EXEC_PATH] || --monit-exec-path PATH
+    ENV[MONITRC_PATH] || --monitrc-path PATH
 
     Absolute path to the monit control file(monitrc). (default: ${monitrc_path})
 
@@ -59,7 +59,7 @@ while [[ $# -gt 0 ]]; do
             monit_log_path="$2"
             shift
         ;;
-        --monit-exec-path)
+        --monitrc-path)
             monitrc_path="$2"
             shift
         ;;

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,8 @@ setup(
 
     packages=find_packages(exclude=['tests*']),
 
+    scripts = ['pkg/scripts/bigchaindb-monit-config'],
+
     entry_points={
         'console_scripts': [
             'bigchaindb=bigchaindb.commands.bigchaindb:main'


### PR DESCRIPTION
## Problem

BigchainDB and Tendermint are very tightly coupled which implies that if the connection(ABCI) between BigchainDB and Tendermint breaks, the system halts i.e. Tendermint does not re-iniate the connection and both processes keep running without being productive.

## Solution

Supervise both the services/processes with a process manager. For now using [Monit](https://mmonit.com/monit/). Monit will launch both BigchainDB and Tendermint and will monitor the lifecycle of both services.

### Workflow

When BigchainDB is installed e.g.:
```
$ git clone https://github.com/bigchaindb/bigchaindb.git
$ cd bigchaindb/
# might need sudo or python3, details not important here
$ python setup.py install

OR
$ pip install bigchaindb
```
It will install a script `bigchaindb-monit-config`, which is placed under `/usr/local/bin` and can be intiated using:
```
$ bigchaindb-monit-config

For more options:

$ bigchaindb-monit-config -h

    Usage: bigchaindb-monit-config [-h]

    Configure Monit for BigchainDB and Tendermint process management.

    ENV[MONIT_PID_PATH] || --monit-pid-path PATH

    Absolute path to directory where the the program's pid-file will reside.
    The pid-file contains the ID(s) of the process(es).

    ENV[MONIT_SCRIPT_PATH] || --monit-script-path PATH

    Absolute path to the directory where the executable program or
    script is present.

    ENV[MONIT_LOG_PATH] || --monit-log-path PATH

    Absolute path to the directory where all the logs for processes
    monitored by Monit are stored.

    ENV[MONIT_EXEC_PATH] || --monit-exec-path PATH

    Absolute path to the directory to run the script form.

    -h|--help
        Show this help and exit.
```

Once the above script is executed successfully with the message `BigchainDB process manager configured!`. User can use monit to monitor both processes at the same time i.e. if one of them crashes or the connection breaks, monit will restart them.

```
$ monit -d 1

# For more detailed info about monit

$ monit --help
```

## Issues Resolved

Resolves #2238 

## Dependencies
[Monit](https://mmonit.com/monit/)

## Remaining TODOs

- [x] The default path for `.monitrc` Monit control file is `$HOME/.monitrc`, we don't want to override it if someone is already using it with monit. So change the current script to become more interactive about `.monitrc` file. Something similar to `ssh-keygen`
- [x] We send monit logs to `$HOME/.bigchaindb-monit/logs/<bigchaindb-logs>` but at the same time the BigchainDB process, generates log files at `$HOME/<bigchaindb-logs>`(default path). There should only be one location for this.
- [x] In help, print the default values
- [x] Cleanup some TBD items in the script.
