### PR TITLE
List the "blocks" endpoint in response to HTTP info requests

### DIFF
--- a/bigchaindb/web/views/info.py
+++ b/bigchaindb/web/views/info.py
@@ -47,6 +47,7 @@ def get_api_v1_info(api_prefix):
     return {
         'docs': ''.join(docs_url),
         'transactions': '{}transactions/'.format(api_prefix),
+        'blocks': '{}blocks/'.format(api_prefix),
         'assets': '{}assets/'.format(api_prefix),
         'outputs': '{}outputs/'.format(api_prefix),
         'streams': websocket_root,

--- a/docs/server/source/http-client-server-api.rst
+++ b/docs/server/source/http-client-server-api.rst
@@ -616,14 +616,8 @@ Validators
    :statuscode 200: The query was executed successfully and validators set was returned.
 
 
-Advanced Usage
---------------------------------
-
-The following endpoints are more advanced
-and meant for debugging and transparency purposes.
-
 Blocks
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------
 
 .. http:get:: /api/v1/blocks/{block_height}
 

--- a/tests/web/test_info.py
+++ b/tests/web/test_info.py
@@ -16,6 +16,7 @@ def test_api_root_endpoint(client, wsserver_base_url):
             'v1': {
                 'docs': ''.join(docs_url),
                 'transactions': '/api/v1/transactions/',
+                'blocks': '/api/v1/blocks/',
                 'assets': '/api/v1/assets/',
                 'outputs': '/api/v1/outputs/',
                 'streams': '{}/api/v1/streams/valid_transactions'.format(
@@ -38,6 +39,7 @@ def test_api_v1_endpoint(client, wsserver_base_url):
     api_v1_info = {
         'docs': ''.join(docs_url),
         'transactions': '/transactions/',
+        'blocks': '/blocks/',
         'assets': '/assets/',
         'outputs': '/outputs/',
                 'streams': '{}/api/v1/streams/valid_transactions'.format(


### PR DESCRIPTION
- Added the "blocks" endpoint to the list of endpoints returned when one sends a request to the BigchainDB Root URL or the API Root Endpoint.
- Also got rid of the "Advanced Usage" section of the HTTP API docs because it only included the "blocks" endpoints and they really aren't that advanced.

Resolves #2544 
