### PR TITLE
Problem: send function has a deprecation warning in the driver

### DIFF
--- a/acceptance/python/src/test_basic.py
+++ b/acceptance/python/src/test_basic.py
@@ -61,7 +61,7 @@ def test_basic():
     bike_id = fulfilled_creation_tx['id']
 
     # Now she is ready to send it to the BigchainDB Network.
-    sent_transfer_tx = bdb.transactions.send(fulfilled_creation_tx)
+    sent_transfer_tx = bdb.transactions.send_commit(fulfilled_creation_tx)
 
     # And just to be 100% sure, she also checks if she can retrieve
     # it from the BigchainDB node.
@@ -107,7 +107,7 @@ def test_basic():
             private_keys=alice.private_key)
 
     # She finally sends the transaction to a BigchainDB node.
-    sent_transfer_tx = bdb.transactions.send(fulfilled_transfer_tx)
+    sent_transfer_tx = bdb.transactions.send_commit(fulfilled_transfer_tx)
 
     # And just to be 100% sure, she also checks if she can retrieve
     # it from the BigchainDB node.

--- a/acceptance/python/src/test_divisible_asset.py
+++ b/acceptance/python/src/test_divisible_asset.py
@@ -74,7 +74,7 @@ def test_divisible_assets():
         prepared_token_tx,
         private_keys=alice.private_key)
 
-    bdb.transactions.send(fulfilled_token_tx, mode='commit')
+    bdb.transactions.send_commit(fulfilled_token_tx)
 
     # We store the `id` of the transaction to use it later on.
     bike_token_id = fulfilled_token_tx['id']
@@ -116,8 +116,7 @@ def test_divisible_assets():
         prepared_transfer_tx,
         private_keys=bob.private_key)
 
-    sent_transfer_tx = bdb.transactions.send(fulfilled_transfer_tx,
-                                             mode='commit')
+    sent_transfer_tx = bdb.transactions.send_commit(fulfilled_transfer_tx)
 
     # First, Bob checks if the transaction was successful.
     assert bdb.transactions.retrieve(
@@ -167,7 +166,7 @@ def test_divisible_assets():
     # Remember Bob, last time you spent 3 tokens already,
     # so you only have 7 left.
     with pytest.raises(BadRequest) as error:
-        bdb.transactions.send(fulfilled_transfer_tx, mode='commit')
+        bdb.transactions.send_commit(fulfilled_transfer_tx)
 
     # Now Bob gets an error saying that the amount he wanted to spent is
     # higher than the amount of tokens he has left.

--- a/acceptance/python/src/test_double_spend.py
+++ b/acceptance/python/src/test_double_spend.py
@@ -30,7 +30,7 @@ def test_double_create():
 
     def send_and_queue(tx):
         try:
-            bdb.transactions.send(tx)
+            bdb.transactions.send_commit(tx)
             results.put('OK')
         except bigchaindb_driver.exceptions.TransportError as e:
             results.put('FAIL')

--- a/acceptance/python/src/test_multiple_owners.py
+++ b/acceptance/python/src/test_multiple_owners.py
@@ -64,7 +64,7 @@ def test_multiple_owners():
         prepared_dw_tx,
         private_keys=[alice.private_key, bob.private_key])
 
-    bdb.transactions.send(fulfilled_dw_tx, mode='commit')
+    bdb.transactions.send_commit(fulfilled_dw_tx)
 
     # We store the `id` of the transaction to use it later on.
     dw_id = fulfilled_dw_tx['id']
@@ -109,8 +109,7 @@ def test_multiple_owners():
         prepared_transfer_tx,
         private_keys=[alice.private_key, bob.private_key])
 
-    sent_transfer_tx = bdb.transactions.send(fulfilled_transfer_tx,
-                                             mode='commit')
+    sent_transfer_tx = bdb.transactions.send_commit(fulfilled_transfer_tx)
 
     # They check if the transaction was successful.
     assert bdb.transactions.retrieve(

--- a/acceptance/python/src/test_naughty_strings.py
+++ b/acceptance/python/src/test_naughty_strings.py
@@ -54,7 +54,7 @@ def send_naughty_tx(asset, metadata):
 
     # The fulfilled tx gets sent to the BDB network
     try:
-        sent_transaction = bdb.transactions.send(fulfilled_transaction)
+        sent_transaction = bdb.transactions.send_commit(fulfilled_transaction)
     except BadRequest as e:
         sent_transaction = e
 

--- a/acceptance/python/src/test_stream.py
+++ b/acceptance/python/src/test_stream.py
@@ -100,7 +100,7 @@ def test_stream():
         # transactions to be in the shared queue: this is a two phase test,
         # first we send a bunch of transactions, then we check if they are
         # valid (and, in this case, they should).
-        bdb.transactions.send(tx, mode='async')
+        bdb.transactions.send_async(tx)
 
         # The `id` of every sent transaction is then stored in a list.
         sent.append(tx['id'])


### PR DESCRIPTION
Solution: replace send with the matching new functions

As you might have noticed when running the test, the driver has a deprecation warning for the `send()` function to send a transaction. We use it in the acceptance tests. Since we want to remove the `send()` in the next driver release, I'm preparing the server for the changes.