### PR TITLE
Problem: Docs page 'BigchainDB and Smart Contracts' is stale

### DIFF
--- a/docs/root/source/permissions.rst
+++ b/docs/root/source/permissions.rst
@@ -3,6 +3,8 @@
    SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
    Code is Apache-2.0 and docs are CC-BY-4.0
 
+.. _permissions-in-bigchaindb:
+
 Permissions in BigchainDB
 -------------------------
 

--- a/docs/root/source/smart-contracts.rst
+++ b/docs/root/source/smart-contracts.rst
@@ -8,16 +8,8 @@ BigchainDB and Smart Contracts
 
 One can store the source code of any smart contract (i.e. a computer program) in BigchainDB, but BigchainDB won't run arbitrary smart contracts.
 
-BigchainDB will run the subset of smart contracts expressible using `Crypto-Conditions <https://tools.ietf.org/html/draft-thomas-crypto-conditions-03>`_.
+BigchainDB can be used to enforce who has permission to transfer assets, both fungible assets and non-fungible assets. It will prevent double-spending. In other words, a BigchainDB network could be used instead of an ERC-20 (fungible token) or ERC-721 (non-fungible token) smart contract.
 
-The owners of an asset can impose conditions on it that must be met for the asset to be transferred to new owners. Examples of possible conditions (crypto-conditions) include:
+Asset transfer permissions can also be interpreted as write permissions, so they can be used to control who can write to a log, journal or audit trail. There is more about that idea in :ref:`the page about permissions in BigchainDB <permissions-in-bigchaindb>`.
 
-- The current owner must sign the transfer transaction (one which transfers ownership to new owners).
-- Three out of five current owners must sign the transfer transaction.
-- (Shannon and Kelly) or Morgan must sign the transfer transaction.
-
-Crypto-conditions can be quite complex. They can't include loops or recursion and therefore will always run/check in finite time.
-
-.. note::
-
-   We used the word "owners" somewhat loosely above. A more accurate word might be fulfillers, signers, controllers, or transfer-enablers. See the section titled **A Note about Owners** in the relevant `BigchainDB Transactions Spec <https://github.com/bigchaindb/BEPs/tree/master/tx-specs/>`_.
+A BigchainDB network can be connected to other blockchain networks, via oracles or inter-chain communications protocols. That means BigchainDB can be used as part of a solution that uses *other* blockchains to run arbitrary smart contracts.


### PR DESCRIPTION
Solution: Update that page to reflect our current thinking on how BigchainDB relates to smart contracts

- It's weird to think of crypto-conditions as a subset of smart contracts (not really _wrong_, just weird). I deleted that sentence.
- How does BigchainDB relate to ERC-20 and ERC-721 smart contracts (the two most popular kinds AFAIK)?
- Note how asset transfer permissions can also be interpreted as write permissions, with a link to the page about that idea.
- Don't need to elaborate on how complex crypto-conditions can be; that's covered on another page.
- How one can connect a BigchainDB network to other blockchain networks that do run smart contracts.