### PR TITLE
Problem: No wait when getting value from queue

### DIFF
--- a/bigchaindb/events.py
+++ b/bigchaindb/events.py
@@ -67,7 +67,7 @@ class Exchange:
         """
 
         try:
-            self.started_queue.get_nowait()
+            self.started_queue.get(timeout=0.01)
             raise RuntimeError('Cannot create a new subscriber queue while Exchange is running.')
         except Empty:
             pass


### PR DESCRIPTION
Solution: Random failure of test `tests/test_events.py::test_event_handler_raises_when_called_after_start` seem to be because of `get_nowait` which returns way to quickly even when the queue
has data.