### PR TITLE
Adjust multiple elections conclusion.

### DIFF
--- a/bigchaindb/backend/localmongodb/query.py
+++ b/bigchaindb/backend/localmongodb/query.py
@@ -283,12 +283,11 @@ def store_validator_set(conn, validators_update):
 
 @register_query(LocalMongoDBConnection)
 def store_election_results(conn, election):
-    height = election['height']
     return conn.run(
         conn.collection('elections').replace_one(
-            {'height': height},
+            {'election_id': election['election_id']},
             election,
-            upsert=True
+            upsert=True,
         )
     )
 

--- a/bigchaindb/migrations/chain_migration_election.py
+++ b/bigchaindb/migrations/chain_migration_election.py
@@ -10,6 +10,15 @@ class ChainMigrationElection(Election):
     TX_SCHEMA_CUSTOM = TX_SCHEMA_CHAIN_MIGRATION_ELECTION
     CHANGES_VALIDATOR_SET = False
 
+    def has_concluded(self, bigchaindb, *args, **kwargs):
+        chain = bigchaindb.get_latest_abci_chain()
+        if chain is not None and not chain['is_synced']:
+            # do not conclude the migration election if
+            # there is another migration in progress
+            return False
+
+        return super().has_concluded(bigchaindb, *args, **kwargs)
+
     @classmethod
     def on_approval(cls, bigchain, election, new_height):
         bigchain.migrate_abci_chain()

--- a/tests/elections/test_election.py
+++ b/tests/elections/test_election.py
@@ -1,64 +1,143 @@
-from unittest.mock import MagicMock
-
 import pytest
 
+from tests.utils import generate_election, generate_validators
+
+from bigchaindb.lib import Block
 from bigchaindb.elections.election import Election
+from bigchaindb.migrations.chain_migration_election import ChainMigrationElection
+from bigchaindb.upsert_validator.validator_election import ValidatorElection
 
 
 @pytest.mark.bdb
-def test_approved_elections_one_migration_one_upsert(
-        b,
-        ongoing_validator_election, validator_election_votes,
-        ongoing_chain_migration_election, chain_migration_election_votes
-):
-    txns = validator_election_votes + \
-           chain_migration_election_votes
-    mock_chain_migration, mock_store_validator = run_approved_elections(b, txns)
-    mock_chain_migration.assert_called_once()
-    mock_store_validator.assert_called_once()
+def test_approved_elections_concludes_all_elections(b):
+    validators = generate_validators([1] * 4)
+    b.store_validator_set(1, [v['storage'] for v in validators])
+
+    new_validator = generate_validators([1])[0]
+
+    public_key = validators[0]['public_key']
+    private_key = validators[0]['private_key']
+    election, votes = generate_election(b,
+                                        ValidatorElection,
+                                        public_key, private_key,
+                                        new_validator['election'])
+    txs = [election]
+    total_votes = votes
+
+    election, votes = generate_election(b,
+                                        ChainMigrationElection,
+                                        public_key, private_key,
+                                        {})
+
+    txs += [election]
+    total_votes += votes
+
+    b.store_abci_chain(1, 'chain-X')
+    b.store_block(Block(height=1,
+                        transactions=[tx.id for tx in txs],
+                        app_hash='')._asdict())
+    b.store_bulk_transactions(txs)
+
+    Election.approved_elections(b, 1, total_votes)
+
+    validators = b.get_validators()
+    assert len(validators) == 5
+    assert new_validator['storage'] in validators
+
+    chain = b.get_latest_abci_chain()
+    assert chain
+    assert chain == {
+        'height': 2,
+        'is_synced': False,
+        'chain_id': 'chain-X-migrated-at-height-1',
+    }
+
+    for tx in txs:
+        election = b.get_election(tx.id)
+        assert election
 
 
 @pytest.mark.bdb
