### PR TITLE
Restart on sporadic failures on BDB container#2624

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     ports:
       - "27017:27017"
     command: mongod
+    restart: always
   bigchaindb:
     depends_on:
       - mongodb
@@ -47,6 +48,7 @@ services:
       timeout: 5s
       retries: 3
     command: '.ci/entrypoint.sh'
+    restart: always
   tendermint:
     image: tendermint/tendermint:0.22.8
     # volumes:
@@ -56,6 +58,7 @@ services:
       - "26656:26656"
       - "26657:26657"
     command: sh -c "tendermint init && tendermint node --consensus.create_empty_blocks=false --proxy_app=tcp://bigchaindb:26658"
+    restart: always
   bdb:
     image: busybox
     depends_on:


### PR DESCRIPTION
To account for sporadic failures on bigchaindb server and container stop, it would be beneficial to include in docker-compose the ability for the containers to restart on failure or docker daemon restart. 

## Solution

Restart always command on docker-compose for mongodb, tendermint and bigchaindb containers

## Issues Resolved

Issue #2624 


