### PR TITLE
Problem: validating create+transfer might crash the system

### DIFF
--- a/bigchaindb/lib.py
+++ b/bigchaindb/lib.py
@@ -285,7 +285,8 @@ class BigchainDB(object):
         current_spent_transactions = []
         for ctxn in current_transactions:
             for ctxn_input in ctxn.inputs:
-                if ctxn_input.fulfills.txid == txid and\
+                if ctxn_input.fulfills and\
+                   ctxn_input.fulfills.txid == txid and\
                    ctxn_input.fulfills.output == output:
                     current_spent_transactions.append(ctxn)
 


### PR DESCRIPTION
Solution: if a TRANSFER transaction is validated after a CREATE
transaction, the system crashes with `AttributeError: 'NoneType' object
has no attribute 'txid'`.

This happens because querying `get_spent` checks the attributes `txid`
and `output` of `input.fulfills` for every transaction in the current
buffer (`current_transactions`). For a CREATE, `input.fulfills` is None,
so the check would fail.

The solution is to check if `input.fulfills` is defined. If not, then
the current transaction cannot spend any output, so we can safely skip
it.