### PR TITLE
See what happens if packaging~=17.0 in setup.py AND docs/*/requirements.txt

### DIFF
--- a/docs/contributing/requirements.txt
+++ b/docs/contributing/requirements.txt
@@ -2,3 +2,4 @@ Sphinx~=1.0
 recommonmark>=0.4.0
 sphinx-rtd-theme>=0.1.9
 wget
+packaging~=17.0

--- a/docs/root/requirements.txt
+++ b/docs/root/requirements.txt
@@ -3,3 +3,4 @@ recommonmark>=0.4.0
 sphinx-rtd-theme>=0.1.9
 sphinxcontrib-napoleon>=0.4.4
 sphinxcontrib-httpdomain>=1.5.0
+packaging~=17.0

--- a/docs/server/requirements.txt
+++ b/docs/server/requirements.txt
@@ -5,3 +5,4 @@ sphinxcontrib-napoleon>=0.4.4
 sphinxcontrib-httpdomain>=1.5.0
 pyyaml~=3.12
 aafigure>=0.6
+packaging~=17.0

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ install_requires = [
     'aiohttp~=3.0',
     'bigchaindb-abci==0.5.1',
     'setproctitle~=1.1.0',
-    'packaging~=18.0',
+    'packaging~=17.0',
 ]
 
 setup(


### PR DESCRIPTION
This is a little experiment to see what happens if `packaging~=17.0` in `setup.py` AND `docs/*/requirements.txt`.

1. Do the Travis tests pass?
1. If we merge this into `master`, do the docs build on ReadTheDocs?

If both of the above work, then do _another_ pull request where we change it to `packaging~=18.0`.
