### PR TITLE
Note that pip 19+ is now needed to install bigchaindb

### DIFF
--- a/docs/server/source/simple-deployment-template/set-up-node-software.md
+++ b/docs/server/source/simple-deployment-template/set-up-node-software.md
@@ -13,12 +13,19 @@ MongoDB and Tendermint.
 ## Install BigchainDB Server
 
 BigchainDB Server requires **Python 3.6+**, so make sure your system has it.
+
 Install the required OS-level packages:
 
 ```
 # For Ubuntu 18.04:
 sudo apt install -y python3-pip libssl-dev
 # Ubuntu 16.04, and other Linux distros, may require other packages or more packages
+```
+
+BigchainDB Server requires [gevent](http://www.gevent.org/), and to install gevent, you must use pip 19 or later (as of 2019, because gevent now uses manylinux2010 wheels). Upgrade pip to the latest version:
+
+```
+sudo pip3 install -U pip
 ```
 
 Now install the latest version of BigchainDB Server.


### PR DESCRIPTION
From http://www.gevent.org/whatsnew_1_5.html#packaging-changes

"gevent now distributes manylinux2010 binary wheels for Linux, instead of the older manylinux1 standard."

From http://www.gevent.org/install.html#id1

"On Linux, you’ll need pip 19 to install the manylinux2010 wheels."

You can get the latest pip3 using:

`sudo pip3 install -U pip`