### PR TITLE
Update the list of MongoDB collections in query.rst

### DIFF
--- a/docs/root/source/query.rst
+++ b/docs/root/source/query.rst
@@ -61,8 +61,10 @@ For example, if you're on a machine that's running a default BigchainDB node, th
     > use bigchain
     switched to db bigchain
     > show collections
+    abci_chains
     assets
     blocks
+    elections
     metadata
     pre_commit
     transactions


### PR DESCRIPTION
I added the recently-added collections `abci_chains` and `elections` to the list of collections given in the docs page about querying MongoDB. I'm not sure if we can expect more MongoDB collections in the near future. @z-bowen do you know?