### PR TITLE
Make requirements.txt files consistent with setup.py

### DIFF
--- a/docs/contributing/requirements.txt
+++ b/docs/contributing/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx>=1.4.8
+Sphinx~=1.0
 recommonmark>=0.4.0
 sphinx-rtd-theme>=0.1.9
 wget

--- a/docs/root/requirements.txt
+++ b/docs/root/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx>=1.4.8
+Sphinx~=1.0
 recommonmark>=0.4.0
 sphinx-rtd-theme>=0.1.9
 sphinxcontrib-napoleon>=0.4.4

--- a/docs/server/requirements.txt
+++ b/docs/server/requirements.txt
@@ -1,7 +1,7 @@
-Sphinx>=1.4.8
+Sphinx~=1.0
 recommonmark>=0.4.0
 sphinx-rtd-theme>=0.1.9
 sphinxcontrib-napoleon>=0.4.4
 sphinxcontrib-httpdomain>=1.5.0
-pyyaml>=3.12
+pyyaml~=3.12
 aafigure>=0.6


### PR DESCRIPTION
I forgot about the `requirements.txt` files when reviewing pull request #2537 but was reminded of them when I created its analogue for the Python driver.