### PR TITLE
Stand-alone container for a BigchainDB node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get -qq update \
     && apt-get -y upgrade \
     && apt-get install -y jq \
     && pip install --no-cache-dir --process-dependency-links . \
-    && pip install --no-cache-dir . \
     && apt-get autoremove \
     && apt-get clean
 

--- a/Dockerfile-all-in-one
+++ b/Dockerfile-all-in-one
@@ -1,4 +1,4 @@
-FROM alpine:latest
+ FROM alpine:latest
 LABEL maintainer "dev@bigchaindb.com"
 
 ARG TM_VERSION=0.22.8
@@ -54,6 +54,5 @@ VOLUME /data/db /data/configdb /tendermint
 
 EXPOSE 27017 28017 9984 9985 26656 26657 26658
 
-COPY pkg/scripts/all-in-one.bash /usr/src/app/
 WORKDIR $HOME
-ENTRYPOINT ["/usr/src/app/all-in-one.bash"]
+ENTRYPOINT ["/usr/src/app/pkg/scripts/all-in-one.bash"]

--- a/Dockerfile-all-in-one
+++ b/Dockerfile-all-in-one
@@ -1,4 +1,4 @@
- FROM alpine:latest
+FROM alpine:latest
 LABEL maintainer "dev@bigchaindb.com"
 
 ARG TM_VERSION=0.22.8
@@ -13,7 +13,7 @@ RUN apk --update add sudo bash \
         libffi-dev openssl-dev build-base jq \
     && apk add --no-cache libstdc++ dpkg gnupg \
     && pip3 install --upgrade pip cffi \
