### PR TITLE
Problem: Sphinx deprecated a config option

### DIFF
--- a/docs/server/source/conf.py
+++ b/docs/server/source/conf.py
@@ -60,9 +60,9 @@ extensions = [
 
 # autodoc settings
 autodoc_member_order = 'bysource'
-autodoc_default_flags = [
-    'members',
-]
+autodoc_default_options = {
+    'members': None,
+}
 
 todo_include_todos = True
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ dev_require = [
 ]
 
 docs_require = [
-    'Sphinx>=1.4.8',
+    'Sphinx~=1.0',
     'recommonmark>=0.4.0',
     'sphinx-rtd-theme>=0.1.9',
     'sphinxcontrib-httpdomain>=1.5.0',


### PR DESCRIPTION
Solution: Move from `autodoc_default_flags` to
`autodoc_default_options`.

Related issue:
- https://github.com/sphinx-doc/sphinx/issues/5421