### PR TITLE
Problem: People reading HTTP API docs not told about the option to query MongoDB directly

### DIFF
--- a/docs/server/source/http-client-server-api.rst
+++ b/docs/server/source/http-client-server-api.rst
@@ -46,6 +46,15 @@ that allows you to discover the BigchainDB API endpoints:
 Transactions
 ------------
 
+.. note::
+
+   If you want to do more sophisticated queries
+   than those provided by the BigchainDB HTTP API,
+   then one option is to connect to MongoDB directly (if possible)
+   and do whatever queries MongoDB allows.
+   For more about that option, see
+   `the page about querying BigchainDB <https://docs.bigchaindb.com/en/latest/query.html>`_.
+
 .. http:get:: /api/v1/transactions/{transaction_id}
 
    Get the transaction with the ID ``transaction_id``.
@@ -179,6 +188,14 @@ The ``/api/v1/outputs`` endpoint returns transactions outputs filtered by a
 given public key, and optionally filtered to only include either spent or
 unspent outputs.
 
+.. note::
+
+   If you want to do more sophisticated queries
+   than those provided by the BigchainDB HTTP API,
+   then one option is to connect to MongoDB directly (if possible)
+   and do whatever queries MongoDB allows.
+   For more about that option, see
+   `the page about querying BigchainDB <https://docs.bigchaindb.com/en/latest/query.html>`_.
 
 .. http:get:: /api/v1/outputs
 
@@ -289,6 +306,15 @@ unspent outputs.
 Assets
 ------
 
+.. note::
+
+   If you want to do more sophisticated queries
+   than those provided by the BigchainDB HTTP API,
+   then one option is to connect to MongoDB directly (if possible)
+   and do whatever queries MongoDB allows.
+   For more about that option, see
+   `the page about querying BigchainDB <https://docs.bigchaindb.com/en/latest/query.html>`_.
+
 .. http:get:: /api/v1/assets
 
    Return all the assets that match a given text search.
@@ -296,10 +322,6 @@ Assets
    :query string search: Text search string to query.
    :query int limit: (Optional) Limit the number of returned assets. Defaults
                      to ``0`` meaning return all matching assets.
-
-   .. note::
-
-        Currently this endpoint is only supported if using MongoDB.
 
 .. http:get:: /api/v1/assets/?search={search}
 
@@ -408,6 +430,15 @@ Assets
 Transaction Metadata
 --------------------
 
+.. note::
+
+   If you want to do more sophisticated queries
+   than those provided by the BigchainDB HTTP API,
+   then one option is to connect to MongoDB directly (if possible)
+   and do whatever queries MongoDB allows.
+   For more about that option, see
+   `the page about querying BigchainDB <https://docs.bigchaindb.com/en/latest/query.html>`_.
+
 .. http:get:: /api/v1/metadata
 
    Return all the metadata objects that match a given text search.
@@ -415,10 +446,6 @@ Transaction Metadata
    :query string search: Text search string to query.
    :query int limit: (Optional) Limit the number of returned metadata objects. Defaults
                      to ``0`` meaning return all matching objects.
-
-   .. note::
-
-        Currently this endpoint is only supported if using MongoDB.
 
 .. http:get:: /api/v1/metadata/?search={search}
 


### PR DESCRIPTION
Solution: Tell them

Note: I also removed some notes about endpoints that only work when using the MongoDB database backend. MongoDB is currently the only supported database backend.