### PR TITLE
Problem: We use an old cryptoconditions version

### DIFF
--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -94,7 +94,7 @@ class Input(object):
         """
         try:
             fulfillment = self.fulfillment.serialize_uri()
-        except (TypeError, AttributeError, ASN1EncodeError):
+        except (TypeError, AttributeError, ASN1EncodeError, ASN1DecodeError):
             fulfillment = _fulfillment_to_details(self.fulfillment)
 
         try:

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ install_requires = [
     # TODO Consider not installing the db drivers, or putting them in extras.
     'pymongo~=3.6',
     'pysha3~=1.0.2',
-    'cryptoconditions~=0.6.0.dev',
+    'cryptoconditions~=0.7.0',
     'python-rapidjson~=0.6.0',
     'logstats~=0.2.1',
     'flask>=0.10.1',


### PR DESCRIPTION
Solution: upgrade to the latest version of the library

This is only upgrading to the last version. The recent changes in cryptoconditions (not released yet) need to be addressed in a separate PR (and when there is a cryptoconditions release)