### PR TITLE
Tendermint upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ For reference, the possible headings are:
 * **Known Issues**
 * **Notes**
 
+## [2.0] - 2019-09-26
+
+### Changed
+
+Migrated from Tendermint 0.22.8 to 0.31.5.
+
 ## [2.0 Beta 9] - 2018-11-27
 
 ### Changed

--- a/Dockerfile-all-in-one
+++ b/Dockerfile-all-in-one
@@ -1,7 +1,7 @@
 FROM alpine:latest
 LABEL maintainer "devs@bigchaindb.com"
 
-ARG TM_VERSION=0.22.8
+ARG TM_VERSION=v0.31.5
 RUN mkdir -p /usr/src/app
 ENV HOME /root
 COPY . /usr/src/app/

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -45,7 +45,7 @@ The following steps are what we do to release a new version of _BigchainDB Serve
    - In `bigchaindb/version.py`:
      - update `__version__` to e.g. `0.9.0` (with no `.dev` on the end)
      - update `__short_version__` to e.g. `0.9` (with no `.dev` on the end)
-   - In the docs about installing BigchainDB (and Tendermint), and in the associated scripts, recommend/install a version of Tendermint that _actually works_ with the soon-to-be-released version of BigchainDB. You can find all such references by doing a search for the previously-recommended version number, such as 0.31.5`.
+   - In the docs about installing BigchainDB (and Tendermint), and in the associated scripts, recommend/install a version of Tendermint that _actually works_ with the soon-to-be-released version of BigchainDB. You can find all such references by doing a search for the previously-recommended version number, such as `0.31.5`.
    - In `setup.py`, _maybe_ update the development status item in the `classifiers` list. For example, one allowed value is `"Development Status :: 5 - Production/Stable"`. The [allowed values are listed at pypi.python.org](https://pypi.python.org/pypi?%3Aaction=list_classifiers).
 
 2. **Wait for all the tests to pass!**

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -45,26 +45,26 @@ The following steps are what we do to release a new version of _BigchainDB Serve
    - In `bigchaindb/version.py`:
      - update `__version__` to e.g. `0.9.0` (with no `.dev` on the end)
      - update `__short_version__` to e.g. `0.9` (with no `.dev` on the end)
-   - In the docs about installing BigchainDB (and Tendermint), and in the associated scripts, recommend/install a version of Tendermint that _actually works_ with the soon-to-be-released version of BigchainDB. You can find all such references by doing a search for the previously-recommended version number, such as `0.22.8`.
+   - In the docs about installing BigchainDB (and Tendermint), and in the associated scripts, recommend/install a version of Tendermint that _actually works_ with the soon-to-be-released version of BigchainDB. You can find all such references by doing a search for the previously-recommended version number, such as 31.5`.
    - In `setup.py`, _maybe_ update the development status item in the `classifiers` list. For example, one allowed value is `"Development Status :: 5 - Production/Stable"`. The [allowed values are listed at pypi.python.org](https://pypi.python.org/pypi?%3Aaction=list_classifiers).
 
-1. **Wait for all the tests to pass!**
-1. Merge the pull request into the `master` branch.
-1. Go to the [bigchaindb/bigchaindb Releases page on GitHub](https://github.com/bigchaindb/bigchaindb/releases)
+2. **Wait for all the tests to pass!**
+3. Merge the pull request into the `master` branch.
+4. Go to the [bigchaindb/bigchaindb Releases page on GitHub](https://github.com/bigchaindb/bigchaindb/releases)
    and click the "Draft a new release" button.
-1. Fill in the details:
+5. Fill in the details:
    - **Tag version:** version number preceded by `v`, e.g. `v0.9.1`
    - **Target:** the last commit that was just merged. In other words, that commit will get a Git tag with the value given for tag version above.
    - **Title:** Same as tag version above, e.g `v0.9.1`
    - **Description:** The body of the changelog entry (Added, Changed, etc.)
-1. Click "Publish release" to publish the release on GitHub.
-1. On your local computer, make sure you're on the `master` branch and that it's up-to-date with the `master` branch in the bigchaindb/bigchaindb repository (e.g. `git pull upstream master`). We're going to use that to push a new `bigchaindb` package to PyPI.
-1. Make sure you have a `~/.pypirc` file containing credentials for PyPI.
-1. Do `make release` to build and publish the new `bigchaindb` package on PyPI. For this step you need to have `twine` installed. If you get an error like `Makefile:135: recipe for target 'clean-pyc' failed` then try doing
+6. Click "Publish release" to publish the release on GitHub.
+7. On your local computer, make sure you're on the `master` branch and that it's up-to-date with the `master` branch in the bigchaindb/bigchaindb repository (e.g. `git pull upstream master`). We're going to use that to push a new `bigchaindb` package to PyPI.
+8. Make sure you have a `~/.pypirc` file containing credentials for PyPI.
+9. Do `make release` to build and publish the new `bigchaindb` package on PyPI. For this step you need to have `twine` installed. If you get an error like `Makefile:135: recipe for target 'clean-pyc' failed` then try doing
    ```text
    sudo chown -R $(whoami):$(whoami) .
    ```
-1. [Log in to readthedocs.org](https://readthedocs.org/accounts/login/) and go to the **BigchainDB Server** project, then:
+10. [Log in to readthedocs.org](https://readthedocs.org/accounts/login/) and go to the **BigchainDB Server** project, then:
    - Click on "Builds", select "latest" from the drop-down menu, then click the "Build Version:" button.
    - Wait for the build of "latest" to finish. This can take a few minutes.
    - Go to Admin --> Advanced Settings
@@ -75,9 +75,9 @@ The following steps are what we do to release a new version of _BigchainDB Serve
    - Go to Admin --> Versions
      and under **Choose Active Versions**, do these things:
      1. Make sure that the new version's tag is "Active" and "Public"
-     1. Make sure the **stable** branch is _not_ active.
-     1. Scroll to the bottom of the page and click "Save".
-1. Go to [Docker Hub](https://hub.docker.com/) and sign in, then:
+     2. Make sure the **stable** branch is _not_ active.
+     3. Scroll to the bottom of the page and click "Save".
+11. Go to [Docker Hub](https://hub.docker.com/) and sign in, then:
    - Click on "Organizations"
    - Click on "bigchaindb"
    - Click on "bigchaindb/bigchaindb"

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -45,7 +45,7 @@ The following steps are what we do to release a new version of _BigchainDB Serve
    - In `bigchaindb/version.py`:
      - update `__version__` to e.g. `0.9.0` (with no `.dev` on the end)
      - update `__short_version__` to e.g. `0.9` (with no `.dev` on the end)
-   - In the docs about installing BigchainDB (and Tendermint), and in the associated scripts, recommend/install a version of Tendermint that _actually works_ with the soon-to-be-released version of BigchainDB. You can find all such references by doing a search for the previously-recommended version number, such as 31.5`.
+   - In the docs about installing BigchainDB (and Tendermint), and in the associated scripts, recommend/install a version of Tendermint that _actually works_ with the soon-to-be-released version of BigchainDB. You can find all such references by doing a search for the previously-recommended version number, such as 0.31.5`.
    - In `setup.py`, _maybe_ update the development status item in the `classifiers` list. For example, one allowed value is `"Development Status :: 5 - Production/Stable"`. The [allowed values are listed at pypi.python.org](https://pypi.python.org/pypi?%3Aaction=list_classifiers).
 
 2. **Wait for all the tests to pass!**

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -9,7 +9,7 @@ import logging
 import sys
 
 from abci.application import BaseApplication
-from abci.types_pb2 import (
+from github.com.tendermint.tendermint.abci.types.types_pb2 import (
     ResponseInitChain,
     ResponseInfo,
     ResponseCheckTx,

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -9,7 +9,7 @@ import logging
 import sys
 
 from abci.application import BaseApplication
-from github.com.tendermint.tendermint.abci.types.types_pb2 import (
+from abci import (
     ResponseInitChain,
     ResponseInfo,
     ResponseCheckTx,

--- a/bigchaindb/parallel_validation.py
+++ b/bigchaindb/parallel_validation.py
@@ -5,7 +5,7 @@
 import multiprocessing as mp
 from collections import defaultdict
 
-from abci.types_pb2 import ResponseCheckTx, ResponseDeliverTx
+from github.com.tendermint.tendermint.abci.types.types_pb2 import ResponseCheckTx, ResponseDeliverTx
 
 from bigchaindb import BigchainDB, App
 from bigchaindb.tendermint_utils import decode_transaction

--- a/bigchaindb/parallel_validation.py
+++ b/bigchaindb/parallel_validation.py
@@ -5,7 +5,7 @@
 import multiprocessing as mp
 from collections import defaultdict
 
-from github.com.tendermint.tendermint.abci.types.types_pb2 import ResponseCheckTx, ResponseDeliverTx
+from abci import ResponseCheckTx, ResponseDeliverTx
 
 from bigchaindb import BigchainDB, App
 from bigchaindb.tendermint_utils import decode_transaction

--- a/bigchaindb/upsert_validator/validator_utils.py
+++ b/bigchaindb/upsert_validator/validator_utils.py
@@ -2,7 +2,7 @@ import codecs
 import base64
 import binascii
 
-from abci.types_pb2 import (ValidatorUpdate,
+from github.com.tendermint.tendermint.abci.types.types_pb2 import (ValidatorUpdate,
                             PubKey)
 from bigchaindb.common.exceptions import InvalidPublicKey
 

--- a/bigchaindb/upsert_validator/validator_utils.py
+++ b/bigchaindb/upsert_validator/validator_utils.py
@@ -2,8 +2,7 @@ import codecs
 import base64
 import binascii
 
-from abci.types_pb2 import (Validator,
-                            ValidatorUpdate,
+from abci.types_pb2 import (ValidatorUpdate,
                             PubKey)
 from bigchaindb.common.exceptions import InvalidPublicKey
 
@@ -14,7 +13,7 @@ def encode_validator(v):
     pub_key = PubKey(type='ed25519',
                      data=bytes.fromhex(ed25519_public_key))
     return ValidatorUpdate(pub_key=pub_key,
-                     power=v['power'])
+                           power=v['power'])
 
 
 def decode_validator(v):

--- a/bigchaindb/upsert_validator/validator_utils.py
+++ b/bigchaindb/upsert_validator/validator_utils.py
@@ -3,7 +3,7 @@ import base64
 import binascii
 
 from github.com.tendermint.tendermint.abci.types.types_pb2 import (ValidatorUpdate,
-                            PubKey)
+                                                                   PubKey)
 from bigchaindb.common.exceptions import InvalidPublicKey
 
 

--- a/bigchaindb/upsert_validator/validator_utils.py
+++ b/bigchaindb/upsert_validator/validator_utils.py
@@ -2,8 +2,7 @@ import codecs
 import base64
 import binascii
 
-from github.com.tendermint.tendermint.abci.types.types_pb2 import (ValidatorUpdate,
-                                                                   PubKey)
+from abci import (ValidatorUpdate, PubKey)
 from bigchaindb.common.exceptions import InvalidPublicKey
 
 

--- a/bigchaindb/upsert_validator/validator_utils.py
+++ b/bigchaindb/upsert_validator/validator_utils.py
@@ -3,6 +3,7 @@ import base64
 import binascii
 
 from abci.types_pb2 import (Validator,
+                            ValidatorUpdate,
                             PubKey)
 from bigchaindb.common.exceptions import InvalidPublicKey
 
@@ -12,8 +13,7 @@ def encode_validator(v):
     # NOTE: tendermint expects public to be encoded in go-amino format
     pub_key = PubKey(type='ed25519',
                      data=bytes.fromhex(ed25519_public_key))
-    return Validator(pub_key=pub_key,
-                     address=b'',
+    return ValidatorUpdate(pub_key=pub_key,
                      power=v['power'])
 
 

--- a/bigchaindb/version.py
+++ b/bigchaindb/version.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
-__version__ = '2.0.0b9'
-__short_version__ = '2.0b9'
+__version__ = '2.0.0'
+__short_version__ = '2.0'
 
 # Supported Tendermint versions
-__tm_supported_versions__ = ["0.22.8"]
+__tm_supported_versions__ = ["0.31.5"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,42 +13,42 @@ services:
       - "27017:27017"
     command: mongod
     restart: always
-  # bigchaindb:
-  #   depends_on:
-  #     - mongodb
-  #     - tendermint
-  #   build:
-  #     context: .
-  #     dockerfile: Dockerfile-dev
-  #   volumes:
-  #     - ./bigchaindb:/usr/src/app/bigchaindb
-  #     - ./tests:/usr/src/app/tests
-  #     - ./docs:/usr/src/app/docs
-  #     - ./htmlcov:/usr/src/app/htmlcov
-  #     - ./setup.py:/usr/src/app/setup.py
-  #     - ./setup.cfg:/usr/src/app/setup.cfg
-  #     - ./pytest.ini:/usr/src/app/pytest.ini
-  #     - ./tox.ini:/usr/src/app/tox.ini
-  #   environment:
-  #     BIGCHAINDB_DATABASE_BACKEND: localmongodb
-  #     BIGCHAINDB_DATABASE_HOST: mongodb
-  #     BIGCHAINDB_DATABASE_PORT: 27017
-  #     BIGCHAINDB_SERVER_BIND: 0.0.0.0:9984
-  #     BIGCHAINDB_WSSERVER_HOST: 0.0.0.0
-  #     BIGCHAINDB_WSSERVER_ADVERTISED_HOST: bigchaindb
-  #     BIGCHAINDB_TENDERMINT_HOST: tendermint
-  #     BIGCHAINDB_TENDERMINT_PORT: 26657
-  #   ports:
-  #     - "9984:9984"
-  #     - "9985:9985"
-  #     - "26658"
-  #   healthcheck:
-  #     test: ["CMD", "bash", "-c", "curl http://bigchaindb:9984 && curl http://tendermint:26657/abci_query"]
-  #     interval: 3s
-  #     timeout: 5s
-  #     retries: 3
-  #   command: '.ci/entrypoint.sh'
-  #   restart: always
+  bigchaindb:
+    depends_on:
+      - mongodb
+      - tendermint
+    build:
+      context: .
+      dockerfile: Dockerfile-dev
+    volumes:
+      - ./bigchaindb:/usr/src/app/bigchaindb
+      - ./tests:/usr/src/app/tests
+      - ./docs:/usr/src/app/docs
+      - ./htmlcov:/usr/src/app/htmlcov
+      - ./setup.py:/usr/src/app/setup.py
+      - ./setup.cfg:/usr/src/app/setup.cfg
+      - ./pytest.ini:/usr/src/app/pytest.ini
+      - ./tox.ini:/usr/src/app/tox.ini
+    environment:
+      BIGCHAINDB_DATABASE_BACKEND: localmongodb
+      BIGCHAINDB_DATABASE_HOST: mongodb
+      BIGCHAINDB_DATABASE_PORT: 27017
+      BIGCHAINDB_SERVER_BIND: 0.0.0.0:9984
+      BIGCHAINDB_WSSERVER_HOST: 0.0.0.0
+      BIGCHAINDB_WSSERVER_ADVERTISED_HOST: bigchaindb
+      BIGCHAINDB_TENDERMINT_HOST: tendermint
+      BIGCHAINDB_TENDERMINT_PORT: 26657
+    ports:
+      - "9984:9984"
+      - "9985:9985"
+      - "26658"
+    healthcheck:
+      test: ["CMD", "bash", "-c", "curl http://bigchaindb:9984 && curl http://tendermint:26657/abci_query"]
+      interval: 3s
+      timeout: 5s
+      retries: 3
+    command: '.ci/entrypoint.sh'
+    restart: always
   tendermint:
     image: tendermint/tendermint:v0.31.5
     # volumes:
@@ -57,48 +57,48 @@ services:
     ports:
       - "26656:26656"
       - "26657:26657"
-    command: sh -c "tendermint init && tendermint node --consensus.create_empty_blocks=false --proxy_app=tcp://10.0.75.1:26658"
+    command: sh -c "tendermint init && tendermint node --consensus.create_empty_blocks=false --proxy_app=tcp://bigchaindb:26658"
     restart: always
-  # bdb:
-  #   image: busybox
-  #   depends_on:
-  #     bigchaindb:
-  #       condition: service_healthy
+  bdb:
+    image: busybox
+    depends_on:
+      bigchaindb:
+        condition: service_healthy
 
 
-  # # curl client to check the health of development env
-  # curl-client:
-  #   image: appropriate/curl
-  #   command: /bin/sh -c "curl -s http://bigchaindb:9984/ > /dev/null && curl -s http://tendermint:26657/ > /dev/null"
+  # curl client to check the health of development env
+  curl-client:
+    image: appropriate/curl
+    command: /bin/sh -c "curl -s http://bigchaindb:9984/ > /dev/null && curl -s http://tendermint:26657/ > /dev/null"
 
-  # # BigchainDB setup to do acceptance testing with Python
-  # python-acceptance:
-  #   build:
-  #     context: .
-  #     dockerfile: ./acceptance/python/Dockerfile
-  #   volumes:
-  #     - ./acceptance/python/docs:/docs
-  #     - ./acceptance/python/src:/src
-  #   environment:
-  #     - BIGCHAINDB_ENDPOINT=bigchaindb
+  # BigchainDB setup to do acceptance testing with Python
+  python-acceptance:
+    build:
+      context: .
+      dockerfile: ./acceptance/python/Dockerfile
+    volumes:
+      - ./acceptance/python/docs:/docs
+      - ./acceptance/python/src:/src
+    environment:
+      - BIGCHAINDB_ENDPOINT=bigchaindb
 
-  # # Build docs only
-  # # docker-compose build bdocs
-  # # docker-compose up -d bdocs
-  # bdocs:
-  #   depends_on:
-  #     - vdocs
-  #   build:
-  #     context: .
-  #     dockerfile: Dockerfile-dev
-  #     args:
-  #       backend: localmongodb
-  #   volumes:
-  #     - .:/usr/src/app/
-  #   command: make -C docs/server html
-  # vdocs:
-  #   image: nginx
-  #   ports:
-  #     - '33333:80'
-  #   volumes:
-  #     - ./docs/server/build/html:/usr/share/nginx/html
+  # Build docs only
+  # docker-compose build bdocs
+  # docker-compose up -d bdocs
+  bdocs:
+    depends_on:
+      - vdocs
+    build:
+      context: .
+      dockerfile: Dockerfile-dev
+      args:
+        backend: localmongodb
+    volumes:
+      - .:/usr/src/app/
+    command: make -C docs/server html
+  vdocs:
+    image: nginx
+    ports:
+      - '33333:80'
+    volumes:
+      - ./docs/server/build/html:/usr/share/nginx/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,92 +13,92 @@ services:
       - "27017:27017"
     command: mongod
     restart: always
-  bigchaindb:
-    depends_on:
-      - mongodb
-      - tendermint
-    build:
-      context: .
-      dockerfile: Dockerfile-dev
-    volumes:
-      - ./bigchaindb:/usr/src/app/bigchaindb
-      - ./tests:/usr/src/app/tests
-      - ./docs:/usr/src/app/docs
-      - ./htmlcov:/usr/src/app/htmlcov
-      - ./setup.py:/usr/src/app/setup.py
-      - ./setup.cfg:/usr/src/app/setup.cfg
-      - ./pytest.ini:/usr/src/app/pytest.ini
-      - ./tox.ini:/usr/src/app/tox.ini
-    environment:
-      BIGCHAINDB_DATABASE_BACKEND: localmongodb
-      BIGCHAINDB_DATABASE_HOST: mongodb
-      BIGCHAINDB_DATABASE_PORT: 27017
-      BIGCHAINDB_SERVER_BIND: 0.0.0.0:9984
-      BIGCHAINDB_WSSERVER_HOST: 0.0.0.0
-      BIGCHAINDB_WSSERVER_ADVERTISED_HOST: bigchaindb
-      BIGCHAINDB_TENDERMINT_HOST: tendermint
-      BIGCHAINDB_TENDERMINT_PORT: 26657
-    ports:
-      - "9984:9984"
-      - "9985:9985"
-      - "26658"
-    healthcheck:
-      test: ["CMD", "bash", "-c", "curl http://bigchaindb:9984 && curl http://tendermint:26657/abci_query"]
-      interval: 3s
-      timeout: 5s
-      retries: 3
-    command: '.ci/entrypoint.sh'
-    restart: always
+  # bigchaindb:
+  #   depends_on:
+  #     - mongodb
+  #     - tendermint
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile-dev
+  #   volumes:
+  #     - ./bigchaindb:/usr/src/app/bigchaindb
+  #     - ./tests:/usr/src/app/tests
+  #     - ./docs:/usr/src/app/docs
+  #     - ./htmlcov:/usr/src/app/htmlcov
+  #     - ./setup.py:/usr/src/app/setup.py
+  #     - ./setup.cfg:/usr/src/app/setup.cfg
+  #     - ./pytest.ini:/usr/src/app/pytest.ini
+  #     - ./tox.ini:/usr/src/app/tox.ini
+  #   environment:
+  #     BIGCHAINDB_DATABASE_BACKEND: localmongodb
+  #     BIGCHAINDB_DATABASE_HOST: mongodb
+  #     BIGCHAINDB_DATABASE_PORT: 27017
+  #     BIGCHAINDB_SERVER_BIND: 0.0.0.0:9984
+  #     BIGCHAINDB_WSSERVER_HOST: 0.0.0.0
+  #     BIGCHAINDB_WSSERVER_ADVERTISED_HOST: bigchaindb
+  #     BIGCHAINDB_TENDERMINT_HOST: tendermint
+  #     BIGCHAINDB_TENDERMINT_PORT: 26657
+  #   ports:
+  #     - "9984:9984"
+  #     - "9985:9985"
+  #     - "26658"
+  #   healthcheck:
+  #     test: ["CMD", "bash", "-c", "curl http://bigchaindb:9984 && curl http://tendermint:26657/abci_query"]
+  #     interval: 3s
+  #     timeout: 5s
+  #     retries: 3
+  #   command: '.ci/entrypoint.sh'
+  #   restart: always
   tendermint:
-    image: tendermint/tendermint:0.22.8
+    image: tendermint/tendermint:v0.31.5
     # volumes:
     #   - ./tmdata:/tendermint
     entrypoint: ''
     ports:
       - "26656:26656"
       - "26657:26657"
-    command: sh -c "tendermint init && tendermint node --consensus.create_empty_blocks=false --proxy_app=tcp://bigchaindb:26658"
+    command: sh -c "tendermint init && tendermint node --consensus.create_empty_blocks=false --proxy_app=tcp://10.0.75.1:26658"
     restart: always
-  bdb:
-    image: busybox
-    depends_on:
-      bigchaindb:
-        condition: service_healthy
+  # bdb:
+  #   image: busybox
+  #   depends_on:
+  #     bigchaindb:
+  #       condition: service_healthy
 
 
-  # curl client to check the health of development env
-  curl-client:
-    image: appropriate/curl
-    command: /bin/sh -c "curl -s http://bigchaindb:9984/ > /dev/null && curl -s http://tendermint:26657/ > /dev/null"
+  # # curl client to check the health of development env
+  # curl-client:
+  #   image: appropriate/curl
+  #   command: /bin/sh -c "curl -s http://bigchaindb:9984/ > /dev/null && curl -s http://tendermint:26657/ > /dev/null"
 
-  # BigchainDB setup to do acceptance testing with Python
-  python-acceptance:
-    build:
-      context: .
-      dockerfile: ./acceptance/python/Dockerfile
-    volumes:
-      - ./acceptance/python/docs:/docs
-      - ./acceptance/python/src:/src
-    environment:
-      - BIGCHAINDB_ENDPOINT=bigchaindb
+  # # BigchainDB setup to do acceptance testing with Python
+  # python-acceptance:
+  #   build:
+  #     context: .
+  #     dockerfile: ./acceptance/python/Dockerfile
+  #   volumes:
+  #     - ./acceptance/python/docs:/docs
+  #     - ./acceptance/python/src:/src
+  #   environment:
+  #     - BIGCHAINDB_ENDPOINT=bigchaindb
 
-  # Build docs only
-  # docker-compose build bdocs
-  # docker-compose up -d bdocs
-  bdocs:
-    depends_on:
-      - vdocs
-    build:
-      context: .
-      dockerfile: Dockerfile-dev
-      args:
-        backend: localmongodb
-    volumes:
-      - .:/usr/src/app/
-    command: make -C docs/server html
-  vdocs:
-    image: nginx
-    ports:
-      - '33333:80'
-    volumes:
-      - ./docs/server/build/html:/usr/share/nginx/html
+  # # Build docs only
+  # # docker-compose build bdocs
+  # # docker-compose up -d bdocs
+  # bdocs:
+  #   depends_on:
+  #     - vdocs
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile-dev
+  #     args:
+  #       backend: localmongodb
+  #   volumes:
+  #     - .:/usr/src/app/
+  #   command: make -C docs/server html
+  # vdocs:
+  #   image: nginx
+  #   ports:
+  #     - '33333:80'
+  #   volumes:
+  #     - ./docs/server/build/html:/usr/share/nginx/html

--- a/docs/contributing/source/dev-setup-coding-and-contribution-process/run-node-as-processes.md
+++ b/docs/contributing/source/dev-setup-coding-and-contribution-process/run-node-as-processes.md
@@ -17,7 +17,7 @@ and of course you also need to install BigchainDB Sever from the local code you 
 
 ## Install and Run MongoDB
 
-MongoDB can be easily installed, just refer to their [installation documentation](https://docs.mongodb.com/manual/installation/) for your distro. 
+MongoDB can be easily installed, just refer to their [installation documentation](https://docs.mongodb.com/manual/installation/) for your distro.
 We know MongoDB 3.4 and 3.6 work with BigchainDB.
 After the installation of MongoDB is complete, run MongoDB using `sudo mongod`
 
@@ -25,13 +25,13 @@ After the installation of MongoDB is complete, run MongoDB using `sudo mongod`
 
 ### Installing a Tendermint Executable
 
-The version of BigchainDB Server described in these docs only works well with Tendermint 0.22.8 (not a higher version number). Install that:
+The version of BigchainDB Server described in these docs only works well with Tendermint 0.31.5 (not a higher version number). Install that:
 
 ```bash
 $ sudo apt install -y unzip
-$ wget https://github.com/tendermint/tendermint/releases/download/v0.22.8/tendermint_0.22.8_linux_amd64.zip
-$ unzip tendermint_0.22.8_linux_amd64.zip
-$ rm tendermint_0.22.8_linux_amd64.zip
+$ wget https://github.com/tendermint/tendermint/releases/download/v0.31.5/tendermint_v0.31.5_linux_amd64.zip
+$ unzip tendermint_v0.31.5_linux_amd64.zip
+$ rm tendermint_v0.31.5_linux_amd64.zip
 $ sudo mv tendermint /usr/local/bin
 ```
 

--- a/docs/server/source/k8s-deployment-template/workflow.rst
+++ b/docs/server/source/k8s-deployment-template/workflow.rst
@@ -59,7 +59,7 @@ you can do this:
 .. code::
 
    $ mkdir $(pwd)/tmdata
-   $ docker run --rm -v $(pwd)/tmdata:/tendermint/config tendermint/tendermint:0.22.8 init
+   $ docker run --rm -v $(pwd)/tmdata:/tendermint/config tendermint/tendermint:v0.31.5 init
    $ cat $(pwd)/tmdata/genesis.json
 
 You should see something that looks like:
@@ -69,7 +69,7 @@ You should see something that looks like:
    {"genesis_time": "0001-01-01T00:00:00Z",
     "chain_id": "test-chain-bGX7PM",
     "validators": [
-        {"pub_key": 
+        {"pub_key":
             {"type": "ed25519",
              "data": "4669C4B966EB8B99E45E40982B2716A9D3FA53B54C68088DAB2689935D7AF1A9"},
          "power": 10,

--- a/docs/server/source/simple-deployment-template/set-up-node-software.md
+++ b/docs/server/source/simple-deployment-template/set-up-node-software.md
@@ -91,13 +91,13 @@ Note that installing the official package _doesn't_ also start MongoDB.
 ## Install Tendermint
 
 The version of BigchainDB Server described in these docs only works well
-with Tendermint 0.22.8 (not a higher version number). Install that:
+with Tendermint 0.31.5 (not a higher version number). Install that:
 
 ```
 sudo apt install -y unzip
-wget https://github.com/tendermint/tendermint/releases/download/v0.22.8/tendermint_0.22.8_linux_amd64.zip
-unzip tendermint_0.22.8_linux_amd64.zip
-rm tendermint_0.22.8_linux_amd64.zip
+wget https://github.com/tendermint/tendermint/releases/download/v0.31.5/tendermint_v0.31.5_linux_amd64.zip
+unzip tendermint_v0.31.5_linux_amd64.zip
+rm tendermint_v0.31.5_linux_amd64.zip
 sudo mv tendermint /usr/local/bin
 ```
 

--- a/k8s/bigchaindb/tendermint_container/Dockerfile
+++ b/k8s/bigchaindb/tendermint_container/Dockerfile
@@ -1,4 +1,4 @@
-FROM tendermint/tendermint:0.22.8
+FROM tendermint/tendermint:v0.31.5
 LABEL maintainer "devs@bigchaindb.com"
 WORKDIR /
 USER root

--- a/pkg/configuration/roles/tendermint/files/Dockerfile
+++ b/pkg/configuration/roles/tendermint/files/Dockerfile
@@ -1,4 +1,4 @@
-ARG tm_version=0.22.8
+ARG tm_version=v0.31.5
 FROM tendermint/tendermint:${tm_version}
 LABEL maintainer "devs@bigchaindb.com"
 WORKDIR /

--- a/pkg/scripts/stack.sh
+++ b/pkg/scripts/stack.sh
@@ -15,7 +15,7 @@ stack_repo=${STACK_REPO:="bigchaindb/bigchaindb"}
 stack_size=${STACK_SIZE:=4}
 stack_type=${STACK_TYPE:="docker"}
 stack_type_provider=${STACK_TYPE_PROVIDER:=""}
-tm_version=${TM_VERSION:="0.22.8"}
+tm_version=${TM_VERSION:="v0.31.5"}
 mongo_version=${MONGO_VERSION:="3.6"}
 stack_vm_memory=${STACK_VM_MEMORY:=2048}
 stack_vm_cpus=${STACK_VM_CPUS:=2}

--- a/pkg/scripts/unstack.sh
+++ b/pkg/scripts/unstack.sh
@@ -15,7 +15,7 @@ stack_repo=${STACK_REPO:="bigchaindb/bigchaindb"}
 stack_size=${STACK_SIZE:=4}
 stack_type=${STACK_TYPE:="docker"}
 stack_type_provider=${STACK_TYPE_PROVIDER:=""}
-tm_version=${TM_VERSION:="0.22.8"}
+tm_version=${TM_VERSION:="0.31.5"}
 mongo_version=${MONGO_VERSION:="3.6"}
 stack_vm_memory=${STACK_VM_MEMORY:=2048}
 stack_vm_cpus=${STACK_VM_CPUS:=2}

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ install_requires = [
     'jsonschema~=2.5.1',
     'pyyaml>=4.2b1',
     'aiohttp~=3.0',
-    'bigchaindb-abci==0.5.1',
+    'bigchaindb-abci==0.6.0',
     'setproctitle~=1.1.0',
     'packaging~=18.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ install_requires = [
     'jsonschema~=2.5.1',
     'pyyaml>=4.2b1',
     'aiohttp~=3.0',
-    'bigchaindb-abci==0.7.0',
+    'bigchaindb-abci==0.7.1',
     'setproctitle~=1.1.0',
     'packaging~=18.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ install_requires = [
     'jsonschema~=2.5.1',
     'pyyaml>=4.2b1',
     'aiohttp~=3.0',
-    'bigchaindb-abci==0.6.0',
+    'bigchaindb-abci==0.6.1',
     'setproctitle~=1.1.0',
     'packaging~=18.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ install_requires = [
     'jsonschema~=2.5.1',
     'pyyaml>=4.2b1',
     'aiohttp~=3.0',
-    'bigchaindb-abci==0.6.1',
+    'bigchaindb-abci==0.6.2',
     'setproctitle~=1.1.0',
     'packaging~=18.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ install_requires = [
     'jsonschema~=2.5.1',
     'pyyaml>=4.2b1',
     'aiohttp~=3.0',
-    'bigchaindb-abci==0.6.2',
+    'bigchaindb-abci==0.7.0',
     'setproctitle~=1.1.0',
     'packaging~=18.0',
 ]

--- a/tests/tendermint/conftest.py
+++ b/tests/tendermint/conftest.py
@@ -5,7 +5,7 @@
 import pytest
 import codecs
 
-import abci.types_pb2 as types
+import github.com.tendermint.tendermint.abci.types.types_pb2 as types
 
 
 @pytest.fixture

--- a/tests/tendermint/conftest.py
+++ b/tests/tendermint/conftest.py
@@ -5,7 +5,7 @@
 import pytest
 import codecs
 
-import github.com.tendermint.tendermint.abci.types.types_pb2 as types
+import abci as types
 
 
 @pytest.fixture

--- a/tests/tendermint/conftest.py
+++ b/tests/tendermint/conftest.py
@@ -15,10 +15,8 @@ def validator_pub_key():
 
 @pytest.fixture
 def init_chain_request():
-    addr = codecs.decode(b'9FD479C869C7D7E7605BF99293457AA5D80C3033', 'hex')
     pk = codecs.decode(b'VAgFZtYw8bNR5TMZHFOBDWk9cAmEu3/c6JgRBmddbbI=',
                        'base64')
-    val_a = types.ValidatorUpdate( power=10,
-                            pub_key=types.PubKey(type='ed25519', data=pk))
-
+    val_a = types.ValidatorUpdate(power=10,
+                                  pub_key=types.PubKey(type='ed25519', data=pk))
     return types.RequestInitChain(validators=[val_a])

--- a/tests/tendermint/conftest.py
+++ b/tests/tendermint/conftest.py
@@ -18,7 +18,7 @@ def init_chain_request():
     addr = codecs.decode(b'9FD479C869C7D7E7605BF99293457AA5D80C3033', 'hex')
     pk = codecs.decode(b'VAgFZtYw8bNR5TMZHFOBDWk9cAmEu3/c6JgRBmddbbI=',
                        'base64')
-    val_a = types.Validator(address=addr, power=10,
+    val_a = types.ValidatorUpdate( power=10,
                             pub_key=types.PubKey(type='ed25519', data=pk))
 
     return types.RequestInitChain(validators=[val_a])

--- a/tests/tendermint/test_core.py
+++ b/tests/tendermint/test_core.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
-import codecs
 import json
 import pytest
 import random
@@ -14,7 +13,6 @@ from abci.types_pb2 import (
     RequestInfo,
     RequestBeginBlock,
     RequestEndBlock,
-    Validator,
     ValidatorUpdate,
 )
 
@@ -49,10 +47,9 @@ def generate_address():
 
 
 def generate_validator():
-    addr = codecs.decode(generate_address(), 'hex')
     pk, _ = generate_key_pair()
     pub_key = PubKey(type='ed25519', data=pk.encode())
-    val = ValidatorUpdate( power=10, pub_key=pub_key)
+    val = ValidatorUpdate(power=10, pub_key=pub_key)
     return val
 
 

--- a/tests/tendermint/test_core.py
+++ b/tests/tendermint/test_core.py
@@ -6,7 +6,7 @@ import json
 import pytest
 import random
 
-from github.com.tendermint.tendermint.abci.types.types_pb2 import (
+from abci import (
     PubKey,
     ResponseInitChain,
     RequestInitChain,

--- a/tests/tendermint/test_core.py
+++ b/tests/tendermint/test_core.py
@@ -6,7 +6,7 @@ import json
 import pytest
 import random
 
-from abci.types_pb2 import (
+from github.com.tendermint.tendermint.abci.types.types_pb2 import (
     PubKey,
     ResponseInitChain,
     RequestInitChain,

--- a/tests/tendermint/test_core.py
+++ b/tests/tendermint/test_core.py
@@ -15,6 +15,7 @@ from abci.types_pb2 import (
     RequestBeginBlock,
     RequestEndBlock,
     Validator,
+    ValidatorUpdate,
 )
 
 from bigchaindb import App
@@ -51,7 +52,7 @@ def generate_validator():
     addr = codecs.decode(generate_address(), 'hex')
     pk, _ = generate_key_pair()
     pub_key = PubKey(type='ed25519', data=pk.encode())
-    val = Validator(address=addr, power=10, pub_key=pub_key)
+    val = ValidatorUpdate( power=10, pub_key=pub_key)
     return val
 
 

--- a/tests/tendermint/test_integration.py
+++ b/tests/tendermint/test_integration.py
@@ -4,7 +4,7 @@
 
 import codecs
 
-import abci.types_pb2 as types
+import github.com.tendermint.tendermint.abci.types.types_pb2 as types
 import json
 import pytest
 

--- a/tests/tendermint/test_integration.py
+++ b/tests/tendermint/test_integration.py
@@ -4,7 +4,7 @@
 
 import codecs
 
-import github.com.tendermint.tendermint.abci.types.types_pb2 as types
+import abci as types
 import json
 import pytest
 


### PR DESCRIPTION
BigchainDB has been running with Tendermint 0.22.8 for a while. It is important to keep pace with the Tendermint evolution. Therefore, upgrading the Tendermint version is crucial. 

**Problem: Tendermint had some breaking changes, therefore, the adaption wasn't straight. **

## Solution

The ABCI module of py-abci got updated and a push request got raised to get this into the official repository. In addition, the ABCI driver got integrated in a way to be compliant and adaptable for the future. This pull request upgrades to Tendermint 0.31.5 (ABCI 16.0).

## Issues Resolved

This pull request successfully upgrades the Tendermint version of BigchainDB.
