### PR TITLE
docs: fix simple typo, neeeded -> needed

### DIFF
--- a/bigchaindb/lib.py
+++ b/bigchaindb/lib.py
@@ -16,7 +16,7 @@ import rapidjson
 try:
     from hashlib import sha3_256
 except ImportError:
-    # NOTE: neeeded for Python < 3.6
+    # NOTE: needed for Python < 3.6
     from sha3 import sha3_256
 
 import requests

--- a/tests/tendermint/test_lib.py
+++ b/tests/tendermint/test_lib.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 try:
     from hashlib import sha3_256
 except ImportError:
-    # NOTE: neeeded for Python < 3.6
+    # NOTE: needed for Python < 3.6
     from sha3 import sha3_256
 
 import pytest


### PR DESCRIPTION
There is a small typo in bigchaindb/lib.py, tests/tendermint/test_lib.py.

Should read `needed` rather than `neeeded`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md