### PR TITLE
Remove --no-cache-dir from all pip install cmds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 RUN apt-get -qq update \
     && apt-get -y upgrade \
     && apt-get install -y jq \
-    && pip install --no-cache-dir . \
+    && pip install . \
     && apt-get autoremove \
     && apt-get clean
 

--- a/Dockerfile-all-in-one
+++ b/Dockerfile-all-in-one
@@ -13,7 +13,7 @@ RUN apk --update add sudo bash \
         libffi-dev openssl-dev build-base jq \
     && apk add --no-cache libstdc++ dpkg gnupg \
     && pip3 install --upgrade pip cffi \
-    && pip install --no-cache-dir -e . \
+    && pip install -e . \
     && apk del build-dependencies \
     && rm -f /var/cache/apk/*
 

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -9,7 +9,7 @@ RUN apk --update add sudo \
         libffi-dev openssl-dev build-base \
     && apk add --no-cache libstdc++ \
     && pip3 install --upgrade pip cffi \
-    && pip install --no-cache-dir -e .[dev] \
+    && pip install -e .[dev] \
     && apk del build-dependencies \
     && rm -f /var/cache/apk/*
 # When developing with Python in a docker container, we are using PYTHONBUFFERED

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -32,5 +32,5 @@ ENV BIGCHAINDB_CI_ABCI ${abci_status}
 RUN mkdir -p /usr/src/app
 COPY . /usr/src/app/
 WORKDIR /usr/src/app
-RUN pip install --no-cache-dir -e .[dev]
+RUN pip install -e .[dev]
 RUN bigchaindb -y configure

--- a/pkg/configuration/roles/bigchaindb/tasks/common.yml
+++ b/pkg/configuration/roles/bigchaindb/tasks/common.yml
@@ -10,7 +10,7 @@
   tags: [bigchaindb]
 
 - name: Install BigchainDB
-  shell: "python3.6 -m pip install --no-cache-dir -e /opt/stack/bigchaindb/.[dev] --ignore-installed pyyaml"
+  shell: "python3.6 -m pip install -e /opt/stack/bigchaindb/.[dev] --ignore-installed pyyaml"
   register: install_bdb
   failed_when: "'FAILED' in install_bdb.stderr or install_bdb.rc != 0"
   tags: [bigchaindb]

--- a/pkg/configuration/roles/py36/templates/install_pip36.j2
+++ b/pkg/configuration/roles/py36/templates/install_pip36.j2
@@ -3,6 +3,6 @@
 set -ex
 export PYTHON_PIP_VERSION=10.0.1
 wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'
-python3.6 get-pip.py --disable-pip-version-check --no-cache-dir
+python3.6 get-pip.py --disable-pip-version-check
 rm -f get-pip.py
 {% endraw %}

--- a/pkg/configuration/roles/py36/templates/install_py36.j2
+++ b/pkg/configuration/roles/py36/templates/install_py36.j2
@@ -28,7 +28,7 @@ cd $HOME && \
 rm -rf /usr/src/python
 export PYTHON_PIP_VERSION=10.0.1
 wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'
-python3 get-pip.py --disable-pip-version-check --no-cache-dir "pip==$PYTHON_PIP_VERSION"
+python3 get-pip.py --disable-pip-version-check "pip==$PYTHON_PIP_VERSION"
 find /usr/local -depth \( \( -type d -a \( -name test -o -name tests \) \) -o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \) -exec rm -rf '{}' +;
 rm -f get-pip.py
 {% endraw %}


### PR DESCRIPTION
because it broke in pip 19

See https://github.com/pypa/pip/issues/6158
