### PR TITLE
Avoid segfault using python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ tests_require = [
 
 install_requires = [
     'aiohttp==3.6.2',
-    'bigchaindb-abci==1.0.5',
+    'bigchaindb-abci==1.0.7',
     'cryptoconditions==0.8.0',
     'flask-cors==3.0.8',
     'flask-restful==0.3.8',


### PR DESCRIPTION
Update dependency version for bigchaindb-abci

this fixes operation using python 3.9 due to a bug in gevent
avoids a segfault on default setup based on debian 11 and derivatives
thanks to @albertolerda for troubleshooting
