### PR TITLE
Problem: websocket might be unresponsive

### DIFF
--- a/bigchaindb/web/websocket_server.py
+++ b/bigchaindb/web/websocket_server.py
@@ -105,7 +105,7 @@ class Dispatcher:
 
             for _, websocket in self.subscribers.items():
                 for str_item in str_buffer:
-                    websocket.send_str(str_item)
+                    yield from websocket.send_str(str_item)
 
 
 @asyncio.coroutine

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ install_requires = [
     'gunicorn~=19.0',
     'jsonschema~=2.5.1',
     'pyyaml~=3.12',
-    'aiohttp~=2.3',
+    'aiohttp~=3.0',
     'python-rapidjson-schema==0.1.1',
     'bigchaindb-abci==0.5.1',
     'setproctitle~=1.1.0',


### PR DESCRIPTION
Solution: It might be related on how aiohttp 2.x handles `send_str`.
AFAIK the call `send_str` was not "fully async". In aiohttp 3.x they
[changed it][1]:

> send_str(), send_bytes(), send_json(), ping() and pong() are genuine
async functions now. (#2475)

So this patch adds support for aiohttp 3.x, and uses the `send_str`
coroutine.

[1]: https://github.com/aio-libs/aiohttp/blob/master/HISTORY.rst#deprecations-and-removals-1