### PR TITLE
using alpine v3.9

### DIFF
--- a/Dockerfile-all-in-one
+++ b/Dockerfile-all-in-one
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.9
 LABEL maintainer "devs@bigchaindb.com"
 
 ARG TM_VERSION=0.22.8


### PR DESCRIPTION
**Problem: Unable to build the all-in-one image using alpine:latest**

## Solution
Since version 3.10, Alpine linux has removed mongodb from the available packages.
Using v3.9 it's still possible to build the all-in-one configuration using the provided Dockerfile.