### PR TITLE
Problem: 'backlog' still referenced by some code & comments

### DIFF
--- a/bigchaindb/backend/localmongodb/schema.py
+++ b/bigchaindb/backend/localmongodb/schema.py
@@ -31,8 +31,7 @@ def create_database(conn, dbname):
 
 @register_schema(LocalMongoDBConnection)
 def create_tables(conn, dbname):
-    for table_name in ['transactions', 'utxos', 'assets', 'blocks', 'metadata',
-                       'validators', 'pre_commit']:
+    for table_name in backend.schema.TABLES:
         logger.info('Create `%s` table.', table_name)
         # create the table
         # TODO: read and write concerns can be declared here

--- a/bigchaindb/backend/query.py
+++ b/bigchaindb/backend/query.py
@@ -14,7 +14,7 @@ PRE_COMMIT_ID = 'a_unique_id_string'
 
 @singledispatch
 def store_transaction(connection, signed_transaction):
-    """Write a transaction to the backlog table.
+    """Write a signed transaction to the 'transactions' table.
 
     Args:
         signed_transaction (dict): a signed transaction.

--- a/bigchaindb/backend/schema.py
+++ b/bigchaindb/backend/schema.py
@@ -2,16 +2,7 @@
 # SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
-"""Database creation and schema-providing interfaces for backends.
-
-Attributes:
-    TABLES (tuple): The three standard tables BigchainDB relies on:
-
-        * ``backlog`` for incoming transactions awaiting to be put into
-          a block.
-        * ``bigchain`` for blocks.
-
-"""
+"""Database creation and schema-providing interfaces for backends."""
 
 from functools import singledispatch
 import logging
@@ -23,7 +14,10 @@ from bigchaindb.common.utils import validate_all_values_for_key
 
 logger = logging.getLogger(__name__)
 
-TABLES = ('bigchain', 'backlog', 'assets', 'metadata')
+# Tables/collections that every backend database must create
+TABLES = ('transactions', 'blocks', 'assets', 'metadata',
+          'validators', 'pre_commit', 'utxos')
+
 VALID_LANGUAGES = ('danish', 'dutch', 'english', 'finnish', 'french', 'german',
                    'hungarian', 'italian', 'norwegian', 'portuguese', 'romanian',
                    'russian', 'spanish', 'swedish', 'turkish', 'none',


### PR DESCRIPTION
Solution: Remove all references to 'backlog'.
Also make the tuple of TABLES common to all backend databases.

The "backlog" was a table/collection created by BigchainDB 1.3 and earlier, but it's gone in BigchainDB 2.0.

### Issues Resolved

This PR resolves #2297 
