### PR TITLE
In NGINX conf files under k8s/: Drop TLSv1 & TLSv1.1, enable TLSv1.3

### DIFF
--- a/k8s/nginx-https-web-proxy/container/nginx.conf.template
+++ b/k8s/nginx-https-web-proxy/container/nginx.conf.template
@@ -62,7 +62,7 @@ http {
     server_name "PROXY_FQDN";
     ssl_certificate        /etc/nginx/ssl/cert.pem;
     ssl_certificate_key    /etc/nginx/ssl/cert.key;
-    ssl_protocols          TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols          TLSv1.2 TLSv1.3;
     ssl_ciphers            HIGH:!aNULL:!MD5;
 
     underscores_in_headers on;

--- a/k8s/nginx-https/container/nginx.conf.template
+++ b/k8s/nginx-https/container/nginx.conf.template
@@ -66,7 +66,7 @@ http {
 
     ssl_certificate /etc/nginx/ssl/cert.pem;
     ssl_certificate_key /etc/nginx/ssl/cert.key;
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;
 
     underscores_in_headers on;

--- a/k8s/nginx-https/container/nginx.conf.threescale.template
+++ b/k8s/nginx-https/container/nginx.conf.threescale.template
@@ -68,7 +68,7 @@ http {
 
     ssl_certificate /etc/nginx/ssl/cert.pem;
     ssl_certificate_key /etc/nginx/ssl/cert.key;
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;
 
     underscores_in_headers on;


### PR DESCRIPTION
because TLS v1 and v1.1 are old