### PR TITLE
Copy-edited the log rotation page (docs)

### DIFF
--- a/docs/server/source/appendices/log-rotation.md
+++ b/docs/server/source/appendices/log-rotation.md
@@ -24,21 +24,12 @@ and [log rotation](https://docs.mongodb.com/v3.6/tutorial/rotate-log-files/).
 
 ## BigchainDB Server Logging and Log Rotation
 
-BigchainDB Server writes its logs to the files:
+BigchainDB Server writes its logs to two files: normal logs and error logs. The names of those files, and their locations, are set as part of the BigchainDB configuration settings. The default names and locations are:
 
-- `bigchaindb.log`
-- `bigchaindb-errors.log`
-- `bigchaindb-benchmark.log`
+- `~/bigchaindb.log`
+- `~/bigchaindb-errors.log`
 
-The default is for those files to be created in the same directory where you ran `bigchaindb start`.
-If you started BigchainDB Server and Tendermint using Monit, as suggested by our guide on
-[How to Set Up a BigchainDB Network](../simple-deployment-template/network-setup.html),
-then the logs will be written to `$HOME/.bigchaindb-monit/logs/`.
-
-Log rotation is baked into BigchainDB Server using Python's `logging` module.
-The logs for BigchainDB Server are rotated when any of the above mentioned files exceeds 209715200 bytes (i.e. approximately 209 MB).
-
-See also: [the BigchainDB Server configuration settings related to logging](../server-reference/configuration.html#log).
+For more information, see the docs about [the BigchainDB Server configuration settings related to logging](../server-reference/configuration.html#log).
 
 ## Tendermint Logging and Log Rotation
 

--- a/docs/server/source/appendices/log-rotation.md
+++ b/docs/server/source/appendices/log-rotation.md
@@ -38,6 +38,8 @@ then the logs will be written to `$HOME/.bigchaindb-monit/logs/`.
 Log rotation is baked into BigchainDB Server using Python's `logging` module.
 The logs for BigchainDB Server are rotated when any of the above mentioned files exceeds 209715200 bytes (i.e. approximately 209 MB).
 
+See also: [the BigchainDB Server configuration settings related to logging](../server-reference/configuration.html#log).
+
 ## Tendermint Logging and Log Rotation
 
 Tendermint writes its logs to the files:

--- a/docs/server/source/appendices/log-rotation.md
+++ b/docs/server/source/appendices/log-rotation.md
@@ -29,6 +29,8 @@ BigchainDB Server writes its logs to two files: normal logs and error logs. The 
 - `~/bigchaindb.log`
 - `~/bigchaindb-errors.log`
 
+Log rotation is baked into BigchainDB Server using Python's `logging` module. The logs for BigchainDB Server are rotated when any of the above mentioned files exceeds 209715200 bytes (i.e. approximately 209 MB).
+
 For more information, see the docs about [the BigchainDB Server configuration settings related to logging](../server-reference/configuration.html#log).
 
 ## Tendermint Logging and Log Rotation

--- a/docs/server/source/appendices/log-rotation.md
+++ b/docs/server/source/appendices/log-rotation.md
@@ -4,45 +4,51 @@ SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
 Code is Apache-2.0 and docs are CC-BY-4.0
 --->
 
-# Log rotation for a BigchainDB node
+# Logging and Log Rotation
 
-Each BigchainDB node comprises of 3 main services:
-  - BigchainDB server
-  - Tendermint
-  - MongoDB
+Each BigchainDB node runs:
 
-To run a BigchainDB test network/dev node, that is expected to run for relatively longer periods
-of time, we need to consider the log rotation of these services i.e. we do not want the logs taking
-up large amounts of storage and making the node unresponsive or get into bad state.
+- MongoDB
+- BigchainDB Server
+- Tendermint
 
-## Log rotation for MongoDB
+When running a BigchainDB node for long periods
+of time, we need to consider doing log rotation, i.e. we do not want the logs taking
+up large amounts of storage and making the node unresponsive or getting it into a bad state.
 
-Currently, we leave the log rotation of MongoDB to the BigchainDB administrator. For more notes on MongoDB log rotation
-please refer to [MongoDB docs](https://docs.mongodb.com/v3.6/tutorial/rotate-log-files/).
+## MongoDB Logging and Log Rotation
 
-## Log rotation for BigchainDB
+See the MongoDB docs about
+[logging](https://docs.mongodb.com/v3.6/administration/monitoring/#monitoring-standard-loggging)
+and [log rotation](https://docs.mongodb.com/v3.6/tutorial/rotate-log-files/).
 
-Log rotation is baked into BigchainDB server using the `logging` module. BigchainDB server logs information into the following files:
- - `bigchaindb.log`
- - `bigchaindb-errors.log`
- - `bigchaindb-benchmark.log`
+## BigchainDB Server Logging and Log Rotation
 
-These log files are created by default in the directory from where you run `bigchaindb start`, if you are using `monit`, from 
-[How to Set Up a BigchainDB Network](../simple-deployment-template/network-setup.md) guide, the default directory is: `$HOME/.bigchaindb-monit/logs`
+BigchainDB Server writes its logs to the files:
 
-The logs for BigchainDB server are rotated when any of the above mentioned file exceeds `209715200 bytes (i.e. approximately 209 MB).`.
+- `bigchaindb.log`
+- `bigchaindb-errors.log`
+- `bigchaindb-benchmark.log`
 
+The default is for those files to be created in the same directory where you ran `bigchaindb start`.
+If you started BigchainDB Server and Tendermint using Monit, as suggested by our guide on
+[How to Set Up a BigchainDB Network](../simple-deployment-template/network-setup.html),
+then the logs will be written to `$HOME/.bigchaindb-monit/logs/`.
 
-## Log rotation for Tendermint
+Log rotation is baked into BigchainDB Server using Python's `logging` module.
+The logs for BigchainDB Server are rotated when any of the above mentioned files exceeds 209715200 bytes (i.e. approximately 209 MB).
 
-In order to set up log rotation of Tendermint, you will need to use the [Monit]( https://www.mmonit.com/monit) scripts provided by us. Covered in the [How to Set Up a BigchainDB Network](../simple-deployment-template/network-setup.md) guide.
+## Tendermint Logging and Log Rotation
 
-```bash
-$ monit -d 1
-```
+Tendermint writes its logs to the files:
 
-Monit monitors both Tendermint and BigchainDB processes as well as the Tendermint log files, `tendermint.out.log` and `tendermint.err.log`. Default location for these log files is:
-`$HOME/.bigchaindb-monit/logs`.
+- `tendermint.out.log`
+- `tendermint.err.log`
 
-Tendermint logs are rotated if any of the above mentioned log files exceeds `200 MB` in size.
+If you started BigchainDB Server and Tendermint using Monit, as suggested by our guide on
+[How to Set Up a BigchainDB Network](../simple-deployment-template/network-setup.html),
+then the logs will be written to `$HOME/.bigchaindb-monit/logs/`.
 
+Moreover, if you started BigchainDB Server and Tendermint using Monit,
+then Monit monitors the Tendermint log files.
+Tendermint logs are rotated if any of the above mentioned log files exceeds 200 MB.

--- a/docs/server/source/server-reference/configuration.md
+++ b/docs/server/source/server-reference/configuration.md
@@ -269,11 +269,11 @@ The full path to the file where logs should be written.
 The user running `bigchaindb` must have write access to the
 specified path.
 
-**Log rotation:** Log files have a size limit of 200 MB
+**Log rotation:** Log files have a size limit of about 200 MB
 and will be rotated up to five times.
-For example, if we `log.file` is set to `"~/bigchain.log"`, then
+For example, if `log.file` is set to `"~/bigchain.log"`, then
 logs would always be written to `bigchain.log`. Each time the file
-`bigchain.log` reaches 200 MB it would be closed and renamed
+`bigchain.log` reaches 200 MB it will be closed and renamed
 `bigchain.log.1`. If `bigchain.log.1` and `bigchain.log.2` already exist they
 would be renamed `bigchain.log.2` and `bigchain.log.3`. This pattern would be
 applied up to `bigchain.log.5` after which `bigchain.log.5` would be

--- a/docs/server/source/simple-deployment-template/network-setup.md
+++ b/docs/server/source/simple-deployment-template/network-setup.md
@@ -356,6 +356,9 @@ If you started BigchainDB in the foreground, a `Ctrl + C` or `Ctrl + Z` would sh
 
 TBD.
 
+## Logging and Log Rotation
+
+See the page in the Appendices about [logging and log rotation](../appendices/log-rotation.html).
 
 [bdb:software]: https://github.com/bigchaindb/bigchaindb/
 [bdb:pypi]: https://pypi.org/project/BigchainDB/#history

--- a/docs/server/source/simple-deployment-template/network-setup.md
+++ b/docs/server/source/simple-deployment-template/network-setup.md
@@ -356,10 +356,6 @@ If you started BigchainDB in the foreground, a `Ctrl + C` or `Ctrl + Z` would sh
 
 TBD.
 
-## Log rotation
-
-Please go over the [document describing log rotation of a BigchainDB node](../appendices/log-rotation.md).
-
 
 [bdb:software]: https://github.com/bigchaindb/bigchaindb/
 [bdb:pypi]: https://pypi.org/project/BigchainDB/#history

--- a/docs/server/source/simple-deployment-template/troubleshooting.md
+++ b/docs/server/source/simple-deployment-template/troubleshooting.md
@@ -3,6 +3,7 @@
 ## General Tips
 
 - Check the BigchainDB, Tendermint and MongoDB logs.
+  For help with that, see the page about [Logging and Log Rotation](../appendices/log-rotation.html).
 - Try Googling the error message.
 
 ## Resolving Tendermint Connectivity Problems


### PR DESCRIPTION
I did my best not to change the meaning of anything in the page. I just rearranged the three subsections (MongoDB, BigchainDB Server, Tendermint) to have parallel structure.

- Changed the titles to include both "Logging" and "Log Rotation"
- Added a hyperlink to MongoDB's docs about logging (and kept the existing link to the MongoDB docs about log rotation).
- Fixed the two hyperlinks to **How to Set Up a BigchainDB Network**.
- Added link to the BigchainDB Server configuration settings related to logging.
- In the **Troubleshooting** page, added a link to the page about **Logging and Log Rotation**.