-    && pip install --no-cache-dir --process-dependency-links -e .[dev] \
+    && pip install --no-cache-dir --process-dependency-links . \
     && apk del build-dependencies \
     && rm -f /var/cache/apk/*
 
@@ -34,10 +34,6 @@ RUN addgroup tmuser \
 # Set permissions required for mongodb
 RUN mkdir -p /data/db /data/configdb \
         && chown -R mongodb:mongodb /data/db /data/configdb
-
-# When developing with Python in a docker container, we are using PYTHONBUFFERED
-# to force stdin, stdout and stderr to be totally unbuffered and to capture logs/outputs
-ENV PYTHONUNBUFFERED 0
 
 # BigchainDB enviroment variables
 ENV BIGCHAINDB_DATABASE_PORT 27017

--- a/Dockerfile-all-in-one
+++ b/Dockerfile-all-in-one
@@ -13,7 +13,7 @@ RUN apk --update add sudo bash \
         libffi-dev openssl-dev build-base jq \
     && apk add --no-cache libstdc++ dpkg gnupg \
     && pip3 install --upgrade pip cffi \
-    && pip install --no-cache-dir --process-dependency-links . \
+    && pip install --no-cache-dir --process-dependency-links -e . \
     && apk del build-dependencies \
     && rm -f /var/cache/apk/*
 
@@ -27,9 +27,6 @@ RUN wget https://github.com/tendermint/tendermint/releases/download/v${TM_VERSIO
     && rm tendermint_${TM_VERSION}_linux_amd64.zip
 
 ENV TMHOME=/tendermint
-
-RUN addgroup tmuser \
-    && adduser -S -G tmuser tmuser -h "$TMHOME"
 
 # Set permissions required for mongodb
 RUN mkdir -p /data/db /data/configdb \

--- a/Dockerfile-all-in-one
+++ b/Dockerfile-all-in-one
@@ -1,0 +1,59 @@
+FROM alpine:latest
+LABEL maintainer "dev@bigchaindb.com"
+
+ARG TM_VERSION=0.22.8
+RUN mkdir -p /usr/src/app
+ENV HOME /root
+COPY . /usr/src/app/
+WORKDIR /usr/src/app
+
+RUN apk --update add sudo bash \
+    && apk --update add python3 openssl ca-certificates git \
+    && apk --update add --virtual build-dependencies python3-dev \
+        libffi-dev openssl-dev build-base jq \
+    && apk add --no-cache libstdc++ dpkg gnupg \
+    && pip3 install --upgrade pip cffi \
+    && pip install --no-cache-dir --process-dependency-links -e .[dev] \
+    && apk del build-dependencies \
+    && rm -f /var/cache/apk/*
+
+# Install mongodb and monit
+RUN apk --update add mongodb monit
+
+# Install Tendermint
+RUN wget https://github.com/tendermint/tendermint/releases/download/v${TM_VERSION}-autodraft/tendermint_${TM_VERSION}_linux_amd64.zip \
+    && unzip tendermint_${TM_VERSION}_linux_amd64.zip \
+    && mv tendermint /usr/local/bin/ \
+    && rm tendermint_${TM_VERSION}_linux_amd64.zip
+
+ENV TMHOME=/tendermint
+
+RUN addgroup tmuser \
+    && adduser -S -G tmuser tmuser -h "$TMHOME"
+
+# Set permissions required for mongodb
+RUN mkdir -p /data/db /data/configdb \
+        && chown -R mongodb:mongodb /data/db /data/configdb
+
+# When developing with Python in a docker container, we are using PYTHONBUFFERED
+# to force stdin, stdout and stderr to be totally unbuffered and to capture logs/outputs
+ENV PYTHONUNBUFFERED 0
+
+# BigchainDB enviroment variables
+ENV BIGCHAINDB_DATABASE_PORT 27017
+ENV BIGCHAINDB_DATABASE_BACKEND localmongodb
+ENV BIGCHAINDB_SERVER_BIND 0.0.0.0:9984
+ENV BIGCHAINDB_WSSERVER_HOST 0.0.0.0
+ENV BIGCHAINDB_WSSERVER_SCHEME ws
+
+ENV BIGCHAINDB_WSSERVER_ADVERTISED_HOST 0.0.0.0
+ENV BIGCHAINDB_WSSERVER_ADVERTISED_SCHEME ws
+ENV BIGCHAINDB_TENDERMINT_PORT 26657
+
+VOLUME /data/db /data/configdb /tendermint
+
+EXPOSE 27017 28017 9984 9985 26656 26657 26658
+
+COPY pkg/scripts/all-in-one.bash /usr/src/app/
+WORKDIR $HOME
+ENTRYPOINT ["/usr/src/app/all-in-one.bash"]

--- a/docs/server/source/appendices/all-in-one-bigchaindb.md
+++ b/docs/server/source/appendices/all-in-one-bigchaindb.md
@@ -13,8 +13,11 @@ This image contains all the services required for a BigchainDB node i.e.
 - MongoDB
 - Tendermint
 
-*We understand that it is an anti-pattern to run multiple services inside a docker.*
-*This image is to help quick deployment for early adopters*
+**Note:** *This image is to help quick deployment for early adopters, for a more standard*
+*approach please refer to one of our deployment guides:*
+
+- [BigchainDB developer setup guides](https://docs.bigchaindb.com/projects/contributing/en/latest/dev-setup-coding-and-contribution-process/index.html).
+- [BigchainDB with Kubernetes](http://docs.bigchaindb.com/projects/server/en/latest/production-deployment-template/index.html).
 
 ## Prerequisite(s)
 - [Docker](https://docs.docker.com/engine/installation/)

--- a/docs/server/source/appendices/all-in-one-bigchaindb.md
+++ b/docs/server/source/appendices/all-in-one-bigchaindb.md
@@ -1,0 +1,84 @@
+# Run BigchainDB with all-in-one Docker
+
+**NOT for Production Use**
+
+For those who like using Docker and wish to experiment with BigchainDB in
+non-production environments, we currently maintain a BigchainDB all-in-one 
+Docker image and a
+`Dockerfile-all-in-one` that can be used to build an image for `bigchaindb`.
+
+This image contains all the services required for a BigchainDB node i.e.
+
+- BigchainDB Server
+- MongoDB
+- Tendermint
+
+*We understand that it is an anti-pattern to run multiple services inside a docker.*
+*This image is to help quick deployment for early adopters*
+
+## Prerequisite(s)
+- [Docker](https://docs.docker.com/engine/installation/)
+
+## Pull and Run the Image from Docker Hub
+
+With Docker installed, you can proceed as follows.
+
+In a terminal shell, pull the latest version of the BigchainDB all-in-one Docker image using:
+```text
+$ docker pull bigchaindb/bigchaindb:all-in-one
+
+$ docker run \
+  --detach \
+  --name bigchaindb \
+  --publish 9984:9984 \
+  --publish 9985:9985 \
+  --publish 27017:27017 \
+  --publish 26657:26657 \
+  --volume $HOME/bigchaindb_docker/mongodb/data/db:/data/db \
+  --volume $HOME/bigchaindb_docker/mongodb/data/configdb:/data/configdb \
+  --volume $HOME/bigchaindb_docker/tendermint:/tendermint \
+  bigchaindb/bigchaindb:all-in-one
+```
+
+Let's analyze that command:
+
+* `docker run` tells Docker to run some image
+* `--detach` run the container in the background
+* `publish 9984:9984` map the host port `9984` to the container port `9984`
+ (the BigchainDB API server) 
+  * `9985` BigchainDB Websocket server
+  * `27017` Default port for MongoDB
+  * `26657` Tendermint RPC server
+* `--volume "$HOME/bigchaindb_docker/mongodb:/data"` map the host directory
+ `$HOME/bigchaindb_docker/mongodb` to the container directory `/data`;
+ this allows us to have the data persisted on the host machine,
+ you can read more in the [official Docker
+ documentation](https://docs.docker.com/engine/tutorials/dockervolumes)
+  * `$HOME/bigchaindb_docker/tendermint:/tendermint` to persist Tendermint data.
+* `bigchaindb/bigchaindb:all-in-one` the image to use. All the options after the container name are passed on to the entrypoint inside the container.
+
+## Verify
+
+```text
+$ docker ps | grep bigchaindb
+```
+
+Send your first transaction using [BigchainDB drivers](../drivers-clients/index.html).
+
+
+## Building Your Own Image
+
+Assuming you have Docker installed, you would proceed as follows.
+
+In a terminal shell:
+```text
+git clone git@github.com:bigchaindb/bigchaindb.git
+cd bigchaindb/
+```
+
+Build the Docker image:
+```text
+docker build --file Dockerfile-all-in-one --tag <tag/name:latest> .
+```
+
+Now you can use your own image to run BigchainDB all-in-one container.

--- a/docs/server/source/appendices/all-in-one-bigchaindb.md
+++ b/docs/server/source/appendices/all-in-one-bigchaindb.md
@@ -1,7 +1,5 @@
 # Run BigchainDB with all-in-one Docker
 
-**NOT for Production Use**
-
 For those who like using Docker and wish to experiment with BigchainDB in
 non-production environments, we currently maintain a BigchainDB all-in-one 
 Docker image and a
@@ -13,8 +11,8 @@ This image contains all the services required for a BigchainDB node i.e.
 - MongoDB
 - Tendermint
 
-**Note:** *This image is to help quick deployment for early adopters, for a more standard*
-*approach please refer to one of our deployment guides:*
+**Note:** **NOT for Production Use:** *This is an single node opinionated image not well suited for a network deployment.*
+*This image is to help quick deployment for early adopters, for a more standard approach please refer to one of our deployment guides:*
 
 - [BigchainDB developer setup guides](https://docs.bigchaindb.com/projects/contributing/en/latest/dev-setup-coding-and-contribution-process/index.html).
 - [BigchainDB with Kubernetes](http://docs.bigchaindb.com/projects/server/en/latest/production-deployment-template/index.html).

--- a/docs/server/source/appendices/index.rst
+++ b/docs/server/source/appendices/index.rst
@@ -15,3 +15,4 @@ Appendices
    firewall-notes
    ntp-notes
    licenses
+   all-in-one-bigchaindb

--- a/pkg/scripts/all-in-one.bash
+++ b/pkg/scripts/all-in-one.bash
@@ -2,11 +2,13 @@
 
 # MongoDB configuration
 [ "$(stat -c %U /data/db)" = mongodb ] || chown -R mongodb /data/db
-nohup mongod > /tmp/mongodb_log_$(date +%Y%m%d_%H%M%S) 2>&1 &
+
+# BigchainDB configuration
+bigchaindb-monit-config
+
+nohup mongod > "$HOME/.bigchaindb-monit/logs/mongodb_log_$(date +%Y%m%d_%H%M%S)" 2>&1 &
 
 # Tendermint configuration
 tendermint init
 
-# BigchainDB configuration
-bigchaindb-monit-config
 monit -d 5 -I -B

--- a/pkg/scripts/all-in-one.bash
+++ b/pkg/scripts/all-in-one.bash
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# MongoDB configuration
+[ "$(stat -c %U /data/db)" = mongodb ] || chown -R mongodb /data/db
+nohup mongod > /tmp/mongodb_log_$(date +%Y%m%d_%H%M%S) 2>&1 &
+
+# Tendermint configuration
+tendermint init
+
+# BigchainDB configuration
+bigchaindb-monit-config
+monit -d 5 -I -B

--- a/pkg/scripts/bigchaindb-monit-config
+++ b/pkg/scripts/bigchaindb-monit-config
@@ -93,7 +93,7 @@ case \$1 in
   start_bigchaindb)
 
     pushd \$4
-      nohup bigchaindb start >> \$3/bigchaindb.out.log 2>> \$3/bigchaindb.err.log &
+      nohup bigchaindb -l DEBUG start >> \$3/bigchaindb.out.log 2>> \$3/bigchaindb.err.log &
 
       echo \$! > \$2
     popd


### PR DESCRIPTION
## Background

- Some customers have asked for a single stand-alone BigchainDB image.
- Easier for early users of BigchainDB

## Solution

- Make BigchainDB, MongoDB and Tendermint be part of the same container, even though it is an anti-pattern but this has been requested at several instances by customers/partners.
- Easier for early adopters of BigchainDB i.e. 2 step approach:
  - docker pull
  - docker run

## TODOs

- [x] Add documentation of this workflow.
- [ ] Tag image once this PR is merged.

## Issues this Resolves

Resolves #2238 (or at least I think it does. -Troy)