### PR TITLE
Fixed not being able to connect to mongo

### DIFF
--- a/pkg/scripts/all-in-one.bash
+++ b/pkg/scripts/all-in-one.bash
@@ -10,7 +10,7 @@
 # BigchainDB configuration
 bigchaindb-monit-config
 
-nohup mongod > "$HOME/.bigchaindb-monit/logs/mongodb_log_$(date +%Y%m%d_%H%M%S)" 2>&1 &
+nohup mongod --bind_ip_all > "$HOME/.bigchaindb-monit/logs/mongodb_log_$(date +%Y%m%d_%H%M%S)" 2>&1 &
 
 # Tendermint configuration
 tendermint init


### PR DESCRIPTION
**Problem: A short statement of the problem.**
Unable to connect to mongodb from host machine 

## Solution
From version 3.6+ mongodb by default binds only to localhost (127.0.0.1) IP. That can be checked with "netstat -tulpn | grep LISTEN" command in container. It will return "127.0.0.1:27017 | 0.0.0.0:* | LISTEN | 15/mongod" for mongod. That causes inability to connect to running mongo from host machine. Proposed change allows mongo to bind to container network interface, thus allowing connections from host machine.

## Issues Resolved
Resolves #2673
