### PR TITLE
Problem: bigchaindb not starting because of a module dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ install_requires = [
     'aiohttp~=3.0',
     'bigchaindb-abci==0.5.1',
     'setproctitle~=1.1.0',
+    'packaging~=17.0',
 ]
 
 setup(


### PR DESCRIPTION
## Solution

Add `packaging` module to setup.py.

