### PR TITLE
Remove pysha3 for python >= 3.6

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,5 +1,5 @@
 ARG python_version=3.6
-FROM pypy:${python_version}
+FROM python:${python_version}
 LABEL maintainer "devs@bigchaindb.com"
 
 RUN apt-get update \

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,5 +1,5 @@
 ARG python_version=3.6
-FROM python:${python_version}
+FROM pypy:${python_version}
 LABEL maintainer "devs@bigchaindb.com"
 
 RUN apt-get update \

--- a/bigchaindb/common/crypto.py
+++ b/bigchaindb/common/crypto.py
@@ -5,7 +5,11 @@
 # Separate all crypto code so that we can easily test several implementations
 from collections import namedtuple
 
-import sha3
+try:
+    from hashlib import sha3_256
+except ImportError:
+    from sha3 import sha3_256
+
 from cryptoconditions import crypto
 
 
@@ -14,7 +18,7 @@ CryptoKeypair = namedtuple('CryptoKeypair', ('private_key', 'public_key'))
 
 def hash_data(data):
     """Hash the provided data using SHA3-256"""
-    return sha3.sha3_256(data.encode()).hexdigest()
+    return sha3_256(data.encode()).hexdigest()
 
 
 def generate_key_pair():

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -19,7 +19,10 @@ import base58
 from cryptoconditions import Fulfillment, ThresholdSha256, Ed25519Sha256
 from cryptoconditions.exceptions import (
     ParsingError, ASN1DecodeError, ASN1EncodeError, UnsupportedTypeError)
-from sha3 import sha3_256
+try:
+    from hashlib import sha3_256
+except ImportError:
+    from sha3 import sha3_256
 
 from bigchaindb.common.crypto import PrivateKey, hash_data
 from bigchaindb.common.exceptions import (KeypairMismatchException,

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ tests_require = [
 install_requires = [
     # TODO Consider not installing the db drivers, or putting them in extras.
     'pymongo~=3.6',
-    'pysha3~=1.0.2',
+    # 'pysha3~=1.0.2', # @PYPY: not compability with PyPy, replaced with native hashlib
     'cryptoconditions==0.8.0',
     'python-rapidjson~=0.6.0',
     'logstats~=0.2.1',

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,6 @@ tests_require = [
 install_requires = [
     # TODO Consider not installing the db drivers, or putting them in extras.
     'pymongo~=3.6',
-    # 'pysha3~=1.0.2', # @PYPY: not compability with PyPy, replaced with native hashlib
     'cryptoconditions==0.8.0',
     'python-rapidjson~=0.6.0',
     'logstats~=0.2.1',
@@ -90,6 +89,9 @@ install_requires = [
     'setproctitle~=1.1.0',
     'packaging~=18.0',
 ]
+
+if sys.version_info < (3, 6):
+    install_requires.append('pysha3~=1.0.2')
 
 setup(
     name='BigchainDB',

--- a/tests/common/test_transaction.py
+++ b/tests/common/test_transaction.py
@@ -11,7 +11,10 @@ from copy import deepcopy
 from base58 import b58encode, b58decode
 from cryptoconditions import Ed25519Sha256
 from pytest import mark, raises
-from sha3 import sha3_256
+try:
+    from hashlib import sha3_256
+except ImportError:
+    from sha3 import sha3_256
 
 pytestmark = mark.bdb
 

--- a/tests/validation/test_transaction_structure.py
+++ b/tests/validation/test_transaction_structure.py
@@ -9,7 +9,10 @@ structural / schematic issues are caught when reading a transaction
 import json
 
 import pytest
-import sha3
+try:
+    import hashlib as sha3
+except ImportError:
+    import sha3
 from unittest.mock import MagicMock
 
 from bigchaindb.common.exceptions import (AmountError,

--- a/tests/web/test_transactions.py
+++ b/tests/web/test_transactions.py
@@ -8,7 +8,10 @@ from unittest.mock import Mock, patch
 import base58
 import pytest
 from cryptoconditions import Ed25519Sha256
-from sha3 import sha3_256
+try:
+    from hashlib import sha3_256
+except ImportError:
+    from sha3 import sha3_256
 
 from bigchaindb.common import crypto
 from bigchaindb.common.transaction_mode_types import (BROADCAST_TX_COMMIT,


### PR DESCRIPTION
Make sure the title of this pull request has the form:

**Removed pysha3 for python >= 3.6**

## Solution

Python >= 3.6 has [hashlib](https://docs.python.org/3.6/library/hashlib.html) builtin, so pysha3 does the same thing as hashlib.

## Issues Resolved

N/A

## BEPs Implemented

N/A

**PS**: Please, squash commits if merge