### PR TITLE
Add quotes to env-variables

### DIFF
--- a/pkg/configuration/roles/bigchaindb/tasks/common.yml
+++ b/pkg/configuration/roles/bigchaindb/tasks/common.yml
@@ -33,13 +33,13 @@
 - name: Start BigchainDB
   shell: nohup bigchaindb -l DEBUG start > /tmp/bigchaindb_log_$(date +%Y%m%d_%H%M%S) 2>&1 &
   environment:
-    BIGCHAINDB_DATABASE_BACKEND: localmongodb
-    BIGCHAINDB_DATABASE_HOST: 127.0.0.1
-    BIGCHAINDB_DATABASE_PORT: 27017
-    BIGCHAINDB_SERVER_BIND: 0.0.0.0:9984
-    BIGCHAINDB_WSSERVER_HOST: 0.0.0.0
-    BIGCHAINDB_WSSERVER_PORT: 9985
-    BIGCHAINDB_TENDERMINT_HOST: 127.0.0.1
-    BIGCHAINDB_TENDERMINT_PORT: 26657
+    BIGCHAINDB_DATABASE_BACKEND: "localmongodb"
+    BIGCHAINDB_DATABASE_HOST: "127.0.0.1"
+    BIGCHAINDB_DATABASE_PORT: "27017"
+    BIGCHAINDB_SERVER_BIND: "0.0.0.0:9984"
+    BIGCHAINDB_WSSERVER_HOST: "0.0.0.0"
+    BIGCHAINDB_WSSERVER_PORT: "9985"
+    BIGCHAINDB_TENDERMINT_HOST: "127.0.0.1"
+    BIGCHAINDB_TENDERMINT_PORT: "26657"
   when: mdb_pchk.stdout| int != 0 and bdb_pchk.stdout| int == 0 and tm_pchk.stdout| int != 0
   tags: [bigchaindb]

--- a/pkg/configuration/roles/bigchaindb/tasks/start.yml
+++ b/pkg/configuration/roles/bigchaindb/tasks/start.yml
@@ -26,13 +26,13 @@
     networks:
       - name: "{{ bigchaindb_docker_net }}"
     env:
-      BIGCHAINDB_DATABASE_BACKEND: localmongodb
+      BIGCHAINDB_DATABASE_BACKEND: "localmongodb"
       BIGCHAINDB_DATABASE_HOST: "{{ mongodb_docker_name }}{{ item }}"
-      BIGCHAINDB_DATABASE_PORT: 27017
-      BIGCHAINDB_SERVER_BIND: 0.0.0.0:9984
-      BIGCHAINDB_WSSERVER_HOST: 0.0.0.0
+      BIGCHAINDB_DATABASE_PORT: "27017"
+      BIGCHAINDB_SERVER_BIND: "0.0.0.0:9984"
+      BIGCHAINDB_WSSERVER_HOST: "0.0.0.0"
       BIGCHAINDB_TENDERMINT_HOST: "{{ tendermint_docker_name }}{{ item }}"
-      BIGCHAINDB_TENDERMINT_PORT: "{{ bigchaindb_tendermint_port }}"
+      BIGCHAINDB_TENDERMINT_PORT: "{{ bigchaindb_tendermint_port | string }}"
     published_ports:
       - "{{ bigchaindb_default_server_port }}"
       - "{{ bigchaindb_default_ws_port }}"


### PR DESCRIPTION
## Problem

Issue #2655 

## Solution

Convert env-variable to string. Necessary because ansible 2.8 requires it for the [docker-container-module](https://docs.ansible.com/ansible/latest/modules/docker_container_module.html).

## Issues Resolved

Resolves #2655