### PR TITLE
Problem: No MongoDB support for election ID index.

### DIFF
--- a/bigchaindb/backend/localmongodb/schema.py
+++ b/bigchaindb/backend/localmongodb/schema.py
@@ -133,6 +133,3 @@ def create_validators_secondary_index(conn, dbname):
     conn.conn[dbname]['validators'].create_index('height',
                                                  name='height',
                                                  unique=True,)
-    conn.conn[dbname]['validators'].create_index('election_id',
-                                                 name='election_id',
-                                                 unique=True,)

--- a/tests/backend/localmongodb/test_schema.py
+++ b/tests/backend/localmongodb/test_schema.py
@@ -44,7 +44,7 @@ def test_init_creates_db_tables_and_indexes():
     assert set(indexes) == {'_id_', 'pre_commit_id'}
 
     indexes = conn.conn[dbname]['validators'].index_information().keys()
-    assert set(indexes) == {'_id_', 'height', 'election_id'}
+    assert set(indexes) == {'_id_', 'height'}
 
 
 def test_init_database_fails_if_db_exists():


### PR DESCRIPTION
Solution: Election ID has to be unique but not every validator set record has it. MongoDB does not support partial indexes, does not even allow for multiple Nones. This is a temporary fix since we are introducing an `election` collection to store election IDs in #2498.