### PR TITLE
Tendermint v0.22.8 backward compatibility

### DIFF
--- a/bigchaindb/__init__.py
+++ b/bigchaindb/__init__.py
@@ -70,6 +70,7 @@ config = {
     'tendermint': {
         'host': 'localhost',
         'port': 26657,
+        'version': 'v0.31.5',  # look for __tm_supported_versions__
     },
     # FIXME: hardcoding to localmongodb for now
     'database': _database_map['localmongodb'],

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -9,15 +9,7 @@ import logging
 import sys
 
 from abci.application import BaseApplication
-from abci import (
-    ResponseInitChain,
-    ResponseInfo,
-    ResponseCheckTx,
-    ResponseBeginBlock,
-    ResponseDeliverTx,
-    ResponseEndBlock,
-    ResponseCommit,
-)
+from abci import CodeTypeOk
 
 from bigchaindb import BigchainDB
 from bigchaindb.elections.election import Election
@@ -30,7 +22,6 @@ import bigchaindb.upsert_validator.validator_utils as vutils
 from bigchaindb.events import EventTypes, Event
 
 
-CodeTypeOk = 0
 CodeTypeError = 1
 logger = logging.getLogger(__name__)
 
@@ -42,7 +33,8 @@ class App(BaseApplication):
     transaction logic to Tendermint Core.
     """
 
-    def __init__(self, bigchaindb=None, events_queue=None):
+    def __init__(self, abci, bigchaindb=None, events_queue=None,):
+        super().__init__(abci)
         self.events_queue = events_queue
         self.bigchaindb = bigchaindb or BigchainDB()
         self.block_txn_ids = []
@@ -108,7 +100,7 @@ class App(BaseApplication):
                                          genesis.chain_id, True)
         self.chain = {'height': abci_chain_height, 'is_synced': True,
                       'chain_id': genesis.chain_id}
-        return ResponseInitChain()
+        return self.abci.ResponseInitChain()
 
     def info(self, request):
         """Return height of the latest committed block."""
@@ -123,7 +115,7 @@ class App(BaseApplication):
 
         logger.info(f"Tendermint version: {request.version}")
 
-        r = ResponseInfo()
+        r = self.abci.ResponseInfo()
         block = self.bigchaindb.get_latest_block()
         if block:
             chain_shift = 0 if self.chain is None else self.chain['height']
@@ -148,10 +140,10 @@ class App(BaseApplication):
         transaction = decode_transaction(raw_transaction)
         if self.bigchaindb.is_valid_transaction(transaction):
             logger.debug('check_tx: VALID')
-            return ResponseCheckTx(code=CodeTypeOk)
+            return self.abci.ResponseCheckTx(code=CodeTypeOk)
         else:
             logger.debug('check_tx: INVALID')
-            return ResponseCheckTx(code=CodeTypeError)
+            return self.abci.ResponseCheckTx(code=CodeTypeError)
 
     def begin_block(self, req_begin_block):
         """Initialize list of transaction.
@@ -168,7 +160,7 @@ class App(BaseApplication):
 
         self.block_txn_ids = []
         self.block_transactions = []
-        return ResponseBeginBlock()
+        return self.abci.ResponseBeginBlock()
 
     def deliver_tx(self, raw_transaction):
         """Validate the transaction before mutating the state.
@@ -185,12 +177,12 @@ class App(BaseApplication):
 
         if not transaction:
             logger.debug('deliver_tx: INVALID')
-            return ResponseDeliverTx(code=CodeTypeError)
+            return self.abci.ResponseDeliverTx(code=CodeTypeError)
         else:
             logger.debug('storing tx')
             self.block_txn_ids.append(transaction.id)
             self.block_transactions.append(transaction)
-            return ResponseDeliverTx(code=CodeTypeOk)
+            return self.abci.ResponseDeliverTx(code=CodeTypeOk)
 
     def end_block(self, request_end_block):
         """Calculate block hash using transaction ids and previous block
@@ -226,7 +218,7 @@ class App(BaseApplication):
                                                   self.new_height,
                                                   self.block_transactions)
 
