### PR TITLE
Note the new C# driver in the server docs

### DIFF
--- a/docs/server/source/drivers-clients/index.rst
+++ b/docs/server/source/drivers-clients/index.rst
@@ -6,15 +6,13 @@
 Drivers & Tools
 ===============
 
-Libraries and Tools Maintained by the BigchainDB Team
------------------------------------------------------
+These drivers were originally created by the original BigchainDB team:
 
 * `Python Driver <https://docs.bigchaindb.com/projects/py-driver/en/latest/index.html>`_
 * `JavaScript / Node.js Driver <https://github.com/bigchaindb/js-bigchaindb-driver>`_
-* `Java driver <https://github.com/bigchaindb/java-bigchaindb-driver>`_
+* `Java Driver <https://github.com/bigchaindb/java-bigchaindb-driver>`_
 
-Community-Driven Libraries and Tools
-------------------------------------
+These drivers and tools were created by the BigchainDB community:
 
 .. warning::
 
@@ -22,6 +20,7 @@ Community-Driven Libraries and Tools
    but may still be useful.
    Others might not work with the latest version of BigchainDB.
 
+* `C# driver <https://github.com/Omnibasis/bigchaindb-csharp-driver>`_ (working as of May 2019)
 * `Haskell transaction builder <https://github.com/bigchaindb/bigchaindb-hs>`_
 * `Go driver <https://github.com/zbo14/envoke/blob/master/bigchain/bigchain.go>`_
 * `Ruby driver <https://github.com/LicenseRocks/bigchaindb_ruby>`_


### PR DESCRIPTION
I got an email from Omnibasis which said, in part, "We wanted to make sure [the new C#] drivers working 100%. After 6 month of testing and many test cases, we released it."

So I added a link to it in the BigchainDB Server docs. (The Server docs default to the last _released_ version tag, not the latest/master branch, so this change won't be visible in the default Sever docs until after a new release comes out. I will also see about adding the C# driver to the website on the page https://www.bigchaindb.com/developers/getstarted/ )

I also made some other cosmetic changes.

`Signed-off-by: Troy McConaghy <troy@bigchaindb.com>`

and yes I understand what that means :smile: 