### PR TITLE
Problem: unit-test-watch loops forever

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 testpaths = tests/
 norecursedirs = .* *.egg *.egg-info env* devenv* docs
 addopts = -m tendermint
+looponfailroots = bigchaindb tests


### PR DESCRIPTION
Solution: BigchainDB by default writes logs in the same directory it is
run. The `looponfail` feature provided by pytest waits for changes in
the current directory, so it is continuously triggered. This patch tells
pytest to only watch the `bigchaindb` and `tests` directories.
