### PR TITLE
Problem: Bigchaindb crashes when restarted after init chain

### DIFF
--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -232,12 +232,13 @@ class App(BaseApplication):
         # register a new block only when new transactions are received
         if self.block_txn_ids:
             self.bigchaindb.store_bulk_transactions(self.block_transactions)
-            block = Block(app_hash=self.block_txn_hash,
-                          height=self.new_height,
-                          transactions=self.block_txn_ids)
-            # NOTE: storing the block should be the last operation during commit
-            # this effects crash recovery. Refer BEP#8 for details
-            self.bigchaindb.store_block(block._asdict())
+
+        block = Block(app_hash=self.block_txn_hash,
+                      height=self.new_height,
+                      transactions=self.block_txn_ids)
+        # NOTE: storing the block should be the last operation during commit
+        # this effects crash recovery. Refer BEP#8 for details
+        self.bigchaindb.store_block(block._asdict())
 
         logger.debug('Commit-ing new block with hash: apphash=%s ,'
                      'height=%s, txn ids=%s', data, self.new_height,

--- a/tests/tendermint/test_integration.py
+++ b/tests/tendermint/test_integration.py
@@ -101,7 +101,7 @@ def test_app(b, init_chain_request):
 
     block0 = b.get_latest_block()
     assert block0
-    assert block0['height'] == 1
+    assert block0['height'] == 2
 
     # when empty block is generated hash of previous block should be returned
     assert block0['app_hash'] == new_block_hash


### PR DESCRIPTION
Solution: Return appropriate height so that Tendermint doesn't execute `init_chain` more than once

Fixes #2518