### PR TITLE
Add Troubleshooting page to Simple Deployment Template

### DIFF
--- a/docs/server/source/simple-deployment-template/index.rst
+++ b/docs/server/source/simple-deployment-template/index.rst
@@ -18,3 +18,4 @@ We also have a :ref:`kubernetes-deployment-template` (not simple).
    :maxdepth: 1
 
    network-setup
+   troubleshooting

--- a/docs/server/source/simple-deployment-template/network-setup.md
+++ b/docs/server/source/simple-deployment-template/network-setup.md
@@ -323,19 +323,6 @@ Check `bigchaindb-monit-config -h` if you want to arrange a different folder for
 
 If you followed the above instructions, then your node should be publicly-accessible with BigchainDB Root URL `http://hostname:9984` (where hostname is something like `bdb7.canada.vmsareus.net` or `17.122.200.76`). That is, anyone can interact with your node using the [BigchainDB HTTP API](http-client-server-api.html) exposed at that address. The most common way to do that is to use one of the [BigchainDB Drivers](./drivers-clients/index.html).
 
-## Troubleshooting
-
-To check which nodes your node is connected to (via Tendermint protocols), do:
-
-```text
-# if you don't jq installed, then install it
-sudo apt install jq
-# then do
-curl -s localhost:26657/net_info | jq ".result.peers[].node_info | {id, listen_addr, moniker}"
-```
-
-Tendermint has other endpoints besides `/net_info`: see [the Tendermint RPC docs](https://tendermint.github.io/slate/?shell#introduction).
-
 ## Refreshing Your Node
 
 If you want to refresh your node back to a fresh empty state, then your best bet is to terminate it and deploy a new virtual machine, but if that's not an option, then you can:

--- a/docs/server/source/simple-deployment-template/troubleshooting.md
+++ b/docs/server/source/simple-deployment-template/troubleshooting.md
@@ -1,0 +1,29 @@
+# Troubleshooting
+
+## General Tips
+
+- Check the BigchainDB, Tendermint and MongoDB logs.
+- Try Googling the error message.
+
+## Resolving Tendermint Connectivity Problems
+
+To check which nodes your node is connected to (via Tendermint protocols), do:
+
+```text
+# if you don't have jq installed, then install it
+sudo apt install jq
+# then do
+curl -s localhost:26657/net_info | jq ".result.peers[].node_info | {id, listen_addr, moniker}"
+```
+
+Note: Tendermint has other endpoints besides `/net_info`: see [the Tendermint RPC docs](https://tendermint.github.io/slate/?shell#introduction).
+
+If you're running your network inside a [private network](https://en.wikipedia.org/wiki/Private_network), e.g. with IP addresses of the form 192.168.x.y, then you may have to change the following setting in `config.toml`:
+
+```text
+addr_book_strict = false
+```
+
+## Other Problems
+
+If you're stuck, maybe [file a new issue on GitHub](https://github.com/bigchaindb/bigchaindb/issues/new). If your problem occurs often enough, we'll write about it here.


### PR DESCRIPTION
This pull request creates a new stand-alone **Troubleshooting** page in the **Simple Deployment Template**.

- Created the new page
- Moved the existing "Troubleshooting" subsection from the existing `network-setup` page
- Added instructions for people running in a private network. This is based on an actual issue that arose with a user in the past week.
- Added some other general tips and advice
- Left room to add more tips in the future