### PR TITLE
pip 19.1 has deprecated --process-dependency-links

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -4,7 +4,7 @@ LABEL maintainer "devs@bigchaindb.com"
 
 RUN apt-get update \
     && apt-get install -y vim \
-    && pip install -U pip \
+    && pip install -U pip==18.1 \
     && pip install pynacl \
     && apt-get autoremove \
     && apt-get clean


### PR DESCRIPTION
## Problem 
PIP 19.1 has deprecated --process-dependency-links 
## Solution
To fix the deprecation problem it was needed to fix the version on pip to 18.1. I would recommend to fix the other versions not to run into other similar bugs.


