### PR TITLE
fixed chardet version to 3.0.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,6 @@ cov: check-deps ## Check code coverage and open the result in the browser
 
 doc: check-deps ## Generate HTML documentation and open it in the browser
 	@$(DC) run --rm --no-deps bdocs make -C docs/root html
-	@$(DC) run --rm --no-deps bdocs make -C docs/server html
-	@$(DC) run --rm --no-deps bdocs make -C docs/contributing html
 	$(BROWSER) docs/root/build/html/index.html
 
 doc-acceptance: check-deps ## Create documentation for acceptance tests

--- a/docs/root/requirements.txt
+++ b/docs/root/requirements.txt
@@ -7,3 +7,4 @@ pyyaml>=4.2b1
 aafigure>=0.6
 packaging~=18.0
 wget
+jinja2==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ tests_require = [
 ] + docs_require
 
 install_requires = [
+    'chardet==3.0.4',
     'aiohttp==3.7.4',
     'bigchaindb-abci==1.0.7',
     'cryptoconditions==0.8.1',

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ install_requires = [
     'pyyaml==5.4.1',
     'requests==2.25.1',
     'setproctitle==1.2.2',
+    'werkzeug==2.0.2'
 ]
 
 if sys.version_info < (3, 6):

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,8 @@ docs_require = [
     'sphinxcontrib-httpdomain>=1.5.0',
     'sphinxcontrib-napoleon>=0.4.4',
     'aafigure>=0.6',
-    'wget'
+    'wget',
+    'jinja2==3.0.0'
 ]
 
 tests_require = [


### PR DESCRIPTION
Signed-off-by: Jürgen Eckel <juergen@riddleandcode.com>

**Problem: chardet version got released and is incompatible to the older version.**

## Solution

defined the chardet version to be used to be version 3.0.4
