### PR TITLE
Problem: get_validator doesn't sepcify height which leads to ambiguity

### DIFF
--- a/bigchaindb/lib.py
+++ b/bigchaindb/lib.py
@@ -462,7 +462,10 @@ class BigchainDB(object):
 
     def get_validators(self):
         try:
-            resp = requests.get('{}validators'.format(self.endpoint))
+            block = self.get_latest_block()
+            query_args = ('?height=' + str(block['height'])) if block else ''
+
+            resp = requests.get('{}validators{}'.format(self.endpoint, query_args))
             validators = resp.json()['result']['validators']
             for v in validators:
                 v.pop('accum')


### PR DESCRIPTION
Solution: `get_validator` should specify the `height` of the latest block witnessed by BigchainDB so that in case tendermint is ahead of BigchainDB correct validator set can be fetched.