### PR TITLE
Problem: setup.py only requires cryptoconditons 0.6.x but 0.7.0 exists

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ install_requires = [
     # TODO Consider not installing the db drivers, or putting them in extras.
     'pymongo~=3.6',
     'pysha3~=1.0.2',
-    'cryptoconditions~=0.6.0.dev',
+    'cryptoconditions~=0.7.0',
     'python-rapidjson==0.0.11',
     'logstats~=0.2.1',
     'flask>=0.10.1',


### PR DESCRIPTION
Solution: Change setup.py to require cryptoconditions~=0.7.0 (i.e. the maximum 0.7.x)

I'm not sure why cryptoconditions~=0.6.0.dev is okay, because 0.7.0 exists and there were changes/commits between the release of 0.6.0.dev1 and 0.7.0, see:

https://github.com/bigchaindb/cryptoconditions/commits/master

@sbellem If you see this and have time, can you comment why we are using cryptoconditions 0.6.x rather than 0.7.x?

I changed setup.py to require 0.7.0 then ran all the unit and acceptance tests locally, and they all passed.

I found that `pip install --upgrade -e .[dev]` failed (with errors), but if I did `pip uninstall cryptoconditions` first, then it worked fine.
