### PR TITLE
Problem: Docs say install highest Tendermint version

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -45,6 +45,7 @@ The following steps are what we do to release a new version of _BigchainDB Serve
    - In `bigchaindb/version.py`:
      - update `__version__` to e.g. `0.9.0` (with no `.dev` on the end)
      - update `__short_version__` to e.g. `0.9` (with no `.dev` on the end)
+   - In the docs about installing BigchainDB (and Tendermint), and in the associated scripts, recommend/install a version of Tendermint that _actually works_ with the soon-to-be-released version of BigchainDB. You can find all such references by doing a search for the previously-recommended version number, such as `0.22.8`.
    - In `setup.py`, _maybe_ update the development status item in the `classifiers` list. For example, one allowed value is `"Development Status :: 5 - Production/Stable"`. The [allowed values are listed at pypi.python.org](https://pypi.python.org/pypi?%3Aaction=list_classifiers).
 
 1. **Wait for all the tests to pass!**

--- a/docs/contributing/source/dev-setup-coding-and-contribution-process/run-node-as-processes.md
+++ b/docs/contributing/source/dev-setup-coding-and-contribution-process/run-node-as-processes.md
@@ -25,7 +25,7 @@ After the installation of MongoDB is complete, run MongoDB using `sudo mongod`
 
 ### Installing a Tendermint Executable
 
-Find [the version number of the latest Tendermint release](https://github.com/tendermint/tendermint/releases) and install it using the following, where 0.22.8 should be replaced by the latest released version number:
+The version of BigchainDB Server described in these docs only works well with Tendermint 0.22.8 (not a higher version number). Install that:
 
 ```bash
 $ sudo apt install -y unzip

--- a/docs/server/source/simple-deployment-template/network-setup.md
+++ b/docs/server/source/simple-deployment-template/network-setup.md
@@ -85,7 +85,7 @@ Note: The `mongodb` package is _not_ the official MongoDB package from MongoDB t
 
 #### Install Tendermint
 
-Install a [recent version of Tendermint][tendermint:releases]. BigchainDB Server requires version 0.22.8 or newer.
+The version of BigchainDB Server described in these docs only works well with Tendermint 0.22.8 (not a higher version number). Install that:
 
 ```
 sudo apt install -y unzip


### PR DESCRIPTION
Solution: Change the docs to recommend installing a specific Tendermint version.
Also update our release process so we change that version number before a release, if necessary.
