### PR TITLE
Problem: Test fails if Tendermint is not up.

### DIFF
--- a/tests/web/test_outputs.py
+++ b/tests/web/test_outputs.py
@@ -71,6 +71,7 @@ def test_get_outputs_endpoint_with_invalid_spent(client, user_pk):
     assert res.status_code == 400
 
 
+@pytest.mark.abci
 @pytest.mark.bdb
 @pytest.mark.usefixtures('inputs')
 def test_get_divisble_transactions_returns_500(b, client):


### PR DESCRIPTION
Solution: Mark the test with the abci mark since it requires running BigchainDB and Tendermint. Fails since the mark cleanup in #2522.
