### PR TITLE
Updates for the switch from BEP-16 to BEP-24

### DIFF
--- a/HOW_TO_HANDLE_PULL_REQUESTS.md
+++ b/HOW_TO_HANDLE_PULL_REQUESTS.md
@@ -1,9 +1,0 @@
-<!---
-Copyright BigchainDB GmbH and BigchainDB contributors
-SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
-Code is Apache-2.0 and docs are CC-BY-4.0
---->
-
-# How to Handle External Pull Requests
-
-See [BEP-16](https://github.com/bigchaindb/BEPs/tree/master/16).

--- a/LICENSES.md
+++ b/LICENSES.md
@@ -2,10 +2,12 @@
 
 ## Copyrights
 
-Except as noted in the **Exceptions** section below, for all code and documentation in this repository, BigchainDB GmbH ("We") either:
+For all the code and documentation in this repository, the copyright is owned by one or more of the following:
 
-1. owns the copyright, or
-2. owns the right to sublicense it under any license (because all external contributors must agree to a Contributor License Agreement).
+- BigchainDB GmbH
+- A BigchainDB contributor who agreed to a BigchainDB Contributor License Agreement (CLA) with BigchainDB GmbH. (See [BEP-16](https://github.com/bigchaindb/BEPs/tree/master/16).)
+- A BigchainDB contributor who signed off on the Developer Certificate of Origin (DCO) for all their contributions. (See [BEP-24](https://github.com/bigchaindb/BEPs/tree/master/24).)
+- (Rarely, see the **Exceptions Section** below) A third pary who licensed the code in question under an open source license.
 
 ## Code Licenses
 

--- a/docs/contributing/source/conf.py
+++ b/docs/contributing/source/conf.py
@@ -49,7 +49,6 @@ extensions = [
 
 try:
     remove('cross-project-policies/code-of-conduct.md')
-    remove('cross-project-policies/shared-workspace.md')
     remove('cross-project-policies/release-process.md')
     remove('cross-project-policies/python-style-guide.md')
 except:
@@ -61,9 +60,6 @@ def get_old_new(url, old, new):
 
 get_old_new('https://raw.githubusercontent.com/bigchaindb/bigchaindb/master/CODE_OF_CONDUCT.md',
             'CODE_OF_CONDUCT.md', 'cross-project-policies/code-of-conduct.md')
-
-get_old_new('https://raw.githubusercontent.com/bigchaindb/BEPs/master/6/README.md',
-            'README.md', 'cross-project-policies/shared-workspace.md')
 
 get_old_new('https://raw.githubusercontent.com/bigchaindb/bigchaindb/master/RELEASE_PROCESS.md',
             'RELEASE_PROCESS.md', 'cross-project-policies/release-process.md')

--- a/docs/contributing/source/cross-project-policies/index.rst
+++ b/docs/contributing/source/cross-project-policies/index.rst
@@ -11,7 +11,6 @@ Policies
    :maxdepth: 1
 
    code-of-conduct
-   shared-workspace
    python-style-guide
    JavaScript Style Guide <https://github.com/ascribe/javascript>
    release-process

--- a/docs/contributing/source/dev-setup-coding-and-contribution-process/write-code.rst
+++ b/docs/contributing/source/dev-setup-coding-and-contribution-process/write-code.rst
@@ -65,6 +65,14 @@ Set Up Your Local Machine. Here's How.
   latest ``pip``, ``wheel`` and ``setuptools`` and put them inside the new virtualenv.
 
 
+Before You Start Writing Code
+-----------------------------
+
+Read `BEP-24 <https://github.com/bigchaindb/BEPs/tree/master/24>`_
+so you know what to do to ensure that your changes (i.e. your future pull request) can be merged.
+It's easy and will save you some hassle later on.
+
+
 Start Writing Code
 ------------------
 
@@ -140,28 +148,9 @@ Codecov gets its configuration from the file `codeocov.yaml <https://github.com/
 `docs.codecov.io <https://docs.codecov.io/v4.3.6/docs/codecov-yaml>`_. Codecov might also use ``setup.cfg``.
 
 
-First-Time Pull Requests from External Users
---------------------------------------------
-
-First-time pull requests from external users who haven't contributed before will get blocked by the requirement to agree to the
-BigchainDB Contributor License Agreement (CLA). It doesn't take long to agree to it. Go to
-`https://www.bigchaindb.com/cla/ <https://www.bigchaindb.com/cla/>`_ and:
-
-- Select the CLA you want to agree to (for individuals or for a whole company)
-- Fill in the form and submit it
-- Wait for an email from us with the next step. There is only one: copying a special block of text to GitHub.
-
-
 Merge!
 ------
 
 Ideally, we like your PR and merge it right away. We don't want to keep you waiting.
 
 If we want to make changes, we'll do them in a follow-up PR.
-
------------------
-
-You are awesome. Do you want a job? `Apply! <https://github.com/bigchaindb/org/tree/master/jobs>`_ Berlin is great. If you got this far, we'd be happy to consider you joining our team. Look at these `Unsplash photos of Berlin <https://unsplash.com/search/photos/berlin>`_. So nice.
-
-
-


### PR DESCRIPTION
This pull request will have to be reviewed and merged by someone affiliated with the IPDB Foundation.

- Made various modifications to account for the switch from BEP-16 to BEP-24.
- Also removed the "Shared Workspace Policy" (BEP-6) from the docs about contributing. It was for the BigchainDB GmbH team.
- Also removed the line about BigchainDB GmbH hiring, from the docs about contributing.

Signed-off-by: Troy McConaghy <troy@bigchaindb.com>
