### PR TITLE
Problem: community drivers not working w/ latest BDB

### DIFF
--- a/docs/server/source/drivers-clients/index.rst
+++ b/docs/server/source/drivers-clients/index.rst
@@ -11,10 +11,11 @@ Libraries and Tools Maintained by the BigchainDB Team
 Community-Driven Libraries and Tools
 ------------------------------------
 
-.. note::
+.. warning::
 
    Some of these projects are a work in progress,
    but may still be useful.
+   Others might not work with the latest version of BigchainDB.
 
 * `Haskell transaction builder <https://github.com/bigchaindb/bigchaindb-hs>`_
 * `Go driver <https://github.com/zbo14/envoke/blob/master/bigchain/bigchain.go>`_


### PR DESCRIPTION
Solution: In the docs page listing the Community-Driven Libraries and Tools, make it clear that they might not work with the latest version of BigchainDB. Make it a warning rather than a note.