-        return ResponseEndBlock(validator_updates=validator_update)
+        return self.abci.ResponseEndBlock(validator_updates=validator_update)
 
     def commit(self):
         """Store the new height and along with block hash."""
@@ -257,7 +249,7 @@ class App(BaseApplication):
             })
             self.events_queue.put(event)
 
-        return ResponseCommit(data=data)
+        return self.abci.ResponseCommit(data=data)
 
 
 def rollback(b):

--- a/bigchaindb/version.py
+++ b/bigchaindb/version.py
@@ -6,4 +6,4 @@ __version__ = '2.1.0'
 __short_version__ = '2.1'
 
 # Supported Tendermint versions
-__tm_supported_versions__ = ["0.31.5"]
+__tm_supported_versions__ = ["0.31.5", "0.22.8"]

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ install_requires = [
     'jsonschema~=2.5.1',
     'pyyaml>=4.2b1',
     'aiohttp~=3.0',
-    'bigchaindb-abci==0.7.1',
+    'bigchaindb-abci==1.0.1',
     'setproctitle~=1.1.0',
     'packaging~=18.0',
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,6 +234,12 @@ def merlin():
 
 
 @pytest.fixture
+def a():
+    from abci import types_v0_31_5
+    return types_v0_31_5
+
+
+@pytest.fixture
 def b():
     from bigchaindb import BigchainDB
     return BigchainDB()
@@ -434,11 +440,12 @@ def event_loop():
 
 @pytest.fixture(scope='session')
 def abci_server():
-    from abci import ABCIServer
+    from abci.server import ABCIServer
+    from abci import types_v0_31_5
     from bigchaindb.core import App
     from bigchaindb.utils import Process
 
-    app = ABCIServer(app=App())
+    app = ABCIServer(app=App(types_v0_31_5))
     abci_proxy = Process(name='ABCI', target=app.run)
     yield abci_proxy.start()
     abci_proxy.terminate()

--- a/tests/tendermint/conftest.py
+++ b/tests/tendermint/conftest.py
@@ -5,7 +5,7 @@
 import pytest
 import codecs
 
-import abci as types
+from abci import types_v0_31_5 as types
 
 
 @pytest.fixture

--- a/tests/tendermint/test_integration.py
+++ b/tests/tendermint/test_integration.py
@@ -4,7 +4,7 @@
 
 import codecs
 
-import abci as types
+from abci import types_v0_31_5 as types
 import json
 import pytest
 
@@ -18,13 +18,13 @@ from io import BytesIO
 
 
 @pytest.mark.bdb
-def test_app(b, init_chain_request):
+def test_app(a, b, init_chain_request):
     from bigchaindb import App
     from bigchaindb.tendermint_utils import calculate_hash
     from bigchaindb.common.crypto import generate_key_pair
     from bigchaindb.models import Transaction
 
-    app = App(b)
+    app = App(a, b)
     p = ProtocolHandler(app)
 
     data = p.process('info',
@@ -146,10 +146,10 @@ def test_post_transaction_responses(tendermint_ws_url, b):
 
 
 @pytest.mark.bdb
-def test_exit_when_tm_ver_not_supported(b):
+def test_exit_when_tm_ver_not_supported(a, b):
     from bigchaindb import App
 
-    app = App(b)
+    app = App(a, b)
     p = ProtocolHandler(app)
 
     with pytest.raises(SystemExit):

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -220,6 +220,7 @@ def test_autoconfigure_read_both_from_file_and_env(monkeypatch, request):
         'tendermint': {
             'host': 'localhost',
             'port': 26657,
+            'version': 'v0.31.5'
         },
         'log': {
             'file': LOG_FILE,


### PR DESCRIPTION
## Problem statement
BigchainDB v2.0.0b9 has been around for quite a while. Recently we have updated
Tendermint supported version to v0.31.5 which has incompatible blockchain.
Despite the fact that we have defined instructions on chain migration, no one
expected to migrate to incompatible chain within patch version range. So there
is a demand for Tendermint v0.22.8 compatibility among BigchainDB users.

## Solution
bigchaindb-abci package was upgraded to support multiple API versions.
New configuration field stating tendermint version was added.
