### PR TITLE
Problem: Source files contain no license info

### DIFF
--- a/.ci/entrypoint.sh
+++ b/.ci/entrypoint.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 set -e -x
 

--- a/.ci/travis-after-success.sh
+++ b/.ci/travis-after-success.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 set -e -x
 

--- a/.ci/travis-before-install.sh
+++ b/.ci/travis-before-install.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 if [[ -z ${TOXENV} ]]; then
   sudo apt-get update

--- a/.ci/travis-before-script.sh
+++ b/.ci/travis-before-script.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 set -e -x
 

--- a/.ci/travis-install.sh
+++ b/.ci/travis-install.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 set -e -x
 

--- a/.ci/travis_script.sh
+++ b/.ci/travis_script.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 set -e -x
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # How to Contribute to the BigchainDB Project
 
 There are many ways you can contribute to the BigchainDB project, some very easy and others more involved.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
     sha: v1.1.1

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 build:
     image: latest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 sudo: required
 
 dist: trusty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Change Log (Release Notes)
 
 All _notable_ changes to this project will be documented in this file (`CHANGELOG.md`).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Contributor Code of Conduct
 
 As contributors and maintainers of this project, and in the interest of

--- a/HOW_TO_HANDLE_PULL_REQUESTS.md
+++ b/HOW_TO_HANDLE_PULL_REQUESTS.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # How to Handle External Pull Requests
 
 See [BEP-16](https://github.com/bigchaindb/BEPs/tree/master/16).

--- a/PYTHON_STYLE_GUIDE.md
+++ b/PYTHON_STYLE_GUIDE.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Python Style Guide
 
 This guide starts out with our general Python coding style guidelines and ends with a section on how we write & run (Python) tests.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 <!--- There is no shield to get the latest version
 (including pre-release versions) from PyPI,
 so show the latest GitHub release instead.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Our Release Process
 
 ## Notes

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # BigchainDB Roadmap
 
 We moved the BigchainDB Roadmap to the bigchaindb/org repository; see:

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Acceptance test suite
 This directory contains the acceptance test suite for BigchainDB.
 

--- a/acceptance/python/src/test_basic.py
+++ b/acceptance/python/src/test_basic.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 # # Basic Acceptance Test
 # Here we check that the primitives of the system behave as expected.
 # As you will see, this script tests basic stuff like:
@@ -36,7 +40,6 @@ def test_basic():
     # The two keypairs will be called—drum roll—Alice and Bob.
     alice, bob = generate_keypair(), generate_keypair()
 
-
     # ## Alice registers her bike in BigchainDB
     # Alice has a nice bike, and here she creates the "digital twin"
     # of her bike.
@@ -57,7 +60,6 @@ def test_basic():
     # a variable with a short and easy name
     bike_id = fulfilled_creation_tx['id']
 
-
     # Now she is ready to send it to the BigchainDB Network.
     sent_transfer_tx = bdb.transactions.send(fulfilled_creation_tx)
 
@@ -68,7 +70,6 @@ def test_basic():
     # Alice is now the proud owner of one unspent asset.
     assert len(bdb.outputs.get(alice.public_key, spent=False)) == 1
     assert bdb.outputs.get(alice.public_key)[0]['transaction_id'] == bike_id
-
 
     # ## Alice transfers her bike to Bob
     # After registering her bike, Alice is ready to transfer it to Bob.

--- a/acceptance/python/src/test_divisible_asset.py
+++ b/acceptance/python/src/test_divisible_asset.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 # # Divisible assets integration testing
 # This test checks if we can successfully divide assets.
 # The script tests various things like:

--- a/acceptance/python/src/test_double_spend.py
+++ b/acceptance/python/src/test_double_spend.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 # # Double Spend testing
 # This test challenge the system with double spends.
 

--- a/acceptance/python/src/test_multiple_owners.py
+++ b/acceptance/python/src/test_multiple_owners.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 # # Multiple owners integration testing
 # This test checks if we can successfully create and transfer a transaction
 # with multiple owners.

--- a/acceptance/python/src/test_naughty_strings.py
+++ b/acceptance/python/src/test_naughty_strings.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 # ## Testing potentially hazardous strings
 # This test uses a library of `naughty` strings (code injections, weird unicode chars., etc.) as both keys and values.
 # We look for either a successful tx, or in the case that we use a naughty string as a key, and it violates some key
@@ -8,7 +12,8 @@
 # env variables.
 import os
 
-# Since the naughty strings get encoded and decoded in odd ways, we'll use a regex to sweep those details under the rug.
+# Since the naughty strings get encoded and decoded in odd ways,
+# we'll use a regex to sweep those details under the rug.
 import re
 
 # We'll use a nice library of naughty strings...

--- a/acceptance/python/src/test_stream.py
+++ b/acceptance/python/src/test_stream.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 # # Stream Acceptance Test
 # This test checks if the event stream works correctly. The basic idea of this
 # test is to generate some random **valid** transaction, send them to a

--- a/bigchaindb/README.md
+++ b/bigchaindb/README.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Overview
 
 A high-level description of the files and subdirectories of BigchainDB.

--- a/bigchaindb/__init__.py
+++ b/bigchaindb/__init__.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import copy
 import logging
 

--- a/bigchaindb/backend/README.md
+++ b/bigchaindb/backend/README.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Backend Interfaces
 
 ## Structure

--- a/bigchaindb/backend/__init__.py
+++ b/bigchaindb/backend/__init__.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Generic backend database interfaces expected by BigchainDB.
 
 The interfaces in this module allow BigchainDB to be agnostic about its

--- a/bigchaindb/backend/connection.py
+++ b/bigchaindb/backend/connection.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from itertools import repeat
 from importlib import import_module
 import logging

--- a/bigchaindb/backend/exceptions.py
+++ b/bigchaindb/backend/exceptions.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from bigchaindb.exceptions import BigchainDBError
 
 

--- a/bigchaindb/backend/localmongodb/__init__.py
+++ b/bigchaindb/backend/localmongodb/__init__.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """MongoDB backend implementation.
 
 Contains a MongoDB-specific implementation of the

--- a/bigchaindb/backend/localmongodb/connection.py
+++ b/bigchaindb/backend/localmongodb/connection.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import time
 import logging
 from ssl import CERT_REQUIRED

--- a/bigchaindb/backend/localmongodb/query.py
+++ b/bigchaindb/backend/localmongodb/query.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Query implementation for MongoDB"""
 
 from pymongo import DESCENDING

--- a/bigchaindb/backend/localmongodb/schema.py
+++ b/bigchaindb/backend/localmongodb/schema.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Utils to initialize and drop the database."""
 
 import logging

--- a/bigchaindb/backend/query.py
+++ b/bigchaindb/backend/query.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Query interfaces for backends."""
 
 from functools import singledispatch
@@ -364,6 +368,7 @@ def store_validator_set(conn, validator_update):
 @singledispatch
 def get_validator_set(conn, height):
     """Get validator set for a given `height`, if `height` is not specified
-    then return the latest validator set"""
+    then return the latest validator set
+    """
 
     raise NotImplementedError

--- a/bigchaindb/backend/schema.py
+++ b/bigchaindb/backend/schema.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Database creation and schema-providing interfaces for backends.
 
 Attributes:

--- a/bigchaindb/backend/utils.py
+++ b/bigchaindb/backend/utils.py
@@ -1,3 +1,8 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
+
 class ModuleDispatchRegistrationError(Exception):
     """Raised when there is a problem registering dispatched functions for a
     module

--- a/bigchaindb/commands/bigchaindb.py
+++ b/bigchaindb/commands/bigchaindb.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Implementation of the `bigchaindb` command,
 the command-line interface (CLI) for BigchainDB Server.
 """

--- a/bigchaindb/commands/utils.py
+++ b/bigchaindb/commands/utils.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Utility functions and basic common arguments
 for ``argparse.ArgumentParser``.
 """

--- a/bigchaindb/common/crypto.py
+++ b/bigchaindb/common/crypto.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 # Separate all crypto code so that we can easily test several implementations
 from collections import namedtuple
 

--- a/bigchaindb/common/exceptions.py
+++ b/bigchaindb/common/exceptions.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Custom exceptions used in the `bigchaindb` package.
 """
 from bigchaindb.exceptions import BigchainDBError

--- a/bigchaindb/common/schema/README.md
+++ b/bigchaindb/common/schema/README.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Introduction
 
 This directory contains the schemas for the different JSON documents BigchainDB uses.

--- a/bigchaindb/common/schema/__init__.py
+++ b/bigchaindb/common/schema/__init__.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Schema validation related functions and data"""
 import os.path
 import logging

--- a/bigchaindb/common/schema/transaction_create_v1.0.yaml
+++ b/bigchaindb/common/schema/transaction_create_v1.0.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 "$schema": "http://json-schema.org/draft-04/schema#"
 type: object

--- a/bigchaindb/common/schema/transaction_create_v2.0.yaml
+++ b/bigchaindb/common/schema/transaction_create_v2.0.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 "$schema": "http://json-schema.org/draft-04/schema#"
 type: object

--- a/bigchaindb/common/schema/transaction_transfer_v1.0.yaml
+++ b/bigchaindb/common/schema/transaction_transfer_v1.0.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 "$schema": "http://json-schema.org/draft-04/schema#"
 type: object

--- a/bigchaindb/common/schema/transaction_transfer_v2.0.yaml
+++ b/bigchaindb/common/schema/transaction_transfer_v2.0.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 "$schema": "http://json-schema.org/draft-04/schema#"
 type: object

--- a/bigchaindb/common/schema/transaction_v1.0.yaml
+++ b/bigchaindb/common/schema/transaction_v1.0.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 "$schema": "http://json-schema.org/draft-04/schema#"
 type: object

--- a/bigchaindb/common/schema/transaction_v2.0.yaml
+++ b/bigchaindb/common/schema/transaction_v2.0.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 "$schema": "http://json-schema.org/draft-04/schema#"
 type: object

--- a/bigchaindb/common/schema/transaction_validator_election_v2.0.yaml
+++ b/bigchaindb/common/schema/transaction_validator_election_v2.0.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 "$schema": "http://json-schema.org/draft-04/schema#"
 type: object

--- a/bigchaindb/common/schema/transaction_validator_election_vote_v2.0.yaml
+++ b/bigchaindb/common/schema/transaction_validator_election_vote_v2.0.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 "$schema": "http://json-schema.org/draft-04/schema#"
 type: object

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Transaction related models to parse and construct transaction
 payloads.
 
@@ -570,7 +574,7 @@ class Transaction(object):
 
     @property
     def spent_outputs(self):
-        """tuple of :obj:`dict`: Inputs of this transaction. Each input
+        """Tuple of :obj:`dict`: Inputs of this transaction. Each input
         is represented as a dictionary containing a transaction id and
         output index.
         """

--- a/bigchaindb/common/utils.py
+++ b/bigchaindb/common/utils.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import time
 import re
 import rapidjson

--- a/bigchaindb/config_utils.py
+++ b/bigchaindb/config_utils.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Utils for reading and setting configuration settings.
 
 The value of each BigchainDB Server configuration setting is

--- a/bigchaindb/consensus.py
+++ b/bigchaindb/consensus.py
@@ -1,3 +1,6 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
 
 
 class BaseConsensusRules():

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -1,5 +1,10 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """This module contains all the goodness to integrate BigchainDB
-with Tendermint."""
+with Tendermint.
+"""
 import logging
 import codecs
 
@@ -33,7 +38,8 @@ class App(BaseApplication):
 
     The role of this class is to expose the BigchainDB
     transactional logic to the Tendermint Consensus
-    State Machine."""
+    State Machine.
+    """
 
     def __init__(self, bigchaindb=None):
         self.bigchaindb = bigchaindb or BigchainDB()
@@ -69,7 +75,8 @@ class App(BaseApplication):
         the mempool.
 
         Args:
-            raw_tx: a raw string (in bytes) transaction."""
+            raw_tx: a raw string (in bytes) transaction.
+        """
 
         logger.benchmark('CHECK_TX_INIT')
         logger.debug('check_tx: %s', raw_transaction)
@@ -101,7 +108,8 @@ class App(BaseApplication):
         """Validate the transaction before mutating the state.
 
         Args:
-            raw_tx: a raw string (in bytes) transaction."""
+            raw_tx: a raw string (in bytes) transaction.
+        """
         logger.debug('deliver_tx: %s', raw_transaction)
         transaction = self.bigchaindb.is_valid_transaction(
             decode_transaction(raw_transaction), self.block_transactions)
@@ -120,7 +128,8 @@ class App(BaseApplication):
         hash to be stored in the next block.
 
         Args:
-            height (int): new height of the chain."""
+            height (int): new height of the chain.
+        """
 
         height = request_end_block.height
         self.new_height = height

--- a/bigchaindb/event_stream.py
+++ b/bigchaindb/event_stream.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import asyncio
 import json
 import logging

--- a/bigchaindb/events.py
+++ b/bigchaindb/events.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from queue import Empty
 from collections import defaultdict
 from multiprocessing import Queue

--- a/bigchaindb/exceptions.py
+++ b/bigchaindb/exceptions.py
@@ -1,3 +1,8 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
+
 class BigchainDBError(Exception):
     """Base class for BigchainDB exceptions."""
 

--- a/bigchaindb/fastquery.py
+++ b/bigchaindb/fastquery.py
@@ -1,19 +1,20 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from bigchaindb.utils import condition_details_has_owner
 from bigchaindb.backend import query
 from bigchaindb.common.transaction import TransactionLink
 
 
 class FastQuery():
-    """
-    Database queries that join on block results from a single node.
-    """
+    """Database queries that join on block results from a single node."""
+
     def __init__(self, connection):
         self.connection = connection
 
     def get_outputs_by_public_key(self, public_key):
-        """
-        Get outputs for a public key
-        """
+        """Get outputs for a public key"""
         txs = list(query.get_owned_ids(self.connection, public_key))
         return [TransactionLink(tx['id'], index)
                 for tx in txs
@@ -22,8 +23,7 @@ class FastQuery():
                                                public_key)]
 
     def filter_spent_outputs(self, outputs):
-        """
-        Remove outputs that have been spent
+        """Remove outputs that have been spent
 
         Args:
             outputs: list of TransactionLink
@@ -36,8 +36,7 @@ class FastQuery():
         return [ff for ff in outputs if ff not in spends]
 
     def filter_unspent_outputs(self, outputs):
-        """
-        Remove outputs that have not been spent
+        """Remove outputs that have not been spent
 
         Args:
             outputs: list of TransactionLink

--- a/bigchaindb/lib.py
+++ b/bigchaindb/lib.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Module containing main contact points with Tendermint and
 MongoDB.
 

--- a/bigchaindb/log.py
+++ b/bigchaindb/log.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import bigchaindb
 import logging
 

--- a/bigchaindb/models.py
+++ b/bigchaindb/models.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from bigchaindb.common.exceptions import (InvalidSignature,
                                           DuplicateTransaction)
 from bigchaindb.common.transaction import Transaction

--- a/bigchaindb/start.py
+++ b/bigchaindb/start.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import logging
 import setproctitle
 

--- a/bigchaindb/tendermint_utils.py
+++ b/bigchaindb/tendermint_utils.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import base64
 import hashlib
 import json

--- a/bigchaindb/upsert_validator/__init__.py
+++ b/bigchaindb/upsert_validator/__init__.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 from bigchaindb.upsert_validator.validator_election import ValidatorElection # noqa
 from bigchaindb.upsert_validator.validator_election_vote import ValidatorElectionVote # noqa

--- a/bigchaindb/upsert_validator/validator_election.py
+++ b/bigchaindb/upsert_validator/validator_election.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from bigchaindb.common.exceptions import (InvalidSignature,
                                           MultipleInputsError,
                                           InvalidProposer,

--- a/bigchaindb/upsert_validator/validator_election_vote.py
+++ b/bigchaindb/upsert_validator/validator_election_vote.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import base58
 
 from bigchaindb.common.transaction import Transaction

--- a/bigchaindb/utils.py
+++ b/bigchaindb/utils.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import contextlib
 import threading
 import queue
@@ -31,7 +35,8 @@ class ProcessGroup(object):
 class Process(mp.Process):
     """Wrapper around multiprocessing.Process that uses
     setproctitle to set the name of the process when running
-    the target task."""
+    the target task.
+    """
 
     def run(self):
         setproctitle.setproctitle(self.name)

--- a/bigchaindb/version.py
+++ b/bigchaindb/version.py
@@ -1,2 +1,6 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 __version__ = '2.0.0b5'
 __short_version__ = '2.0b5'

--- a/bigchaindb/web/routes.py
+++ b/bigchaindb/web/routes.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """API routes definition"""
 from flask_restful import Api
 from bigchaindb.web.views import (

--- a/bigchaindb/web/server.py
+++ b/bigchaindb/web/server.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """This module contains basic functions to instantiate the BigchainDB API.
 
 The application is implemented in Flask and runs using Gunicorn.

--- a/bigchaindb/web/strip_content_type_middleware.py
+++ b/bigchaindb/web/strip_content_type_middleware.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import logging
 
 logger = logging.getLogger(__name__)

--- a/bigchaindb/web/views/assets.py
+++ b/bigchaindb/web/views/assets.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """This module provides the blueprint for some basic API endpoints.
 
 For more information please refer to the documentation: http://bigchaindb.com/http-api

--- a/bigchaindb/web/views/base.py
+++ b/bigchaindb/web/views/base.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Common classes and methods for API handlers
 """
 import logging

--- a/bigchaindb/web/views/blocks.py
+++ b/bigchaindb/web/views/blocks.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """This module provides the blueprint for the blocks API endpoints.
 
 For more information please refer to the documentation: http://bigchaindb.com/http-api

--- a/bigchaindb/web/views/info.py
+++ b/bigchaindb/web/views/info.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """API Index endpoint"""
 
 import flask

--- a/bigchaindb/web/views/metadata.py
+++ b/bigchaindb/web/views/metadata.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """This module provides the blueprint for some basic API endpoints.
 
 For more information please refer to the documentation: http://bigchaindb.com/http-api

--- a/bigchaindb/web/views/outputs.py
+++ b/bigchaindb/web/views/outputs.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from flask import current_app
 from flask_restful import reqparse, Resource
 

--- a/bigchaindb/web/views/parameters.py
+++ b/bigchaindb/web/views/parameters.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import re
 
 

--- a/bigchaindb/web/views/transactions.py
+++ b/bigchaindb/web/views/transactions.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """This module provides the blueprint for some basic API endpoints.
 
 For more information please refer to the documentation: http://bigchaindb.com/http-api

--- a/bigchaindb/web/views/validators.py
+++ b/bigchaindb/web/views/validators.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from flask import current_app
 from flask_restful import Resource
 

--- a/bigchaindb/web/websocket_server.py
+++ b/bigchaindb/web/websocket_server.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """WebSocket server for the BigchainDB Event Stream API."""
 
 # NOTE

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 codecov:
   branch: master     # the branch to show by default
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 version: '2.1'
 
 services:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 - [Documentation on ReadTheDocs](http://bigchaindb.readthedocs.org/)
 - [BigchainDB Upgrade Guides](upgrade-guides/)
 

--- a/docs/contributing/source/conf.py
+++ b/docs/contributing/source/conf.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
-# -*- coding: utf-8 -*-
-#
 # BigchainDB documentation build configuration file, created by
 # sphinx-quickstart on Thu Sep 29 11:13:27 2016.
 #

--- a/docs/contributing/source/conf.py
+++ b/docs/contributing/source/conf.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 # -*- coding: utf-8 -*-
 #
 # BigchainDB documentation build configuration file, created by

--- a/docs/contributing/source/cross-project-policies/index.rst
+++ b/docs/contributing/source/cross-project-policies/index.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Policies
 ========
 

--- a/docs/contributing/source/dev-setup-coding-and-contribution-process/index.rst
+++ b/docs/contributing/source/dev-setup-coding-and-contribution-process/index.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Developer Setup, Coding & Contribution Process
 ==============================================
 

--- a/docs/contributing/source/dev-setup-coding-and-contribution-process/run-dev-network-ansible.md
+++ b/docs/contributing/source/dev-setup-coding-and-contribution-process/run-dev-network-ansible.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Run a BigchainDB network with Ansible
 
 **NOT for Production Use**

--- a/docs/contributing/source/dev-setup-coding-and-contribution-process/run-dev-network-stack.md
+++ b/docs/contributing/source/dev-setup-coding-and-contribution-process/run-dev-network-stack.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Run a BigchainDB network
 
 **NOT for Production Use**

--- a/docs/contributing/source/dev-setup-coding-and-contribution-process/run-node-as-processes.md
+++ b/docs/contributing/source/dev-setup-coding-and-contribution-process/run-node-as-processes.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Notes on Running a Local Dev Node as Processes
 
 The following doc describes how to run a local node for developing BigchainDB Tendermint version.

--- a/docs/contributing/source/dev-setup-coding-and-contribution-process/run-node-with-docker-compose.md
+++ b/docs/contributing/source/dev-setup-coding-and-contribution-process/run-node-with-docker-compose.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Notes on Running a Local Dev Node with Docker Compose
 
 ## Setting up a single node development environment with ``docker-compose``

--- a/docs/contributing/source/dev-setup-coding-and-contribution-process/write-code.rst
+++ b/docs/contributing/source/dev-setup-coding-and-contribution-process/write-code.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Write Code
 ==========
 

--- a/docs/contributing/source/index.rst
+++ b/docs/contributing/source/index.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Contributing to BigchainDB
 ==========================
 

--- a/docs/contributing/source/ways-to-contribute/answer-questions.md
+++ b/docs/contributing/source/ways-to-contribute/answer-questions.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Answer Questions
 
 People ask questions about BigchainDB in the following places:

--- a/docs/contributing/source/ways-to-contribute/index.rst
+++ b/docs/contributing/source/ways-to-contribute/index.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Ways to Contribute
 ==================
 

--- a/docs/contributing/source/ways-to-contribute/make-a-feature-request-or-proposal.md
+++ b/docs/contributing/source/ways-to-contribute/make-a-feature-request-or-proposal.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Make a Feature Request or Proposal
 
 To make a feature request or proposal, [write a BigchainDB Enhancement Proposal (BEP)](write-a-bep.html).

--- a/docs/contributing/source/ways-to-contribute/report-a-bug.md
+++ b/docs/contributing/source/ways-to-contribute/report-a-bug.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Report a Bug
 
 To report a bug, go to the relevant GitHub repository, click on the **Issues** tab, click on the **New issue** button, and read the instructions.

--- a/docs/contributing/source/ways-to-contribute/write-a-bep.md
+++ b/docs/contributing/source/ways-to-contribute/write-a-bep.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Write a BigchainDB Enhancement Proposal (BEP)
 
 If you have an idea for a new feature or enhancement, and you want some feedback before you write a full BigchainDB Enhancement Proposal (BEP), then feel free to:

--- a/docs/contributing/source/ways-to-contribute/write-an-issue.md
+++ b/docs/contributing/source/ways-to-contribute/write-an-issue.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Write an Issue
 
 To write an issue, go to the relevant GitHub repository, click on the **Issues** tab, click on the **New issue** button, and read the instructions.

--- a/docs/contributing/source/ways-to-contribute/write-docs.md
+++ b/docs/contributing/source/ways-to-contribute/write-docs.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Write Docs
 
 If you're writing code, you should also update any related docs. However, you might want to write docs only, such as:

--- a/docs/root/source/assets.rst
+++ b/docs/root/source/assets.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 How BigchainDB is Good for Asset Registrations & Transfers
 ==========================================================
 

--- a/docs/root/source/bft.md
+++ b/docs/root/source/bft.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # BigchainDB and Byzantine Fault Tolerance
 
 [BigchainDB Server](https://docs.bigchaindb.com/projects/server/en/latest/index.html)

--- a/docs/root/source/conf.py
+++ b/docs/root/source/conf.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
-# -*- coding: utf-8 -*-
-#
 # BigchainDB documentation build configuration file, created by
 # sphinx-quickstart on Thu Sep 29 11:13:27 2016.
 #

--- a/docs/root/source/conf.py
+++ b/docs/root/source/conf.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 # -*- coding: utf-8 -*-
 #
 # BigchainDB documentation build configuration file, created by

--- a/docs/root/source/decentralized.md
+++ b/docs/root/source/decentralized.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # How BigchainDB is Decentralized
 
 Decentralization means that no one owns or controls everything, and there is no single point of failure.

--- a/docs/root/source/diversity.md
+++ b/docs/root/source/diversity.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Kinds of Node Diversity
 
 Steps should be taken to make it difficult for any one actor or event to control or damage “enough” of the nodes. (Because BigchainDB Server uses Tendermint, "enough" is ⅓.) There are many kinds of diversity to consider, listed below. It may be quite difficult to have high diversity of all kinds.

--- a/docs/root/source/immutable.md
+++ b/docs/root/source/immutable.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # How BigchainDB is Immutable
 
 The word _immutable_ means "unchanging over time or unable to be changed." For example, the decimal digits of π are immutable (3.14159…).

--- a/docs/root/source/index.rst
+++ b/docs/root/source/index.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 BigchainDB Documentation
 ========================
 

--- a/docs/root/source/permissions.rst
+++ b/docs/root/source/permissions.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Permissions in BigchainDB
 -------------------------
 

--- a/docs/root/source/private-data.rst
+++ b/docs/root/source/private-data.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 BigchainDB, Privacy and Private Data
 ------------------------------------
 

--- a/docs/root/source/production-ready.md
+++ b/docs/root/source/production-ready.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Production-Ready?
 
 Depending on your use case, BigchainDB may or may not be production-ready. You should ask your service provider.

--- a/docs/root/source/query.rst
+++ b/docs/root/source/query.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Querying BigchainDB
 ===================
 

--- a/docs/root/source/smart-contracts.rst
+++ b/docs/root/source/smart-contracts.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 BigchainDB and Smart Contracts
 ==============================
 

--- a/docs/root/source/store-files.md
+++ b/docs/root/source/store-files.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # How to Store Files in BigchainDB
 
 While it's possible to store a file in a BigchainDB network, we don't recommend doing that. It works best for storing, indexing and querying _structured data_, not files.

--- a/docs/root/source/terminology.md
+++ b/docs/root/source/terminology.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Terminology
 
 There is some specialized terminology associated with BigchainDB. To get started, you should at least know the following:

--- a/docs/root/source/transaction-concepts.md
+++ b/docs/root/source/transaction-concepts.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Transaction Concepts
 
 In BigchainDB, _transactions_ are used to register, issue, create or transfer

--- a/docs/server/generate_http_server_api_documentation.py
+++ b/docs/server/generate_http_server_api_documentation.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """ Script to build http examples for http server api docs """
 
 import json

--- a/docs/server/source/appendices/all-in-one-bigchaindb.md
+++ b/docs/server/source/appendices/all-in-one-bigchaindb.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Run BigchainDB with all-in-one Docker
 
 For those who like using Docker and wish to experiment with BigchainDB in

--- a/docs/server/source/appendices/aws-setup.md
+++ b/docs/server/source/appendices/aws-setup.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Basic AWS Setup 
 
 Before you can deploy anything on AWS, you must do a few things.

--- a/docs/server/source/appendices/backend.rst
+++ b/docs/server/source/appendices/backend.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 ###########################
 Database Backend Interfaces
 ###########################

--- a/docs/server/source/appendices/commands.rst
+++ b/docs/server/source/appendices/commands.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 ######################
 Command Line Interface
 ######################

--- a/docs/server/source/appendices/cryptography.rst
+++ b/docs/server/source/appendices/cryptography.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Cryptography
 ============
 

--- a/docs/server/source/appendices/firewall-notes.md
+++ b/docs/server/source/appendices/firewall-notes.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Notes for Firewall Setup
 
 This is a page of notes on the ports potentially used by BigchainDB nodes and the traffic they should expect, to help with firewall setup (or security group setup on cloud providers). This page is _not_ a firewall tutorial or step-by-step guide.

--- a/docs/server/source/appendices/generate-key-pair-for-ssh.md
+++ b/docs/server/source/appendices/generate-key-pair-for-ssh.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Generate a Key Pair for SSH
 
 This page describes how to use `ssh-keygen`

--- a/docs/server/source/appendices/index.rst
+++ b/docs/server/source/appendices/index.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Appendices
 ==========
 

--- a/docs/server/source/appendices/json-serialization.rst
+++ b/docs/server/source/appendices/json-serialization.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 JSON Serialization
 ==================
 

--- a/docs/server/source/appendices/licenses.md
+++ b/docs/server/source/appendices/licenses.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Licenses
 
 Information about how the BigchainDB Server code and documentation are licensed can be found in [the LICENSES.md file](https://github.com/bigchaindb/bigchaindb/blob/master/LICENSES.md) of the bigchaindb/bigchaindb repository on GitHub.

--- a/docs/server/source/appendices/ntp-notes.md
+++ b/docs/server/source/appendices/ntp-notes.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Notes on NTP Daemon Setup
 
 There are several NTP daemons available, including:

--- a/docs/server/source/appendices/the-bigchaindb-class.rst
+++ b/docs/server/source/appendices/the-bigchaindb-class.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 ####################
 The BigchainDB Class
 ####################

--- a/docs/server/source/clusters.md
+++ b/docs/server/source/clusters.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Clusters
 
 A **BigchainDB Cluster** is a set of connected **BigchainDB Nodes**, managed by a **BigchainDB Consortium** (i.e. an organization). Those terms are defined in the [BigchainDB Terminology page](https://docs.bigchaindb.com/en/latest/terminology.html).

--- a/docs/server/source/conf.py
+++ b/docs/server/source/conf.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
-# -*- coding: utf-8 -*-
-#
 # BigchainDB Server documentation build configuration file, created by
 # sphinx-quickstart on Tue Jan 19 14:42:58 2016.
 #

--- a/docs/server/source/conf.py
+++ b/docs/server/source/conf.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 # -*- coding: utf-8 -*-
 #
 # BigchainDB Server documentation build configuration file, created by

--- a/docs/server/source/data-models/asset-model.rst
+++ b/docs/server/source/data-models/asset-model.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 The Asset Model
 ===============
 

--- a/docs/server/source/data-models/block-model.rst
+++ b/docs/server/source/data-models/block-model.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. _the-block-model:
 
 The Block Model

--- a/docs/server/source/data-models/conditions.rst
+++ b/docs/server/source/data-models/conditions.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Conditions
 ==========
 

--- a/docs/server/source/data-models/index.rst
+++ b/docs/server/source/data-models/index.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Data Models
 ===========
 

--- a/docs/server/source/data-models/inputs-outputs.rst
+++ b/docs/server/source/data-models/inputs-outputs.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Inputs and Outputs
 ==================
 

--- a/docs/server/source/data-models/transaction-model.rst
+++ b/docs/server/source/data-models/transaction-model.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. _the-transaction-model:
 
 The Transaction Model

--- a/docs/server/source/dev-and-test/index.rst
+++ b/docs/server/source/dev-and-test/index.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Develop & Test BigchainDB Server
 ================================
 

--- a/docs/server/source/drivers-clients/index.rst
+++ b/docs/server/source/drivers-clients/index.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Drivers & Tools
 ===============
 

--- a/docs/server/source/events/index.rst
+++ b/docs/server/source/events/index.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 The Events API
 ==============
 

--- a/docs/server/source/events/websocket-event-stream-api.rst
+++ b/docs/server/source/events/websocket-event-stream-api.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. _the-websocket-event-stream-api:
 
 The WebSocket Event Stream API

--- a/docs/server/source/http-client-server-api.rst
+++ b/docs/server/source/http-client-server-api.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. _the-http-client-server-api:
 
 The HTTP Client-Server API

--- a/docs/server/source/index.rst
+++ b/docs/server/source/index.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 BigchainDB Server Documentation
 ===============================
 

--- a/docs/server/source/introduction.md
+++ b/docs/server/source/introduction.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Introduction
 
 This is the documentation for BigchainDB Server, the BigchainDB software that one runs on servers (but not on clients).

--- a/docs/server/source/k8s-deployment-template/architecture.rst
+++ b/docs/server/source/k8s-deployment-template/architecture.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Architecture of a BigchainDB Node Running in a Kubernetes Cluster
 =================================================================
 

--- a/docs/server/source/k8s-deployment-template/bigchaindb-network-on-kubernetes.rst
+++ b/docs/server/source/k8s-deployment-template/bigchaindb-network-on-kubernetes.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. _kubernetes-template-deploy-bigchaindb-network:
 
 Kubernetes Template: Deploying a BigchainDB network

--- a/docs/server/source/k8s-deployment-template/ca-installation.rst
+++ b/docs/server/source/k8s-deployment-template/ca-installation.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. _how-to-set-up-a-self-signed-certificate-authority:
 
 How to Set Up a Self-Signed Certificate Authority

--- a/docs/server/source/k8s-deployment-template/client-tls-certificate.rst
+++ b/docs/server/source/k8s-deployment-template/client-tls-certificate.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. _how-to-generate-a-client-certificate-for-mongodb:
 
 How to Generate a Client Certificate for MongoDB

--- a/docs/server/source/k8s-deployment-template/cloud-manager.rst
+++ b/docs/server/source/k8s-deployment-template/cloud-manager.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. _configure-mongodb-cloud-manager-for-monitoring:
 
 Configure MongoDB Cloud Manager for Monitoring

--- a/docs/server/source/k8s-deployment-template/easy-rsa.rst
+++ b/docs/server/source/k8s-deployment-template/easy-rsa.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. _how-to-install-and-configure-easyrsa:
 
 How to Install & Configure Easy-RSA

--- a/docs/server/source/k8s-deployment-template/index.rst
+++ b/docs/server/source/k8s-deployment-template/index.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Kubernetes Deployment Template
 ==============================
 

--- a/docs/server/source/k8s-deployment-template/log-analytics.rst
+++ b/docs/server/source/k8s-deployment-template/log-analytics.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Log Analytics on Azure
 ======================
 

--- a/docs/server/source/k8s-deployment-template/node-config-map-and-secrets.rst
+++ b/docs/server/source/k8s-deployment-template/node-config-map-and-secrets.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. _how-to-configure-a-bigchaindb-node:
 
 How to Configure a BigchainDB Node

--- a/docs/server/source/k8s-deployment-template/node-on-kubernetes.rst
+++ b/docs/server/source/k8s-deployment-template/node-on-kubernetes.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. _kubernetes-template-deploy-a-single-bigchaindb-node:
 
 Kubernetes Template: Deploy a Single BigchainDB Node

--- a/docs/server/source/k8s-deployment-template/revoke-tls-certificate.rst
+++ b/docs/server/source/k8s-deployment-template/revoke-tls-certificate.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 How to Revoke an SSL/TLS Certificate
 ====================================
 

--- a/docs/server/source/k8s-deployment-template/server-tls-certificate.rst
+++ b/docs/server/source/k8s-deployment-template/server-tls-certificate.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. _how-to-generate-a-server-certificate-for-mongodb:
 
 How to Generate a Server Certificate for MongoDB

--- a/docs/server/source/k8s-deployment-template/tectonic-azure.rst
+++ b/docs/server/source/k8s-deployment-template/tectonic-azure.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Walkthrough: Deploy a Kubernetes Cluster on Azure using Tectonic by CoreOS
 ==========================================================================
 

--- a/docs/server/source/k8s-deployment-template/template-kubernetes-azure.rst
+++ b/docs/server/source/k8s-deployment-template/template-kubernetes-azure.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Template: Deploy a Kubernetes Cluster on Azure
 ==============================================
 

--- a/docs/server/source/k8s-deployment-template/troubleshoot.rst
+++ b/docs/server/source/k8s-deployment-template/troubleshoot.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. _cluster-troubleshooting:
 
 Cluster Troubleshooting

--- a/docs/server/source/k8s-deployment-template/upgrade-on-kubernetes.rst
+++ b/docs/server/source/k8s-deployment-template/upgrade-on-kubernetes.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Kubernetes Template: Upgrade all Software in a BigchainDB Node
 ==============================================================
 

--- a/docs/server/source/k8s-deployment-template/workflow.rst
+++ b/docs/server/source/k8s-deployment-template/workflow.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 .. _kubernetes-template-overview:
 
 Overview

--- a/docs/server/source/production-nodes/index.rst
+++ b/docs/server/source/production-nodes/index.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Production Nodes
 ================
 

--- a/docs/server/source/production-nodes/node-assumptions.md
+++ b/docs/server/source/production-nodes/node-assumptions.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Production Node Assumptions
 
 Be sure you know the key BigchainDB terminology:

--- a/docs/server/source/production-nodes/node-components.md
+++ b/docs/server/source/production-nodes/node-components.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Production Node Components
 
 A production BigchainDB node must include:

--- a/docs/server/source/production-nodes/node-requirements.md
+++ b/docs/server/source/production-nodes/node-requirements.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Production Node Requirements
 
 **This page is about the requirements of BigchainDB Server.** You can find the requirements of MongoDB, Tendermint and other [production node components](node-components.html) in the documentation for that software.

--- a/docs/server/source/production-nodes/node-security-and-privacy.md
+++ b/docs/server/source/production-nodes/node-security-and-privacy.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Production Node Security & Privacy
 
 Here are some references about how to secure an Ubuntu 18.04 server:

--- a/docs/server/source/production-nodes/reverse-proxy-notes.md
+++ b/docs/server/source/production-nodes/reverse-proxy-notes.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Using a Reverse Proxy
 
 You may want to:

--- a/docs/server/source/quickstart.md
+++ b/docs/server/source/quickstart.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Quickstart
 
 <style media="screen" type="text/css">

--- a/docs/server/source/release-notes.md
+++ b/docs/server/source/release-notes.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Release Notes
 
 You can find a list of all BigchainDB Server releases and release notes on GitHub at:

--- a/docs/server/source/server-reference/bigchaindb-cli.md
+++ b/docs/server/source/server-reference/bigchaindb-cli.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Command Line Interface (CLI)
 
 The command-line command to interact with BigchainDB Server is `bigchaindb`.

--- a/docs/server/source/server-reference/configuration.md
+++ b/docs/server/source/server-reference/configuration.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Configuration Settings
 
 The value of each BigchainDB Server configuration setting is determined according to the following rules:

--- a/docs/server/source/server-reference/index.rst
+++ b/docs/server/source/server-reference/index.rst
@@ -1,3 +1,8 @@
+
+.. Copyright BigchainDB GmbH and BigchainDB contributors
+   SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+   Code is Apache-2.0 and docs are CC-BY-4.0
+
 Settings & CLI
 ==============
 

--- a/docs/server/source/simple-network-setup.md
+++ b/docs/server/source/simple-network-setup.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # How to Set Up a BigchainDB Network
 
 Note 1: These instructions will also work for a "network" with only one node.

--- a/docs/upgrade-guides/v0.10-v1.0.md
+++ b/docs/upgrade-guides/v0.10-v1.0.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Updating from BigchainDB v0.10 to v1.0
 
 BigchainDB v1.0 stands for backwards compatibility. This means that all

--- a/k8s/bigchaindb/bigchaindb-ext-conn-svc.yaml
+++ b/k8s/bigchaindb/bigchaindb-ext-conn-svc.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/k8s/bigchaindb/bigchaindb-pv.yaml
+++ b/k8s/bigchaindb/bigchaindb-pv.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 #########################################################
 # This YAML section desribes a k8s PV for tendermint db #
 #########################################################

--- a/k8s/bigchaindb/bigchaindb-pvc.yaml
+++ b/k8s/bigchaindb/bigchaindb-pvc.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ##########################################################
 # This section file desribes a k8s pvc for tendermint db #
 ##########################################################

--- a/k8s/bigchaindb/bigchaindb-sc.yaml
+++ b/k8s/bigchaindb/bigchaindb-sc.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ###################################################################
 # This YAML section desribes a StorageClass for the tendermint db #
 ###################################################################

--- a/k8s/bigchaindb/bigchaindb-ss.yaml
+++ b/k8s/bigchaindb/bigchaindb-ss.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 #################################################################################
 # This YAML file desribes a StatefulSet with a service for running and exposing #
 # a Tendermint instance. It depends on the tendermint-config-db-claim           #

--- a/k8s/bigchaindb/bigchaindb-svc.yaml
+++ b/k8s/bigchaindb/bigchaindb-svc.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/k8s/bigchaindb/nginx_container/README.md
+++ b/k8s/bigchaindb/nginx_container/README.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 ## Nginx container for hosting public key for a tendermint instance
 
 

--- a/k8s/bigchaindb/nginx_container/docker_build_and_push.bash
+++ b/k8s/bigchaindb/nginx_container/docker_build_and_push.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 docker build -t bigchaindb/nginx_pub_key_access:2.0.0-alpha3 .
 

--- a/k8s/bigchaindb/nginx_container/nginx_entrypoint.bash
+++ b/k8s/bigchaindb/nginx_container/nginx_entrypoint.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 set -euo pipefail
 
 # Tendermint public key access port

--- a/k8s/bigchaindb/tendermint_container/README.md
+++ b/k8s/bigchaindb/tendermint_container/README.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 ## Tendermint container used for BFT replication and consensus
 
 

--- a/k8s/bigchaindb/tendermint_container/docker_build_and_push.bash
+++ b/k8s/bigchaindb/tendermint_container/docker_build_and_push.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 docker build -t bigchaindb/tendermint:2.0.0-alpha3 .
 

--- a/k8s/bigchaindb/tendermint_container/tendermint_entrypoint.bash
+++ b/k8s/bigchaindb/tendermint_container/tendermint_entrypoint.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 set -euo pipefail
 
 # Cluster vars

--- a/k8s/configuration/config-map.yaml
+++ b/k8s/configuration/config-map.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ## Note: data values do NOT have to be base64-encoded in this file.
 
 ## vars is common environment variables for this BigchaindB node

--- a/k8s/configuration/secret.yaml
+++ b/k8s/configuration/secret.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 # All secret data should be base64 encoded before embedding them here.
 # Short strings can be encoded using, e.g.
 # echo "secret string" | base64 -w 0 > secret.string.b64

--- a/k8s/dev-setup/bigchaindb.yaml
+++ b/k8s/dev-setup/bigchaindb.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/k8s/dev-setup/mongo.yaml
+++ b/k8s/dev-setup/mongo.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/k8s/dev-setup/nginx-http.yaml
+++ b/k8s/dev-setup/nginx-http.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/k8s/dev-setup/nginx-https.yaml
+++ b/k8s/dev-setup/nginx-https.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/k8s/dev-setup/nginx-openresty.yaml
+++ b/k8s/dev-setup/nginx-openresty.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/k8s/logging-and-monitoring/analyze.py
+++ b/k8s/logging-and-monitoring/analyze.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """
 A little Python script to do some analysis of the NGINX logs.
 To get the relevant NGINX logs:

--- a/k8s/logging-and-monitoring/oms-daemonset.yaml
+++ b/k8s/logging-and-monitoring/oms-daemonset.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:

--- a/k8s/mongodb-monitoring-agent/container/docker_build_and_push.bash
+++ b/k8s/mongodb-monitoring-agent/container/docker_build_and_push.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 docker build -t bigchaindb/mongodb-monitoring-agent:2.0.0-alpha .
 

--- a/k8s/mongodb-monitoring-agent/container/mongodb_mon_agent_entrypoint.bash
+++ b/k8s/mongodb-monitoring-agent/container/mongodb_mon_agent_entrypoint.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 set -euo pipefail
 # -e Abort at the first failed line (i.e. if exit status is not 0)

--- a/k8s/mongodb-monitoring-agent/mongo-mon-dep.yaml
+++ b/k8s/mongodb-monitoring-agent/mongo-mon-dep.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ############################################################
 # This config file defines a k8s Deployment for the        #
 # bigchaindb/mongodb-monitoring-agent Docker image         #

--- a/k8s/mongodb/configure_mdb.sh
+++ b/k8s/mongodb/configure_mdb.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 # Checking if kubectl exists
 command -v kubectl > /dev/null

--- a/k8s/mongodb/container/README.md
+++ b/k8s/mongodb/container/README.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 ## Custom MongoDB container for BigchainDB Backend
 
 ### Step 1: Build and Push the Latest Container

--- a/k8s/mongodb/container/configure_mdb_users.template.js
+++ b/k8s/mongodb/container/configure_mdb_users.template.js
@@ -1,3 +1,7 @@
+// Copyright BigchainDB GmbH and BigchainDB contributors
+// SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+// Code is Apache-2.0 and docs are CC-BY-4.0
+
 var configure_adminUser = CONFIGURE_ADMIN_USER;
 var configure_bdbUser = CONFIGURE_BDB_USER;
 var configure_mdbMonUser = CONFIGURE_MDB_MON_USER;

--- a/k8s/mongodb/container/docker_build_and_push.bash
+++ b/k8s/mongodb/container/docker_build_and_push.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 docker build -t bigchaindb/localmongodb:2.0.0-alpha5 .
 docker push bigchaindb/localmongodb:2.0.0-alpha5

--- a/k8s/mongodb/container/mongod_entrypoint.bash
+++ b/k8s/mongodb/container/mongod_entrypoint.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 set -euo pipefail
 
 MONGODB_PORT=""

--- a/k8s/mongodb/mongo-ext-conn-svc.yaml
+++ b/k8s/mongodb/mongo-ext-conn-svc.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/k8s/mongodb/mongo-pv.yaml
+++ b/k8s/mongodb/mongo-pv.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 #############################################################
 # This YAML section desribes a k8s PV for mongodb dbPath    #
 #############################################################

--- a/k8s/mongodb/mongo-pvc.yaml
+++ b/k8s/mongodb/mongo-pvc.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ###########################################################
 # This section file desribes a k8s pvc for mongodb dbPath #
 ###########################################################

--- a/k8s/mongodb/mongo-sc.yaml
+++ b/k8s/mongodb/mongo-sc.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ####################################################################
 # This YAML section desribes a StorageClass for the mongodb dbPath #
 ####################################################################

--- a/k8s/mongodb/mongo-ss.yaml
+++ b/k8s/mongodb/mongo-ss.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ########################################################################
 # This YAML file desribes a StatefulSet with a service for running and #
 # exposing a MongoDB instance.                                         #

--- a/k8s/mongodb/mongo-svc.yaml
+++ b/k8s/mongodb/mongo-svc.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/k8s/nginx-http/container/README.md
+++ b/k8s/nginx-http/container/README.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 ## Nginx container for Secure WebSocket Support
 
 

--- a/k8s/nginx-http/container/docker_build_and_push.bash
+++ b/k8s/nginx-http/container/docker_build_and_push.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 docker build -t bigchaindb/nginx_http:2.0.0-alpha5 .
 

--- a/k8s/nginx-http/container/nginx_entrypoint.bash
+++ b/k8s/nginx-http/container/nginx_entrypoint.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 set -euo pipefail
 
 # Cluster vars

--- a/k8s/nginx-http/nginx-http-dep.yaml
+++ b/k8s/nginx-http/nginx-http-dep.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/k8s/nginx-http/nginx-http-svc.yaml
+++ b/k8s/nginx-http/nginx-http-svc.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/k8s/nginx-https-web-proxy/README.md
+++ b/k8s/nginx-https-web-proxy/README.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 ## Deploying the BigchainDB Web Proxy on a Kubernetes Cluster
 
 

--- a/k8s/nginx-https-web-proxy/container/docker_build_and_push.bash
+++ b/k8s/nginx-https-web-proxy/container/docker_build_and_push.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 docker build -t bigchaindb/nginx-https-web-proxy:0.12 .
 

--- a/k8s/nginx-https-web-proxy/container/nginx_entrypoint.bash
+++ b/k8s/nginx-https-web-proxy/container/nginx_entrypoint.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 set -euo pipefail
 
 # Proxy vars

--- a/k8s/nginx-https-web-proxy/nginx-https-web-proxy-conf.yaml
+++ b/k8s/nginx-https-web-proxy/nginx-https-web-proxy-conf.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 # All secret data should be base64 encoded before embedding them in the Secret.
 # Short strings can be encoded using, e.g.
 # echo "secret string" | base64 -w 0 > secret.string.b64

--- a/k8s/nginx-https-web-proxy/nginx-https-web-proxy-dep.yaml
+++ b/k8s/nginx-https-web-proxy/nginx-https-web-proxy-dep.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/k8s/nginx-https-web-proxy/nginx-https-web-proxy-svc.yaml
+++ b/k8s/nginx-https-web-proxy/nginx-https-web-proxy-svc.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/k8s/nginx-https/container/README.md
+++ b/k8s/nginx-https/container/README.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 ## Nginx container for Secure WebSocket Support
 
 

--- a/k8s/nginx-https/container/docker_build_and_push.bash
+++ b/k8s/nginx-https/container/docker_build_and_push.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 docker build -t bigchaindb/nginx_https:2.0.0-alpha5 .
 

--- a/k8s/nginx-https/container/nginx_entrypoint.bash
+++ b/k8s/nginx-https/container/nginx_entrypoint.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 set -euo pipefail
 
 # Authorization Modes

--- a/k8s/nginx-https/nginx-https-dep.yaml
+++ b/k8s/nginx-https/nginx-https-dep.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/k8s/nginx-https/nginx-https-svc.yaml
+++ b/k8s/nginx-https/nginx-https-svc.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/k8s/nginx-openresty/container/docker_build_and_push.bash
+++ b/k8s/nginx-openresty/container/docker_build_and_push.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 docker build -t bigchaindb/nginx_3scale:2.0.0-alpha .
 

--- a/k8s/nginx-openresty/container/nginx_openresty_entrypoint.bash
+++ b/k8s/nginx-openresty/container/nginx_openresty_entrypoint.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 set -euo pipefail
 
 # Openresty vars

--- a/k8s/nginx-openresty/nginx-openresty-dep.yaml
+++ b/k8s/nginx-openresty/nginx-openresty-dep.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/k8s/nginx-openresty/nginx-openresty-svc.yaml
+++ b/k8s/nginx-openresty/nginx-openresty-svc.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/k8s/scripts/generate_configs.sh
+++ b/k8s/scripts/generate_configs.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 set -euo pipefail
 
 source vars

--- a/k8s/toolbox/README.md
+++ b/k8s/toolbox/README.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 ## Docker container with debugging tools
 
 *  curl

--- a/pkg/configuration/bigchaindb-start.yml
+++ b/pkg/configuration/bigchaindb-start.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 - hosts: all
   gather_facts: false
   vars_files:

--- a/pkg/configuration/bigchaindb-stop.yml
+++ b/pkg/configuration/bigchaindb-stop.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 - hosts: all
   vars_files:
     - vars/stack-config.yml

--- a/pkg/configuration/roles/bigchaindb/defaults/main.yml
+++ b/pkg/configuration/roles/bigchaindb/defaults/main.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 dependencies_deb:
   - g++

--- a/pkg/configuration/roles/bigchaindb/tasks/centos.yml
+++ b/pkg/configuration/roles/bigchaindb/tasks/centos.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Creating directories | yum
   file:

--- a/pkg/configuration/roles/bigchaindb/tasks/common.yml
+++ b/pkg/configuration/roles/bigchaindb/tasks/common.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Install pymongo
   pip:

--- a/pkg/configuration/roles/bigchaindb/tasks/debian.yml
+++ b/pkg/configuration/roles/bigchaindb/tasks/debian.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Install dependencies | apt
   apt:

--- a/pkg/configuration/roles/bigchaindb/tasks/fedora.yml
+++ b/pkg/configuration/roles/bigchaindb/tasks/fedora.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Install dependencies | dnf
   dnf:

--- a/pkg/configuration/roles/bigchaindb/tasks/main.yml
+++ b/pkg/configuration/roles/bigchaindb/tasks/main.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Check if Docker is running
   command: docker info

--- a/pkg/configuration/roles/bigchaindb/tasks/start.yml
+++ b/pkg/configuration/roles/bigchaindb/tasks/start.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Building BigchainDB Docker
   docker_image:

--- a/pkg/configuration/roles/bigchaindb/tasks/stop.yml
+++ b/pkg/configuration/roles/bigchaindb/tasks/stop.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Stopping BigchainDB Docker
   docker_container:

--- a/pkg/configuration/roles/docker/defaults/main.yml
+++ b/pkg/configuration/roles/docker/defaults/main.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 uninstall_old_version: false #[true, false]
 docker_edition: 'ce' #[ce, ee] Currently, onlt CE is supported

--- a/pkg/configuration/roles/docker/tasks/centos.yml
+++ b/pkg/configuration/roles/docker/tasks/centos.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Uninstall older versions of Docker | CentOS
   yum:

--- a/pkg/configuration/roles/docker/tasks/debian.yml
+++ b/pkg/configuration/roles/docker/tasks/debian.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Uninstall older versions of Docker | Debian
   apt:

--- a/pkg/configuration/roles/docker/tasks/fedora.yml
+++ b/pkg/configuration/roles/docker/tasks/fedora.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Uninstall older versions of Docker | Fedora
   dnf:

--- a/pkg/configuration/roles/docker/tasks/macos.yml
+++ b/pkg/configuration/roles/docker/tasks/macos.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Check if Docker is Present
   command: docker

--- a/pkg/configuration/roles/docker/tasks/main.yml
+++ b/pkg/configuration/roles/docker/tasks/main.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - import_tasks: debian.yml
   when: distribution_name == "debian" or distribution_name == "ubuntu"

--- a/pkg/configuration/roles/mongodb/defaults/main.yml
+++ b/pkg/configuration/roles/mongodb/defaults/main.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 mongodb_package: "mongodb-org"
 apt_key_fingerprint: "2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"

--- a/pkg/configuration/roles/mongodb/tasks/centos.yml
+++ b/pkg/configuration/roles/mongodb/tasks/centos.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Check if EPEL repo is already configured.
   stat: path={{ epel_repofile_path }}

--- a/pkg/configuration/roles/mongodb/tasks/debian.yml
+++ b/pkg/configuration/roles/mongodb/tasks/debian.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Removing apt cache lists
   file:

--- a/pkg/configuration/roles/mongodb/tasks/fedora.yml
+++ b/pkg/configuration/roles/mongodb/tasks/fedora.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Add MongoDB Repo | dnf
   yum_repository:

--- a/pkg/configuration/roles/mongodb/tasks/main.yml
+++ b/pkg/configuration/roles/mongodb/tasks/main.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Check if Docker is running
   command: docker info

--- a/pkg/configuration/roles/mongodb/tasks/start.yml
+++ b/pkg/configuration/roles/mongodb/tasks/start.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Running MongoDB Docker
   docker_container:

--- a/pkg/configuration/roles/mongodb/tasks/stop.yml
+++ b/pkg/configuration/roles/mongodb/tasks/stop.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Stopping MongoDB Docker
   docker_container:

--- a/pkg/configuration/roles/py36/tasks/centos.yml
+++ b/pkg/configuration/roles/py36/tasks/centos.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Install dependencies py36 | yum
   yum:

--- a/pkg/configuration/roles/py36/tasks/debian.yml
+++ b/pkg/configuration/roles/py36/tasks/debian.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Check if python3 already installed
   shell: which python3

--- a/pkg/configuration/roles/py36/tasks/fedora.yml
+++ b/pkg/configuration/roles/py36/tasks/fedora.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Check version of python3
   shell: "python3 -c 'import platform; print(platform.python_version())' | cut -d. -f-2"

--- a/pkg/configuration/roles/py36/tasks/main.yml
+++ b/pkg/configuration/roles/py36/tasks/main.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - import_tasks: debian.yml
   when: stack_type|lower == "local" and (ansible_distribution|lower == "debian" or ansible_distribution|lower == "ubuntu")

--- a/pkg/configuration/roles/tendermint/defaults/main.yml
+++ b/pkg/configuration/roles/tendermint/defaults/main.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 dependencies_key_exchange:
   - nginx
   - jq

--- a/pkg/configuration/roles/tendermint/tasks/centos.yml
+++ b/pkg/configuration/roles/tendermint/tasks/centos.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Install dependencies | yum
   yum:

--- a/pkg/configuration/roles/tendermint/tasks/common.yml
+++ b/pkg/configuration/roles/tendermint/tasks/common.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 - name: Download Tendermint Binary
   get_url:
     url: "{{ tendermint_binary_url }}"

--- a/pkg/configuration/roles/tendermint/tasks/debian.yml
+++ b/pkg/configuration/roles/tendermint/tasks/debian.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Install dependencies for Tendermint | apt
   apt:

--- a/pkg/configuration/roles/tendermint/tasks/fedora.yml
+++ b/pkg/configuration/roles/tendermint/tasks/fedora.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Install dependencies | dnf
   dnf:

--- a/pkg/configuration/roles/tendermint/tasks/main.yml
+++ b/pkg/configuration/roles/tendermint/tasks/main.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Check if Docker is running
   command: docker info

--- a/pkg/configuration/roles/tendermint/tasks/start.yml
+++ b/pkg/configuration/roles/tendermint/tasks/start.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Building Tendermint Docker
   docker_image:

--- a/pkg/configuration/roles/tendermint/tasks/stop.yml
+++ b/pkg/configuration/roles/tendermint/tasks/stop.yml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 ---
 - name: Stopping Tendermint Containers I
   docker_container:

--- a/pkg/scripts/all-in-one.bash
+++ b/pkg/scripts/all-in-one.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 # MongoDB configuration
 [ "$(stat -c %U /data/db)" = mongodb ] || chown -R mongodb /data/db

--- a/pkg/scripts/bootstrap.sh
+++ b/pkg/scripts/bootstrap.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 BASEDIR="${BASH_SOURCE%/*}"
 if [[ ! -d "$BASEDIR" ]]; then BASEDIR="$PWD"; fi

--- a/pkg/scripts/bootstrap_constants.sh
+++ b/pkg/scripts/bootstrap_constants.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 OS_CONF=/etc/os-release
 declare -a SUPPORTED_OS=('centos' 'fedora' 'ubuntu' 'debian' 'macOS')
 declare -a OS_DEPENDENCIES=('ansible')

--- a/pkg/scripts/bootstrap_helper.sh
+++ b/pkg/scripts/bootstrap_helper.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 BASEDIR="${BASH_SOURCE%/*}"
 if [[ ! -d "$BASEDIR" ]]; then BASEDIR="$PWD"; fi

--- a/pkg/scripts/stack.sh
+++ b/pkg/scripts/stack.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 set -o nounset
 

--- a/pkg/scripts/unstack.sh
+++ b/pkg/scripts/unstack.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 set -o nounset
 

--- a/proposals/extend-post-txn.md
+++ b/proposals/extend-post-txn.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 ## Feature : Add query parameter "mode" to `POST` transaction
 Add new query parameter `mode` to the [post transaction api](https://docs.bigchaindb.com/projects/server/en/latest/http-client-server-api.html#post--api-v1-transactions) such that client can,
 - asynchronously post the transaction

--- a/proposals/integration-test-cases.md
+++ b/proposals/integration-test-cases.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Integration test case suggestions
 This document gives an overview of possible integration test cases, provides some useful links and a specification how to write the Python `docstring` for a test case.
 

--- a/proposals/integration-testing.md
+++ b/proposals/integration-testing.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Integration testing tools for BigchainDB
 
 ## Problem Description

--- a/proposals/migrate-cli.md
+++ b/proposals/migrate-cli.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # Migrate Bigchaindb cli for Tendermint
 
 ## Problem Description

--- a/run-acceptance-test.sh
+++ b/run-acceptance-test.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 # Set up a BigchainDB node and return only when we are able to connect to both
 # the BigchainDB container *and* the Tendermint container.

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """
 BigchainDB: The Blockchain Database
 

--- a/snap/README.md
+++ b/snap/README.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 This is the packaging metadata for the BigchainDB snap.
 
 Snaps and the snap store allows for the secure installation of apps that work

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 name: bigchaindb
 version: git
 summary: The blockchain database

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,3 +1,9 @@
+<!---
+Copyright BigchainDB GmbH and BigchainDB contributors
+SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+Code is Apache-2.0 and docs are CC-BY-4.0
+--->
+
 # BigchainDB Server Tests
 
 ## The tests/ Folder

--- a/tests/assets/test_digital_assets.py
+++ b/tests/assets/test_digital_assets.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 import random
 

--- a/tests/assets/test_divisible_assets.py
+++ b/tests/assets/test_divisible_assets.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 import random
 

--- a/tests/backend/localmongodb/conftest.py
+++ b/tests/backend/localmongodb/conftest.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from pymongo import MongoClient
 from pytest import fixture
 

--- a/tests/backend/localmongodb/test_connection.py
+++ b/tests/backend/localmongodb/test_connection.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from unittest import mock
 
 import pytest

--- a/tests/backend/localmongodb/test_queries.py
+++ b/tests/backend/localmongodb/test_queries.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from copy import deepcopy
 
 import pytest

--- a/tests/backend/localmongodb/test_schema.py
+++ b/tests/backend/localmongodb/test_schema.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 
 

--- a/tests/backend/test_connection.py
+++ b/tests/backend/test_connection.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 
 

--- a/tests/backend/test_generics.py
+++ b/tests/backend/test_generics.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 
 from pytest import mark, raises

--- a/tests/backend/test_utils.py
+++ b/tests/backend/test_utils.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from functools import singledispatch
 from types import ModuleType
 

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from argparse import Namespace
 
 import pytest

--- a/tests/commands/test_commands.py
+++ b/tests/commands/test_commands.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import json
 
 from unittest.mock import Mock, patch

--- a/tests/commands/test_utils.py
+++ b/tests/commands/test_utils.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import argparse
 from argparse import Namespace
 import logging

--- a/tests/common/conftest.py
+++ b/tests/common/conftest.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from base58 import b58decode
 import pytest
 

--- a/tests/common/test_schema.py
+++ b/tests/common/test_schema.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """This module is tests related to schema checking, but _not_ of granular schematic
 properties related to validation.
 """

--- a/tests/common/test_transaction.py
+++ b/tests/common/test_transaction.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """These are tests of the API of the Transaction class and associated classes.
 Tests for transaction validation are separate.
 """

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -1,3 +1,8 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
+
 def validate_transaction_model(tx):
     from bigchaindb.common.transaction import Transaction
     from bigchaindb.common.schema import validate_transaction_schema

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Fixtures and setup / teardown functions
 
 Tasks:

--- a/tests/db/test_bigchain_api.py
+++ b/tests/db/test_bigchain_api.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from time import sleep
 from unittest.mock import patch
 

--- a/tests/tendermint/conftest.py
+++ b/tests/tendermint/conftest.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 import codecs
 

--- a/tests/tendermint/test_core.py
+++ b/tests/tendermint/test_core.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import json
 import pytest
 

--- a/tests/tendermint/test_event_stream.py
+++ b/tests/tendermint/test_event_stream.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import json
 import base64
 from queue import Queue

--- a/tests/tendermint/test_fastquery.py
+++ b/tests/tendermint/test_fastquery.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 
 from bigchaindb.common.transaction import TransactionLink

--- a/tests/tendermint/test_integration.py
+++ b/tests/tendermint/test_integration.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import codecs
 
 import abci.types_pb2 as types

--- a/tests/tendermint/test_lib.py
+++ b/tests/tendermint/test_lib.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import os
 from unittest.mock import patch
 

--- a/tests/tendermint/test_utils.py
+++ b/tests/tendermint/test_utils.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import base64
 import json
 

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import copy
 from unittest.mock import mock_open, patch
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 
 pytestmark = pytest.mark.tendermint

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 
 import subprocess
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 pytestmark = pytest.mark.tendermint
 

--- a/tests/test_txlist.py
+++ b/tests/test_txlist.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """Test getting a list of transactions from the backend.
 
 This test module defines it's own fixture which is used by all the tests.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import queue
 from unittest.mock import patch, call
 

--- a/tests/upsert_validator/conftest.py
+++ b/tests/upsert_validator/conftest.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 
 from bigchaindb.upsert_validator import ValidatorElection

--- a/tests/upsert_validator/test_validator_election.py
+++ b/tests/upsert_validator/test_validator_election.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 
 from bigchaindb.upsert_validator import ValidatorElection

--- a/tests/upsert_validator/test_validator_election_vote.py
+++ b/tests/upsert_validator/test_validator_election_vote.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 
 from bigchaindb.upsert_validator import ValidatorElectionVote

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from functools import singledispatch
 
 from bigchaindb.backend.localmongodb.connection import LocalMongoDBConnection

--- a/tests/validation/test_transaction_structure.py
+++ b/tests/validation/test_transaction_structure.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 """All tests of transaction structure. The concern here is that transaction
 structural / schematic issues are caught when reading a transaction
 (ie going from dict -> transaction).

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 
 

--- a/tests/web/test_assets.py
+++ b/tests/web/test_assets.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 
 ASSETS_ENDPOINT = '/api/v1/assets/'

--- a/tests/web/test_block_tendermint.py
+++ b/tests/web/test_block_tendermint.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 
 from bigchaindb.models import Transaction

--- a/tests/web/test_blocks.py
+++ b/tests/web/test_blocks.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 
 BLOCKS_ENDPOINT = '/api/v1/blocks/'

--- a/tests/web/test_content_type_middleware.py
+++ b/tests/web/test_content_type_middleware.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from unittest.mock import Mock
 
 OUTPUTS_ENDPOINT = '/api/v1/outputs/'

--- a/tests/web/test_info.py
+++ b/tests/web/test_info.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 from unittest import mock
 
 

--- a/tests/web/test_metadata.py
+++ b/tests/web/test_metadata.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 
 METADATA_ENDPOINT = '/api/v1/metadata/'

--- a/tests/web/test_outputs.py
+++ b/tests/web/test_outputs.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 from unittest.mock import MagicMock, patch
 

--- a/tests/web/test_parameters.py
+++ b/tests/web/test_parameters.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 
 

--- a/tests/web/test_server.py
+++ b/tests/web/test_server.py
@@ -1,3 +1,8 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
+
 def test_settings():
     import bigchaindb
     from bigchaindb.web import server

--- a/tests/web/test_transactions.py
+++ b/tests/web/test_transactions.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import json
 from unittest.mock import Mock, patch
 

--- a/tests/web/test_validators.py
+++ b/tests/web/test_validators.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import pytest
 
 pytestmark = pytest.mark.tendermint

--- a/tests/web/test_websocket_server.py
+++ b/tests/web/test_websocket_server.py
@@ -1,3 +1,7 @@
+# Copyright BigchainDB GmbH and BigchainDB contributors
+# SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
+# Code is Apache-2.0 and docs are CC-BY-4.0
+
 import asyncio
 import json
 import queue


### PR DESCRIPTION
Solution: Add comments with SPDX license info to source files

Notes:
- I used the `add-spdx` script from https://github.com/bigchaindb/BEPs/tree/master/tools
- After doing that, I undid the changes it made to the files:
  - `.github/ISSUE_TEMPLATE.md`
  - `.github/PULL_REQUEST_TEMPLATE.md`
  - `k8s/nginx-openresty/LICENSE.md`
  - `k8s/nginx-openresty/container/README.md`
  - `LICENSES.md`
- When I tried to commit the changes, the Git pre-commit checks were failing for Flake8 and PEP257 compliance, so I fixed all the errors and got those checks to pass.
