### PR TITLE
owners_before error message correction

### DIFF
--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -78,7 +78,7 @@ class Input(object):
         if fulfills is not None and not isinstance(fulfills, TransactionLink):
             raise TypeError('`fulfills` must be a TransactionLink instance')
         if not isinstance(owners_before, list):
-            raise TypeError('`owners_after` must be a list instance')
+            raise TypeError('`owners_before` must be a list instance')
 
         self.fulfillment = fulfillment
         self.fulfills = fulfills

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -546,7 +546,7 @@ class Transaction(object):
         elif (operation == self.TRANSFER and
                 not (isinstance(asset, dict) and 'id' in asset)):
             raise TypeError(('`asset` must be a dict holding an `id` property '
-                             "for 'TRANSFER' Transactions".format(operation)))
+                             "for 'TRANSFER' Transactions"))
 
         if outputs and not isinstance(outputs, list):
             raise TypeError('`outputs` must be a list instance or None')

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -546,7 +546,7 @@ class Transaction(object):
         elif (operation == self.TRANSFER and
                 not (isinstance(asset, dict) and 'id' in asset)):
             raise TypeError(('`asset` must be a dict holding an `id` property '
-                             "for \'TRANSFER\' Transactions"))
+                             'for \'TRANSFER\' Transactions'))
 
         if outputs and not isinstance(outputs, list):
             raise TypeError('`outputs` must be a list instance or None')

--- a/bigchaindb/common/transaction.py
+++ b/bigchaindb/common/transaction.py
@@ -546,7 +546,7 @@ class Transaction(object):
         elif (operation == self.TRANSFER and
                 not (isinstance(asset, dict) and 'id' in asset)):
             raise TypeError(('`asset` must be a dict holding an `id` property '
-                             "for 'TRANSFER' Transactions"))
+                             "for \'TRANSFER\' Transactions"))
 
         if outputs and not isinstance(outputs, list):
             raise TypeError('`outputs` must be a list instance or None')
@@ -869,8 +869,9 @@ class Transaction(object):
             return cls._sign_threshold_signature_fulfillment(input_, message,
                                                              key_pairs)
         else:
-            raise ValueError("Fulfillment couldn't be matched to "
-                             'Cryptocondition fulfillment type.')
+            raise ValueError(
+                'Fulfillment couldn\'t be matched to '
+                'Cryptocondition fulfillment type.')
 
     @classmethod
     def _sign_simple_signature_fulfillment(cls, input_, message, key_pairs):

--- a/bigchaindb/core.py
+++ b/bigchaindb/core.py
@@ -46,9 +46,9 @@ class App(BaseApplication):
         self.chain = self.bigchaindb.get_latest_abci_chain()
 
     def log_abci_migration_error(self, chain_id, validators):
-        logger.error(f'An ABCI chain migration is in process. ' +
-                     'Download the new ABCI client and configure it with ' +
-                     'chain_id={chain_id} and validators={validators}.')
+        logger.error('An ABCI chain migration is in process. '
+                     'Download the new ABCI client and configure it with '
+                     f'chain_id={chain_id} and validators={validators}.')
 
     def abort_if_abci_chain_is_not_synced(self):
         if self.chain is None or self.chain['is_synced']:
@@ -69,8 +69,8 @@ class App(BaseApplication):
             chain_id = known_chain['chain_id']
 
             if known_chain['is_synced']:
-                msg = f'Got invalid InitChain ABCI request ({genesis}) - ' + \
-                      'the chain {chain_id} is already synced.'
+                msg = (f'Got invalid InitChain ABCI request ({genesis}) - '
+                       f'the chain {chain_id} is already synced.')
                 logger.error(msg)
                 sys.exit(1)
 

--- a/tests/backend/localmongodb/test_queries.py
+++ b/tests/backend/localmongodb/test_queries.py
@@ -271,8 +271,8 @@ def test_get_spending_transactions_multiple_inputs():
         ({'transaction_id': tx3.id, 'output_index': 0}, 1, [tx4.id]),
         ({'transaction_id': tx3.id, 'output_index': 1}, 0, None),
     ]
-    for l, num, match in links:
-        txns = list(query.get_spending_transactions(conn, [l]))
+    for li, num, match in links:
+        txns = list(query.get_spending_transactions(conn, [li]))
         assert len(txns) == num
         if len(txns):
             assert [tx['id'] for tx in txns] == match


### PR DESCRIPTION
Make sure the title of this pull request has the form:

**Problem: A short statement of the problem.**
Wrong error message on owners_before not being an instance if a list

## Solution

A short statement about how this PR solves the **Problem**.

I have simply changed the error message to point in the right direction. The documentation containing basic usage examples might also be needed to change a little bit as any asset transfer needs owner_before as a list and in the documentation, a string of public key is supplied.

## Issues Resolved

What issues does this PR resolve, if any? Please include lines like the following (i.e. "Resolves #NNNN), so that when this PR gets merged, GitHub will automatically close those issues.

Resolves #2697 

## BEPs Implemented

What [BEPs](https://github.com/bigchaindb/beps) does this pull request implement, if any?
