### PR TITLE
Last PR before releasing 2.0.0b7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,31 @@ For reference, the possible headings are:
 * **Known Issues**
 * **Notes**
 
+## [2.0 Beta 7] - 2018-09-28
+
+Tag name: v2.0.0b7
+
+### Added
+
+Completed the implementation of chain-migration elections (BEP-42). Pull requests [#2553](https://github.com/bigchaindb/bigchaindb/pull/2553), [#2556](https://github.com/bigchaindb/bigchaindb/pull/2556), [#2558](https://github.com/bigchaindb/bigchaindb/pull/2558), [#2563](https://github.com/bigchaindb/bigchaindb/pull/2563) and [#2566](https://github.com/bigchaindb/bigchaindb/pull/2566)
+
+### Changed
+
+* Code that used the Python driver's (deprecated) transactions.send() method now uses its transactions.send_commit() method instead. [Pull request #2547](https://github.com/bigchaindb/bigchaindb/pull/2547)
+* Code that implied pluggable "consensus" now implies pluggable transaction "validation" (a more accurate word). [Pull request #2561](https://github.com/bigchaindb/bigchaindb/pull/2561)
+
+### Removed
+
+Benchmark logs. [Pull request #2565](https://github.com/bigchaindb/bigchaindb/pull/2565)
+
+### Fixed
+
+A bug caused by an incorrect MongoDB query. [Pull request #2567](https://github.com/bigchaindb/bigchaindb/pull/2567)
+
+### Notes
+
+There's now better documentation about logs, log rotation, and the `server.bind` config setting. Pull requests [#2546](https://github.com/bigchaindb/bigchaindb/pull/2546) and [#2575](https://github.com/bigchaindb/bigchaindb/pull/2575)
+
 ## [2.0 Beta 6] - 2018-09-17
 
 Tag name: v2.0.0b6

--- a/bigchaindb/version.py
+++ b/bigchaindb/version.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
-__version__ = '2.0.0b6'
-__short_version__ = '2.0b6'
+__version__ = '2.0.0b7'
+__short_version__ = '2.0b7'
 # supported Tendermint version
 __tm_supported_versions__ = ["0.22.8"]

--- a/docs/server/source/simple-deployment-template/network-setup.md
+++ b/docs/server/source/simple-deployment-template/network-setup.md
@@ -62,11 +62,11 @@ sudo apt install -y python3-pip libssl-dev
 # Ubuntu 16.04, and other Linux distros, may require other packages or more packages
 ```
 
-Now install the latest version of BigchainDB. You can find the latest version by going to the [BigchainDB project release history page on PyPI][bdb:pypi]. For example, to install version 2.0.0b3, you would do:
+Now install the latest version of BigchainDB. You can find the latest version by going to the [BigchainDB project release history page on PyPI][bdb:pypi]. For example, to install version 2.0.0b7, you would do:
 
 ```
-# Change 2.0.0b3 to the latest version as explained above:
-sudo pip3 install bigchaindb==2.0.0b3
+# Change 2.0.0b7 to the latest version as explained above:
+sudo pip3 install bigchaindb==2.0.0b7
 ```
 
 Check that you installed the correct version of BigchainDB Server using `bigchaindb --version`.

--- a/k8s/bigchaindb/bigchaindb-ss.yaml
+++ b/k8s/bigchaindb/bigchaindb-ss.yaml
@@ -158,7 +158,7 @@ spec:
           timeoutSeconds: 15
       # BigchainDB container
       - name: bigchaindb
-        image: bigchaindb/bigchaindb:2.0.0-beta6
+        image: bigchaindb/bigchaindb:2.0.0-beta7
         imagePullPolicy: Always
         args:
         - start

--- a/k8s/dev-setup/bigchaindb.yaml
+++ b/k8s/dev-setup/bigchaindb.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: bigchaindb
-        image: bigchaindb/bigchaindb:2.0.0-beta6
+        image: bigchaindb/bigchaindb:2.0.0-beta7
         imagePullPolicy: Always
         args:
         - start


### PR DESCRIPTION
Following [the BigchainDB release process](https://github.com/bigchaindb/bigchaindb/blob/master/RELEASE_PROCESS.md).

Note that I also updated 2.0.0b3 to 2.0.0b7 in `network-setup.md`.