-def test_approved_elections_one_migration_two_upsert(
-        b,
-        ongoing_validator_election, validator_election_votes,
-        ongoing_validator_election_2, validator_election_votes_2,
-        ongoing_chain_migration_election, chain_migration_election_votes
-):
-    txns = validator_election_votes + \
-           validator_election_votes_2 + \
-           chain_migration_election_votes
-    mock_chain_migration, mock_store_validator = run_approved_elections(b, txns)
-    mock_chain_migration.assert_called_once()
-    mock_store_validator.assert_called_once()
+def test_approved_elections_applies_only_one_validator_update(b):
+    validators = generate_validators([1] * 4)
+    b.store_validator_set(1, [v['storage'] for v in validators])
+
+    new_validator = generate_validators([1])[0]
+
+    public_key = validators[0]['public_key']
+    private_key = validators[0]['private_key']
+    election, votes = generate_election(b,
+                                        ValidatorElection,
+                                        public_key, private_key,
+                                        new_validator['election'])
+    txs = [election]
+    total_votes = votes
+
+    another_validator = generate_validators([1])[0]
+
+    election, votes = generate_election(b,
+                                        ValidatorElection,
+                                        public_key, private_key,
+                                        another_validator['election'])
+    txs += [election]
+    total_votes += votes
+
+    b.store_block(Block(height=1,
+                        transactions=[tx.id for tx in txs],
+                        app_hash='')._asdict())
+    b.store_bulk_transactions(txs)
+
+    Election.approved_elections(b, 1, total_votes)
+
+    validators = b.get_validators()
+    assert len(validators) == 5
+    assert new_validator['storage'] in validators
+    assert another_validator['storage'] not in validators
+
+    assert b.get_election(txs[0].id)
+    assert not b.get_election(txs[1].id)
 
 
 @pytest.mark.bdb
-def test_approved_elections_two_migrations_one_upsert(
-        b,
-        ongoing_validator_election, validator_election_votes,
-        ongoing_chain_migration_election, chain_migration_election_votes,
-        ongoing_chain_migration_election_2, chain_migration_election_votes_2
-):
-    txns = validator_election_votes + \
-           chain_migration_election_votes + \
-           chain_migration_election_votes_2
-    mock_chain_migration, mock_store_validator = run_approved_elections(b, txns)
-    assert mock_chain_migration.call_count == 2
-    mock_store_validator.assert_called_once()
+def test_approved_elections_applies_only_one_migration(b):
+    validators = generate_validators([1] * 4)
+    b.store_validator_set(1, [v['storage'] for v in validators])
+
+    public_key = validators[0]['public_key']
+    private_key = validators[0]['private_key']
+    election, votes = generate_election(b,
+                                        ChainMigrationElection,
+                                        public_key, private_key,
+                                        {})
+    txs = [election]
+    total_votes = votes
+
+    election, votes = generate_election(b,
+                                        ChainMigrationElection,
+                                        public_key, private_key,
+                                        {})
+
+    txs += [election]
+    total_votes += votes
+
+    b.store_abci_chain(1, 'chain-X')
+    b.store_block(Block(height=1,
+                        transactions=[tx.id for tx in txs],
+                        app_hash='')._asdict())
+    b.store_bulk_transactions(txs)
+
+    Election.approved_elections(b, 1, total_votes)
+    chain = b.get_latest_abci_chain()
+    assert chain
+    assert chain == {
+        'height': 2,
+        'is_synced': False,
+        'chain_id': 'chain-X-migrated-at-height-1',
+    }
+
+    assert b.get_election(txs[0].id)
+    assert not b.get_election(txs[1].id)
 
 
-def test_approved_elections_no_elections(b):
-    txns = []
-    mock_chain_migration, mock_store_validator = run_approved_elections(b, txns)
-    mock_chain_migration.assert_not_called()
-    mock_store_validator.assert_not_called()
-
-
-def run_approved_elections(bigchain, txns):
-    mock_chain_migration = MagicMock()
-    mock_store_validator = MagicMock()
-    bigchain.migrate_abci_chain = mock_chain_migration
-    bigchain.store_validator_set = mock_store_validator
-    Election.approved_elections(bigchain, 1, txns)
-    return mock_chain_migration, mock_store_validator
+def test_approved_elections_gracefully_handles_empty_block(b):
+    Election.approved_elections(b, 1, [])


### PR DESCRIPTION
- Do not conclude migration election if there is a migration in progress.
- Rewrite election tests to not use mocks and assert many different things.
- Record concluded elections in the `election` collection.
