### PR TITLE
Problem: JSON schema allows output amount "0"

### DIFF
--- a/bigchaindb/common/schema/transaction_v2.0.yaml
+++ b/bigchaindb/common/schema/transaction_v2.0.yaml
@@ -79,7 +79,7 @@ definitions:
     properties:
       amount:
         type: string
-        pattern: "^[0-9]{1,20}$"
+        pattern: "^[1-9][0-9]{0,19}$"
       condition:
         type: object
         additionalProperties: false


### PR DESCRIPTION
Solution: Change the regex to allow "1" to "9"x20 but not "0"

TODO:

- [ ] Write a unit test for the "0" case, i.e. make sure a transaction containing an output amount "0" is not considered valid. @z-bowen could you do that? It could be added as another commit to this pull request.