### PR TITLE
Problem: No test to validate duplicate inputs

### DIFF
--- a/tests/tendermint/test_lib.py
+++ b/tests/tendermint/test_lib.py
@@ -382,7 +382,15 @@ def test_get_spent_transaction_critical_double_spend(b, alice, bob, carol):
                                         asset_id=tx.id)\
                               .sign([alice.private_key])
 
+    same_input_double_spend = Transaction.transfer(tx.to_inputs() + tx.to_inputs(),
+                                                   [([bob.public_key], 1)],
+                                                   asset_id=tx.id)\
+                                         .sign([alice.private_key])
+
     b.store_bulk_transactions([tx])
+
+    with pytest.raises(DoubleSpend):
+        same_input_double_spend.validate(b)
 
     assert b.get_spent(tx.id, tx_transfer.inputs[0].fulfills.output, [tx_transfer])
 


### PR DESCRIPTION
Solution: Update tests to include a case wherein the same an input has been used more than once in the same transaction