### PR TITLE
Problem: "pluggable consensus" is actually "pluggable validation"

### DIFF
--- a/bigchaindb/README.md
+++ b/bigchaindb/README.md
@@ -18,9 +18,9 @@ The `BigchainDB` class is defined here.  Most node-level operations and database
 
 `Block`, `Transaction`, and `Asset` classes are defined here.  The classes mirror the block and transaction structure from the [documentation](https://docs.bigchaindb.com/projects/server/en/latest/data-models/index.html), but also include methods for validation and signing.
 
-### [`consensus.py`](./consensus.py)
+### [`validation.py`](./validation.py)
 
-Base class for consensus methods (verification of votes, blocks, and transactions).  The actual logic is mostly found in `transaction` and `block` models, defined in [`models.py`](./models.py).
+Base class for validation methods (verification of votes, blocks, and transactions).  The actual logic is mostly found in `transaction` and `block` models, defined in [`models.py`](./models.py).
 
 ### [`processes.py`](./processes.py)
 

--- a/bigchaindb/config_utils.py
+++ b/bigchaindb/config_utils.py
@@ -28,7 +28,7 @@ from bigchaindb.common import exceptions
 
 import bigchaindb
 
-from bigchaindb.consensus import BaseConsensusRules
+from bigchaindb.validation import BaseValidationRules
 
 # TODO: move this to a proper configuration file for logging
 logging.getLogger('requests').setLevel(logging.WARNING)
@@ -258,38 +258,38 @@ def autoconfigure(filename=None, config=None, force=False):
 
 
 @lru_cache()
-def load_consensus_plugin(name=None):
-    """Find and load the chosen consensus plugin.
+def load_validation_plugin(name=None):
+    """Find and load the chosen validation plugin.
 
     Args:
         name (string): the name of the entry_point, as advertised in the
             setup.py of the providing package.
 
     Returns:
-        an uninstantiated subclass of ``bigchaindb.consensus.AbstractConsensusRules``
+        an uninstantiated subclass of ``bigchaindb.validation.AbstractValidationRules``
     """
     if not name:
-        return BaseConsensusRules
+        return BaseValidationRules
 
-    # TODO: This will return the first plugin with group `bigchaindb.consensus`
+    # TODO: This will return the first plugin with group `bigchaindb.validation`
     #       and name `name` in the active WorkingSet.
     #       We should probably support Requirements specs in the config, e.g.
-    #       consensus_plugin: 'my-plugin-package==0.0.1;default'
+    #       validation_plugin: 'my-plugin-package==0.0.1;default'
     plugin = None
-    for entry_point in iter_entry_points('bigchaindb.consensus', name):
+    for entry_point in iter_entry_points('bigchaindb.validation', name):
         plugin = entry_point.load()
 
     # No matching entry_point found
     if not plugin:
         raise ResolutionError(
-            'No plugin found in group `bigchaindb.consensus` with name `{}`'.
+            'No plugin found in group `bigchaindb.validation` with name `{}`'.
             format(name))
 
     # Is this strictness desireable?
     # It will probably reduce developer headaches in the wild.
-    if not issubclass(plugin, (BaseConsensusRules,)):
+    if not issubclass(plugin, (BaseValidationRules,)):
         raise TypeError('object of type "{}" does not implement `bigchaindb.'
-                        'consensus.BaseConsensusRules`'.format(type(plugin)))
+                        'validation.BaseValidationRules`'.format(type(plugin)))
 
     return plugin
 

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -40,8 +40,7 @@ class App(BaseApplication):
     """Bridge between BigchainDB and Tendermint.
 
     The role of this class is to expose the BigchainDB
-    transactional logic to the Tendermint Consensus
-    State Machine.
+    transaction logic to Tendermint Core.
     """
 
     def __init__(self, bigchaindb=None, events_queue=None):

--- a/bigchaindb/lib.py
+++ b/bigchaindb/lib.py
@@ -27,7 +27,7 @@ from bigchaindb.common.exceptions import (SchemaValidationError,
                                           DoubleSpend)
 from bigchaindb.tendermint_utils import encode_transaction, merkleroot
 from bigchaindb import exceptions as core_exceptions
-from bigchaindb.consensus import BaseConsensusRules
+from bigchaindb.validation import BaseValidationRules
 
 
 logger = logging.getLogger(__name__)
@@ -64,12 +64,12 @@ class BigchainDB(object):
         self.tendermint_port = bigchaindb.config['tendermint']['port']
         self.endpoint = 'http://{}:{}/'.format(self.tendermint_host, self.tendermint_port)
 
-        consensusPlugin = bigchaindb.config.get('consensus_plugin')
+        validationPlugin = bigchaindb.config.get('validation_plugin')
 
-        if consensusPlugin:
-            self.consensus = config_utils.load_consensus_plugin(consensusPlugin)
+        if validationPlugin:
+            self.validation = config_utils.load_validation_plugin(validationPlugin)
         else:
-            self.consensus = BaseConsensusRules
+            self.validation = BaseValidationRules
 
         self.connection = connection if connection else backend.connect(**bigchaindb.config['database'])
 

--- a/bigchaindb/validation.py
+++ b/bigchaindb/validation.py
@@ -3,23 +3,22 @@
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
 
-class BaseConsensusRules():
-    """Base consensus rules for Bigchain.
+class BaseValidationRules():
+    """Base validation rules for BigchainDB.
 
-    A consensus plugin must expose a class inheriting from this one via an entry_point.
+    A validation plugin must expose a class inheriting from this one via an entry_point.
 
     All methods listed below must be implemented.
-
     """
 
     @staticmethod
-    def validate_transaction(bigchain, transaction):
+    def validate_transaction(bigchaindb, transaction):
         """See :meth:`bigchaindb.models.Transaction.validate`
         for documentation.
         """
-        return transaction.validate(bigchain)
+        return transaction.validate(bigchaindb)
 
     @staticmethod
-    def validate_block(bigchain, block):
+    def validate_block(bigchaindb, block):
         """See :meth:`bigchaindb.models.Block.validate` for documentation."""
-        return block.validate(bigchain)
+        return block.validate(bigchaindb)

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -31,24 +31,24 @@ def test_bigchain_instance_is_initialized_when_conf_provided():
     assert bigchaindb.config['CONFIGURED'] is True
 
 
-def test_load_consensus_plugin_loads_default_rules_without_name():
+def test_load_validation_plugin_loads_default_rules_without_name():
     from bigchaindb import config_utils
-    from bigchaindb.consensus import BaseConsensusRules
+    from bigchaindb.validation import BaseValidationRules
 
-    assert config_utils.load_consensus_plugin() == BaseConsensusRules
+    assert config_utils.load_validation_plugin() == BaseValidationRules
 
 
-def test_load_consensus_plugin_raises_with_unknown_name():
+def test_load_validation_plugin_raises_with_unknown_name():
     from pkg_resources import ResolutionError
     from bigchaindb import config_utils
 
     with pytest.raises(ResolutionError):
-        config_utils.load_consensus_plugin('bogus')
+        config_utils.load_validation_plugin('bogus')
 
 
-def test_load_consensus_plugin_raises_with_invalid_subclass(monkeypatch):
+def test_load_validation_plugin_raises_with_invalid_subclass(monkeypatch):
     # Monkeypatch entry_point.load to return something other than a
-    # ConsensusRules instance
+    # ValidationRules instance
     from bigchaindb import config_utils
     import time
     monkeypatch.setattr(config_utils,
@@ -58,7 +58,7 @@ def test_load_consensus_plugin_raises_with_invalid_subclass(monkeypatch):
     with pytest.raises(TypeError):
         # Since the function is decorated with `lru_cache`, we need to
         # "miss" the cache using a name that has not been used previously
-        config_utils.load_consensus_plugin(str(time.time()))
+        config_utils.load_validation_plugin(str(time.time()))
 
 
 def test_load_events_plugins(monkeypatch):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -35,20 +35,20 @@ def config(request, monkeypatch):
 
 def test_bigchain_class_default_initialization(config):
     from bigchaindb import BigchainDB
-    from bigchaindb.consensus import BaseConsensusRules
+    from bigchaindb.validation import BaseValidationRules
     from bigchaindb.backend.connection import Connection
     bigchain = BigchainDB()
     assert isinstance(bigchain.connection, Connection)
     assert bigchain.connection.host == config['database']['host']
     assert bigchain.connection.port == config['database']['port']
     assert bigchain.connection.dbname == config['database']['name']
-    assert bigchain.consensus == BaseConsensusRules
+    assert bigchain.validation == BaseValidationRules
 
 
 def test_bigchain_class_initialization_with_parameters():
     from bigchaindb import BigchainDB
     from bigchaindb.backend import connect
-    from bigchaindb.consensus import BaseConsensusRules
+    from bigchaindb.validation import BaseValidationRules
     init_db_kwargs = {
         'backend': 'localmongodb',
         'host': 'this_is_the_db_host',
@@ -61,7 +61,7 @@ def test_bigchain_class_initialization_with_parameters():
     assert bigchain.connection.host == init_db_kwargs['host']
     assert bigchain.connection.port == init_db_kwargs['port']
     assert bigchain.connection.dbname == init_db_kwargs['name']
-    assert bigchain.consensus == BaseConsensusRules
+    assert bigchain.validation == BaseValidationRules
 
 
 def test_get_spent_issue_1271(b, alice, bob, carol):


### PR DESCRIPTION
Solution: rename "consensus" to "validation" where relevant.

To understand where this problem came from, see issue #1779. I don't care about doing deprecation warnings because anyone clever enough to use the "pluggable consensus" feature can figure out how to edit their code to make it work once this change goes into effect.

This pull request resolves #1779 
