### PR TITLE
Problem: Need better exception handling for `store_unspent_outputs`

### DIFF
--- a/bigchaindb/backend/localmongodb/query.py
+++ b/bigchaindb/backend/localmongodb/query.py
@@ -228,7 +228,9 @@ def store_unspent_outputs(conn, *unspent_outputs):
                 )
             )
         except DuplicateKeyError:
-            # TODO log warning at least
+            raise DuplicateKeyError(
+                f'Duplicate keys in transactions [{unspent_outputs}].'
+            )
             pass
 
 


### PR DESCRIPTION
Solution: Added an error message in case of a `DuplicateKeyError`