### PR TITLE
Problem: No volume mounted to store tendermint data

### DIFF
--- a/pkg/configuration/roles/tendermint/defaults/main.yml
+++ b/pkg/configuration/roles/tendermint/defaults/main.yml
@@ -17,6 +17,7 @@ bigchaindb_docker_net: "bigchaindb_docker_net"
 tendermint_host_mount_dir: "{{ home_dir }}/tendermint_docker"
 tendermint_host_mount_config_dir: "{{ home_dir }}/tendermint_config"
 tendermint_home: /tendermint/config
+tendermint_data: /tendermint/data
 tendermint_p2p_port: 26656
 tendermint_rpc_port: 26657
 tendermint_abci_port: 26658

--- a/pkg/configuration/roles/tendermint/tasks/start.yml
+++ b/pkg/configuration/roles/tendermint/tasks/start.yml
@@ -53,6 +53,7 @@
       - "{{ tendermint_rpc_port }}"
     volumes:
       - "{{ tendermint_host_mount_dir }}{{ item|string }}{{ tendermint_home }}:{{ tendermint_home }}"
+      - "{{ tendermint_host_mount_dir }}{{ item|string }}{{ tendermint_data }}:{{ tendermint_data }}"
       - "{{ tendermint_host_mount_config_dir }}{{ tendermint_home }}:/tendermint_config"
     entrypoint: ''
     command: bash -c 'cp /tendermint_config/genesis.json /tendermint/config/genesis.json &&


### PR DESCRIPTION
## Solution

Mount a volume to the tendermint container to store tendermint data outside of the container.
The tendermint data folder stores data like `mempool, tx_index, blockstore.db`

## Issues Resolved

The tendermint docker container keeps on storing the tendermint data inside the container inefficiently. Mounting a volume stores the tendermint data outside the container which persists even after the container stops. 